### PR TITLE
fix: handle null order_by sorting in pyarrow frame_aggregate and window_aggregation

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_pyarrow.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_pyarrow.py
@@ -143,32 +143,6 @@ class TestPyArrowNullHandling:
 
         assert col == [130, 10, 30]
 
-    def test_multiple_null_order_by_values(self) -> None:
-        """Two or more null order_by values must not crash during sorting."""
-        table = pa.table(
-            {
-                "region": ["A", "A", "A", "A"],
-                "ts": [None, 1, None, 2],
-                "value": [100, 10, 200, 20],
-            }
-        )
-        feature = Feature(
-            "value__cumsum",
-            options=Options(context={"partition_by": ["region"], "order_by": "ts"}),
-        )
-        fs = FeatureSet()
-        fs.add(feature)
-
-        result = PyArrowFrameAggregate.calculate_feature(table, fs)
-        col = result.column("value__cumsum").to_pylist()
-
-        # Sorted order: ts=1 (10), ts=2 (20), ts=None (100), ts=None (200)
-        # Cumsum:        10,       30,          130,            330
-        # Map back to original positions: row0=None->130 or 330, row1=1->10, row2=None->330 or 130, row3=2->30
-        assert col[1] == 10
-        assert col[3] == 30
-        assert set([col[0], col[2]]) == {130, 330}
-
     def test_all_null_values_returns_none(self) -> None:
         """When all values in the window are null, the result should be None."""
         table = pa.table(

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_pyarrow.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_pyarrow.py
@@ -5,11 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 import pyarrow as pa
-import pytest
-
-from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.core.abstract_plugins.components.options import Options
-from mloda.user import Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.pyarrow_window_aggregation import (
     PyArrowWindowAggregation,
@@ -37,53 +32,3 @@ class TestPyArrowWindowAggregation(WindowAggregationTestBase):
 
     def get_expected_type(self) -> Any:
         return pa.Table
-
-
-class TestPyArrowWindowAggregationNullSorting:
-    """Regression tests for null order_by sorting."""
-
-    def test_multiple_null_order_by_first(self) -> None:
-        """Two or more null order_by values must not crash when using first aggregation."""
-        table = pa.table(
-            {
-                "region": ["A", "A", "A", "A"],
-                "ts": [None, 1, None, 2],
-                "value": [100, 10, 200, 20],
-            }
-        )
-        feature = Feature(
-            "value__first_groupby",
-            options=Options(context={"partition_by": ["region"], "order_by": "ts"}),
-        )
-        fs = FeatureSet()
-        fs.add(feature)
-
-        result = PyArrowWindowAggregation.calculate_feature(table, fs)
-        col = result.column("value__first_groupby").to_pylist()
-
-        # first with order_by sorts by ts: [1->10, 2->20, None->100, None->200]
-        # first non-null = 10, broadcast to all rows
-        assert col == [10, 10, 10, 10]
-
-    def test_multiple_null_order_by_last(self) -> None:
-        """Two or more null order_by values must not crash when using last aggregation."""
-        table = pa.table(
-            {
-                "region": ["A", "A", "A", "A"],
-                "ts": [None, 1, None, 2],
-                "value": [100, 10, 200, 20],
-            }
-        )
-        feature = Feature(
-            "value__last_groupby",
-            options=Options(context={"partition_by": ["region"], "order_by": "ts"}),
-        )
-        fs = FeatureSet()
-        fs.add(feature)
-
-        result = PyArrowWindowAggregation.calculate_feature(table, fs)
-        col = result.column("value__last_groupby").to_pylist()
-
-        # last with order_by sorts by ts: [1->10, 2->20, None->100, None->200]
-        # last non-null = 200, broadcast to all rows
-        assert col == [200, 200, 200, 200]

--- a/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate.py
@@ -406,3 +406,25 @@ class FrameAggregateTestBase(ABC):
         # With window 100, each row sees all preceding rows in its partition.
         # This is equivalent to cumulative sum.
         assert result_col == EXPECTED_CUMSUM
+
+    def test_multiple_null_order_by_values(self) -> None:
+        """Two or more null order_by values must not crash during sorting."""
+        table = pa.table(
+            {
+                "region": ["A", "A", "A", "A"],
+                "ts": [None, 1, None, 2],
+                "value": [100, 10, 200, 20],
+            }
+        )
+        data = self.create_test_data(table)
+        fs = make_feature_set("value__cumsum", ["region"], "ts")
+        result = self.implementation_class().calculate_feature(data, fs)
+
+        result_col = self.extract_column(result, "value__cumsum")
+
+        # Sorted order: ts=1 (10), ts=2 (20), ts=None (100), ts=None (200)
+        # Cumsum:        10,       30,          130,            330
+        # Map back to original positions: row1->10, row3->30, nulls get 130 and 330
+        assert result_col[1] == 10
+        assert result_col[3] == 30
+        assert set([result_col[0], result_col[2]]) == {130, 330}

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation.py
@@ -464,6 +464,46 @@ class WindowAggregationTestBase(ABC):
         assert result_col[4] == 1  # B/X: 1 non-null (row 4 is null)
         assert result_col[7] == 1
 
+    def test_multiple_null_order_by_first(self) -> None:
+        """Two or more null order_by values must not crash when using first aggregation."""
+        self._skip_if_unsupported("first")
+        table = pa.table(
+            {
+                "region": ["A", "A", "A", "A"],
+                "ts": [None, 1, None, 2],
+                "value": [100, 10, 200, 20],
+            }
+        )
+        data = self.create_test_data(table)
+        fs = make_feature_set("value__first_groupby", ["region"], order_by="ts")
+        result = self.implementation_class().calculate_feature(data, fs)
+
+        result_col = self.extract_column(result, "value__first_groupby")
+
+        # first with order_by sorts by ts: [1->10, 2->20, None->100, None->200]
+        # first non-null = 10, broadcast to all rows
+        assert result_col == [10, 10, 10, 10]
+
+    def test_multiple_null_order_by_last(self) -> None:
+        """Two or more null order_by values must not crash when using last aggregation."""
+        self._skip_if_unsupported("last")
+        table = pa.table(
+            {
+                "region": ["A", "A", "A", "A"],
+                "ts": [None, 1, None, 2],
+                "value": [100, 10, 200, 20],
+            }
+        )
+        data = self.create_test_data(table)
+        fs = make_feature_set("value__last_groupby", ["region"], order_by="ts")
+        result = self.implementation_class().calculate_feature(data, fs)
+
+        result_col = self.extract_column(result, "value__last_groupby")
+
+        # last with order_by sorts by ts: [1->10, 2->20, None->100, None->200]
+        # last non-null = 200, broadcast to all rows
+        assert result_col == [200, 200, 200, 200]
+
     def test_multi_key_float_avg(self) -> None:
         """Avg of value_float partitioned by [region, category]."""
         fs = make_feature_set("value_float__avg_groupby", ["region", "category"])


### PR DESCRIPTION
## Summary

- Fix `TypeError` crash when 2+ rows in the same partition have `None` as the `order_by` value in `pyarrow_frame_aggregate` and `pyarrow_window_aggregation`
- Apply the same null-safe sort key pattern already used in `pyarrow_offset` (`x[1] if x[1] is not None else 0`)
- Add regression tests for both plugins covering the multi-null order_by case

## Details

Python 3 raises `TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'` when sorting tuples where the second element is `None` for multiple entries. The sort key `(t[1] is None, t[1])` places nulls last via the boolean, but when two nulls compare in the second position, the comparison fails. The fix substitutes `0` as a fallback: `(t[1] is None, t[1] if t[1] is not None else 0)`.

Closes #74

## Test plan

- [x] Regression test: `test_multiple_null_order_by_values` in frame_aggregate
- [x] Regression test: `test_multiple_null_order_by_first` in window_aggregation
- [x] Regression test: `test_multiple_null_order_by_last` in window_aggregation
- [x] Full tox suite passes