### PR TITLE
fix: add persist-credentials: false to publish checkout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,7 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: main
 
       - name: Fetch changes on main


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to the publish job's `actions/checkout@v4` step
- Aligns with the `github_release` job which already has this setting

Closes #48