### PR TITLE
chore(deps): upgrade mloda to 0.5.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Never continue TDD cycles if agents are stuck** - this wastes resources and indicates a fundamental issue that requires human intervention.
 
+## Git Commits
+
+- No agent should add `Co-Authored-By` lines or any other commit authorship attribution.
+
 ## Virtual Environment Setup
 
 If not in a devcontainer, set up the environment:

--- a/config/packages.toml
+++ b/config/packages.toml
@@ -3,34 +3,34 @@
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 path = "mloda/registry"
 
 [packages.mloda-testing]
 description = "Test utilities for mloda plugin development"
-dependencies = ["mloda>=0.5.3", "pytest"]
+dependencies = ["mloda>=0.5.4", "pytest"]
 path = "mloda/testing"
 optional_dependencies = { dev = ["pytest"] }
 
 [packages.mloda-community]
 description = "All community plugins for mloda"
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 path = "mloda/community"
 
 [packages.mloda-enterprise]
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 path = "mloda/enterprise"
 
 [packages.mloda-community-example]
 description = "Example community FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 path = "mloda/community/feature_groups/example"
 optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-example-b"] }
 
 [packages.mloda-enterprise-example]
 description = "Example enterprise FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 path = "mloda/enterprise/feature_groups/example"
 
 [packages.mloda-community-example-a]
@@ -45,20 +45,20 @@ path = "mloda/community/feature_groups/example/example_b"
 
 [packages.mloda-community-compute-frameworks-example]
 description = "Example community ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 path = "mloda/community/compute_frameworks/example"
 
 [packages.mloda-community-extenders-example]
 description = "Example community Extender plugin for mloda"
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 path = "mloda/community/extenders/example"
 
 [packages.mloda-enterprise-compute-frameworks-example]
 description = "Example enterprise ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 path = "mloda/enterprise/compute_frameworks/example"
 
 [packages.mloda-enterprise-extenders-example]
 description = "Example enterprise Extender plugin for mloda"
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 path = "mloda/enterprise/extenders/example"

--- a/docs/guides/10-create-compute-framework.md
+++ b/docs/guides/10-create-compute-framework.md
@@ -51,7 +51,7 @@ Q11: Ready to test your implementation?
 |----------|-------------|
 | [01-stateless-eager](compute-framework-patterns/01-stateless-eager.md) | Simple in-memory frameworks (Pandas, PyArrow, Polars DataFrame) |
 | [02-stateless-lazy](compute-framework-patterns/02-stateless-lazy.md) | Lazy evaluation frameworks (Polars LazyFrame, Ibis) |
-| [03-stateful-connection](compute-framework-patterns/03-stateful-connection.md) | Connection/session required (DuckDB, Spark) |
+| [03-stateful-connection](compute-framework-patterns/03-stateful-connection.md) | Connection/session required (DuckDB, SQLite, Spark) |
 | [04-zero-dependency](compute-framework-patterns/04-zero-dependency.md) | Pure Python, no external libs (Python dict) |
 | [05-data-lake](compute-framework-patterns/05-data-lake.md) | Catalog-based table formats (Iceberg, Delta) |
 

--- a/docs/guides/compute-framework-patterns/03-stateful-connection.md
+++ b/docs/guides/compute-framework-patterns/03-stateful-connection.md
@@ -5,7 +5,7 @@ Stateful frameworks require a connection or session object to operate.
 **What**: Frameworks requiring a connection/session to process data.
 **When**: Database connections, distributed compute engines, SQL-based queries.
 **Why**: External engine handles computation; enables distributed processing.
-**Where**: DuckDB, Spark, Trino, Dask distributed.
+**Where**: DuckDB, SQLite, Spark, Trino, Dask distributed.
 **How**: Same as Category 1, plus implement `set_framework_connection_object()`.
 
 ## Key Difference from Stateless
@@ -62,6 +62,7 @@ result = mloda.run_all(
 | File | Description |
 |------|-------------|
 | [duckdb/duckdb_framework.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py) | DuckDB |
+| [sqlite/sqlite_framework.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py) | SQLite (0.5.4+) |
 | [spark/spark_framework.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py) | Spark |
 
 ## Combines With

--- a/docs/guides/feature-group-patterns/09-framework-specific.md
+++ b/docs/guides/feature-group-patterns/09-framework-specific.md
@@ -5,7 +5,7 @@ Framework-specific features restrict computation to certain frameworks.
 **What**: Features that use framework-specific APIs (Pandas groupby, Polars expressions, Spark).
 **When**: You need framework-specific optimizations or APIs not available cross-framework.
 **Why**: Leverage native performance; some operations only exist in specific frameworks.
-**Where**: Pandas groupby/transform, Polars lazy evaluation, DuckDB SQL, Spark distributed ops.
+**Where**: Pandas groupby/transform, Polars lazy evaluation, DuckDB SQL, SQLite SQL, Spark distributed ops.
 **How**: Return allowed frameworks from `compute_framework_rule()`.
 
 ## Key Characteristic
@@ -64,6 +64,7 @@ def test_pandas_group_mean():
 | Polars Lazy | `mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe.PolarsLazyDataFrame` |
 | PyArrow | `mloda_plugins.compute_framework.base_implementations.pyarrow.table.PyArrowTable` |
 | DuckDB | `mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework.DuckDBFramework` |
+| SQLite | `mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework.SqliteFramework` |
 | Spark | `mloda_plugins.compute_framework.base_implementations.spark.spark_framework.SparkFramework` |
 
 ## Real Implementations

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example community ComputeFramework plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example community Extender plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example community FeatureGroup plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "All community plugins for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example enterprise ComputeFramework plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example enterprise Extender plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example enterprise FeatureGroup plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Plugin discovery and search for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3"]
+dependencies = ["mloda>=0.5.4"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/testing/pyproject.toml
+++ b/mloda/testing/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Test utilities for mloda plugin development"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.3", "pytest"]
+dependencies = ["mloda>=0.5.4", "pytest"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Development workspace for mloda registry packages"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "mloda==0.5.3",
+    "mloda==0.5.4",
 ]
 authors = [
     { name = "Tom Kaltofen", email = "info@mloda.ai" }

--- a/uv.lock
+++ b/uv.lock
@@ -165,13 +165,13 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.5.3"
+version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/9c/0aca151a75e5ec496abaa913a449b9049a5251416652a9bc3e458c663374/mloda-0.5.3-py3-none-any.whl", hash = "sha256:c01331a6c0c974798949d9199d9e540817bb23071f28f5db06004f5c3c6e207e", size = 371301, upload-time = "2026-03-15T03:12:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ad/956458848b2fda62589bde6fb5ad32271fd9a5bd3a408fdecb72dc053934/mloda-0.5.4-py3-none-any.whl", hash = "sha256:858babbc6f9609966953e71c5fda30f5c5e72aca710de1d3f8c6433954e867cc", size = 385250, upload-time = "2026-03-21T18:36:27.577Z" },
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.5.3" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.5.4" }]
 
 [[package]]
 name = "mloda-community-compute-frameworks-example"
@@ -201,7 +201,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.3" },
+    { name = "mloda", specifier = ">=0.5.4" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -227,7 +227,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.3" },
+    { name = "mloda", specifier = ">=0.5.4" },
     { name = "mloda-community-example-a", marker = "extra == 'all'" },
     { name = "mloda-community-example-b", marker = "extra == 'all'" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
@@ -295,7 +295,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.3" },
+    { name = "mloda", specifier = ">=0.5.4" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -310,7 +310,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.5.3" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.5.4" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
@@ -328,7 +328,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.3" },
+    { name = "mloda", specifier = ">=0.5.4" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -350,7 +350,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.3" },
+    { name = "mloda", specifier = ">=0.5.4" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -372,7 +372,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.3" },
+    { name = "mloda", specifier = ">=0.5.4" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -394,7 +394,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.3" },
+    { name = "mloda", specifier = ">=0.5.4" },
     { name = "mloda-testing", marker = "extra == 'dev'", editable = "mloda/testing" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -422,7 +422,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
-    { name = "mloda", specifier = "==0.5.3" },
+    { name = "mloda", specifier = "==0.5.4" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -448,7 +448,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.3" },
+    { name = "mloda", specifier = ">=0.5.4" },
     { name = "pytest" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]


### PR DESCRIPTION
## Summary
- Upgrade mloda dependency from 0.5.3 to 0.5.4 across workspace and all packages
- Add SQLite framework references to compute framework and framework-specific guides
- Add no-authorship-attribution rule to CLAUDE.md

## Test plan
- [x] `uv run tox` passes (70 tests, ruff, mypy, bandit clean)
- [x] `uv sync --all-extras` resolves successfully