### PR TITLE
refactor: update DefaultOptionKeys imports to graduated path

### DIFF
--- a/docs/guides/feature-group-patterns/03-chained-features.md
+++ b/docs/guides/feature-group-patterns/03-chained-features.md
@@ -21,11 +21,8 @@ Chained features use naming patterns like `price__scaled` for reusable transform
 
 ```python
 from typing import Any, Optional, Set
-from mloda.provider import FeatureGroup
-from mloda.provider import FeatureChainParserMixin
+from mloda.provider import DefaultOptionKeys, FeatureChainParserMixin, FeatureGroup, FeatureSet
 from mloda.user import Feature, Options, FeatureName
-from mloda.provider import FeatureSet
-from mloda.provider import DefaultOptionKeys
 
 
 class MeanImputedFeature(FeatureChainParserMixin, FeatureGroup):

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -7,8 +7,7 @@ from typing import Any, Optional
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import FeatureGroup
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 # Aggregation types that require an order_by column to be deterministic.
 _ORDER_DEPENDENT_AGG_TYPES = {"first", "last"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,11 @@ description = "Development workspace for mloda registry packages"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "mloda>=0.5.5",
+    "mloda>=0.5.6",
 ]
 authors = [
     { name = "Tom Kaltofen", email = "info@mloda.ai" }
 ]
-
-[tool.uv.sources]
-mloda = { git = "https://github.com/mloda-ai/mloda.git", branch = "main" }
 
 [project.optional-dependencies]
 dev = [

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,6 @@ envlist = python310 #python310, python311, python312, python313
 [testenv]
 usedevelop = true
 extras = dev
-deps =
-    mloda @ git+https://github.com/mloda-ai/mloda.git@main
 passenv =
     USE_TOX_LOCK
 allowlist_externals = sh, bandit

--- a/uv.lock
+++ b/uv.lock
@@ -208,10 +208,13 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.5.5"
-source = { git = "https://github.com/mloda-ai/mloda.git?branch=main#580abaf87dd02a0f102de5fb24d80619460b8815" }
+version = "0.5.6"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/6e/4fc066e2b6d9837fe768d771a00f8ccda9ed06c9deaae6f17cd66ce0ce55/mloda-0.5.6-py3-none-any.whl", hash = "sha256:0bc2a56112a8e5bfb26a825c63ded8e1bacc242524a62678b396854229efd9c7", size = 386577, upload-time = "2026-03-28T10:57:19.796Z" },
 ]
 
 [[package]]
@@ -223,7 +226,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", git = "https://github.com/mloda-ai/mloda.git?branch=main" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.5.5" }]
 
 [[package]]
 name = "mloda-community-compute-frameworks-example"
@@ -426,7 +429,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", git = "https://github.com/mloda-ai/mloda.git?branch=main" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.5.5" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
@@ -510,7 +513,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", git = "https://github.com/mloda-ai/mloda.git?branch=main" },
+    { name = "mloda", specifier = ">=0.5.5" },
     { name = "mloda-testing", marker = "extra == 'dev'", editable = "mloda/testing" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -538,7 +541,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
-    { name = "mloda", git = "https://github.com/mloda-ai/mloda.git?branch=main" },
+    { name = "mloda", specifier = ">=0.5.6" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -564,7 +567,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", git = "https://github.com/mloda-ai/mloda.git?branch=main" },
+    { name = "mloda", specifier = ">=0.5.5" },
     { name = "pytest" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]


### PR DESCRIPTION
## Summary

- Replace deprecated `mloda_plugins.feature_group.experimental.default_options_key` imports with the canonical `from mloda.provider import DefaultOptionKeys` path, graduated in mloda core PR #238 (commit 580abaf)
- Update workspace dependency to use mloda from git (main branch) until the next mloda release (0.5.6) includes the graduation
- Add tox `deps` for git-based mloda so test environments also pick up the new export

## Files Changed

- `docs/guides/feature-group-patterns/03-chained-features.md`: import path updated
- `mloda/community/.../window_aggregation/base.py`: import path updated
- `pyproject.toml`: workspace dep changed from `==0.5.5` to `>=0.5.5` with `[tool.uv.sources]` git override
- `tox.ini`: added `deps` for git-based mloda in test environments
- `uv.lock`: regenerated

Closes #68

## Test plan

- [x] All 132 tests pass
- [x] ruff format clean
- [x] mypy strict passes
- [x] bandit passes
- [ ] Revert pyproject.toml/tox.ini git overrides once mloda 0.5.6 is released on PyPI