### PR TITLE
docs: update plugin guides for _resolve_operation helper

### DIFF
--- a/docs/guides/feature-group-patterns/03-chained-features.md
+++ b/docs/guides/feature-group-patterns/03-chained-features.md
@@ -1,6 +1,6 @@
 # Pattern 3: Chained Features (FeatureChainParserMixin)
 
-Chained features use naming patterns like `price__scaled` for reusable transformations. They support two creation methods: **string-based** (parameters in name) and **configuration-based** (parameters in Options). String-based is built on top of configuration-based as a convenience layer—prefer it for readability when feature complexity is low.
+Chained features use naming patterns like `price__scaled` for reusable transformations. They support two creation methods: **string-based** (parameters in name) and **configuration-based** (parameters in Options). String-based is built on top of configuration-based as a convenience layer. Prefer it for readability when feature complexity is low.
 
 **What**: Reusable transformations that work on any input via naming patterns (`input__operation`).
 **When**: The same operation applies to many different inputs (scaling, encoding, cleaning).
@@ -21,7 +21,7 @@ Chained features use naming patterns like `price__scaled` for reusable transform
 
 ```python
 from typing import Any, Optional, Set
-from mloda.provider import FeatureGroup, FeatureChainParser
+from mloda.provider import FeatureGroup
 from mloda.provider import FeatureChainParserMixin
 from mloda.user import Feature, Options, FeatureName
 from mloda.provider import FeatureSet
@@ -60,17 +60,16 @@ class MeanImputedFeature(FeatureChainParserMixin, FeatureGroup):
         for feature in features.features:
             name = feature.get_name()
 
-            # String-based or config-based extraction
-            if FeatureChainParser.is_chained_feature(name):
-                method, source = FeatureChainParser.parse_feature_name(name, [cls.PREFIX_PATTERN])
-            else:
-                method = feature.options.get("imputation_method")
-                source = next(iter(feature.options.get_in_features())).get_name()
+            # Resolve operation from name or config (handles both paths)
+            method = cls._resolve_operation(feature, "imputation_method")
+            source = next(iter(feature.options.get_in_features())).get_name()
 
             col = data[source]
             data[name] = col.fillna(col.mean() if method == "mean" else col.median())
         return data
 ```
+
+> **Manual alternative**: Before `_resolve_operation()`, plugins called `FeatureChainParser.parse_feature_name()` directly and handled the options fallback themselves. The helper handles this dual-path lookup automatically, so prefer `_resolve_operation()` in new code.
 
 ## Usage
 
@@ -82,7 +81,7 @@ Feature("income__mean_imputed")
 Feature("imputed_income", Options(context={"imputation_method": "mean", "in_features": "income"}))
 ```
 
-> **Note on Context**: Context options are local by default—they don't flow to input features. If you need context to propagate through the chain (e.g., a trace ID), use `propagate_context_keys`. See [Options](11-options.md#context-propagation) for details.
+> **Note on Context**: Context options are local by default and do not flow to input features. If you need context to propagate through the chain (e.g., a trace ID), use `propagate_context_keys`. See [Options](11-options.md#context-propagation) for details.
 
 ### Discriminator Keys
 

--- a/docs/guides/feature-group-patterns/12-calculate-feature.md
+++ b/docs/guides/feature-group-patterns/12-calculate-feature.md
@@ -41,10 +41,34 @@ def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
     return data
 ```
 
+## Extracting the Operation Type
+
+Chained feature groups (using `FeatureChainParserMixin`) often need to extract an operation type inside `calculate_feature`. The operation can come from the feature name string or from a config key in options. Use `_resolve_operation()` to handle both paths in one call:
+
+```python
+@classmethod
+def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+    for feature in features.features:
+        name = feature.get_name()
+
+        # Resolves from PREFIX_PATTERN match or options["imputation_method"]
+        method = cls._resolve_operation(feature, "imputation_method")
+        source = next(iter(feature.options.get_in_features())).get_name()
+
+        col = data[source]
+        data[name] = col.fillna(col.mean() if method == "mean" else col.median())
+    return data
+```
+
+`_resolve_operation(feature, config_key)` tries string-based parsing via `PREFIX_PATTERN` first, then falls back to `options.get(config_key)`. See [Chained Features](03-chained-features.md) for the full pattern.
+
+---
+
 ## Related
 
 - [Options](11-options.md) - Accessing feature options
 - [Filter Concepts](15-filter-concepts.md) - Using filters in data sources
+- [Chained Features](03-chained-features.md) - FeatureChainParserMixin and `_resolve_operation()`
 
 ## Full Documentation
 

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -103,6 +103,21 @@ Feature("my_output", Options(context={"my_method": "algo_b", "in_features": "inp
 
 **Note:** Subclasses typically only override `compute_framework_rule()` to specify which framework they support (Pandas, Polars, etc.), not matching logic.
 
+### Extracting the Discriminator at Compute Time
+
+At matching time, the mixin resolves string-based and config-based features automatically. At compute time (inside `calculate_feature`), use `_resolve_operation()` to extract the discriminator value without calling `FeatureChainParser` directly:
+
+```python
+@classmethod
+def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+    for feature in features.features:
+        # Resolves from PREFIX_PATTERN or options["my_method"]
+        method = cls._resolve_operation(feature, cls.MY_METHOD)
+        source = next(iter(feature.options.get_in_features())).get_name()
+        data[feature.get_name()] = apply_transform(data[source], method)
+    return data
+```
+
 ### Why Unique Keys?
 
 - **Semantic clarity**: `scaler_type` is clearer than generic `operation_type`

--- a/docs/guides/feature-group-patterns/22-feature-config.md
+++ b/docs/guides/feature-group-patterns/22-feature-config.md
@@ -42,6 +42,12 @@ result = mloda.run_all(features, compute_frameworks=["PandasDataFrame"])
 
 Items can be plain strings (`"feature_name"`) or feature objects. `options` and `group_options`/`context_options` are mutually exclusive.
 
+## How Plugins Resolve Config Values
+
+When a JSON config specifies `context_options` like `{"aggregation_type": "sum"}`, the receiving FeatureGroup needs to extract that value at compute time. Plugins using `FeatureChainParserMixin` call `_resolve_operation(feature, config_key)` to handle both string-based names (where the operation is embedded in the feature name) and config-based creation (where the operation comes from options) in one call. See [Chained Features](03-chained-features.md) for the full pattern.
+
+---
+
 ## Full Documentation
 
 See [Feature Configuration](https://mloda-ai.github.io/mloda/in_depth/feature-config/) for additional details.


### PR DESCRIPTION
## Summary

Updates four plugin development guides to recommend `_resolve_operation()` for dual-path operation extraction, following the addition of this helper in mloda core PR mloda-ai/mloda#242.

- **03-chained-features.md**: Replaced `FeatureChainParser.parse_feature_name()` with `_resolve_operation()` in the `calculate_feature` example. Added a "manual alternative" note for the old approach.
- **12-calculate-feature.md**: Added a new "Extracting the Operation Type" section showing how to use `_resolve_operation()` in `calculate_feature`.
- **14-feature-matching.md**: Added "Extracting the Discriminator at Compute Time" subsection showing `_resolve_operation()` usage alongside the existing discriminator key pattern.
- **22-feature-config.md**: Added "How Plugins Resolve Config Values" section explaining how `_resolve_operation()` connects JSON config to plugin internals.

Closes #58

## Test plan

- [x] `uv run tox` passes (132 tests, ruff, mypy, bandit all green)
- [ ] Review guide changes for accuracy and style consistency