### PR TITLE
refactor: remove unnecessary ROW_NUMBER sort from SQLite aggregation

### DIFF
--- a/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
@@ -42,17 +42,13 @@ class SqliteColumnAggregation(ColumnAggregationFeatureGroup):
 
         quoted_source = quote_ident(source_col)
         quoted_feature = quote_ident(feature_name)
-        qrn = quote_ident("__mloda_rn__")
 
         sql = " ".join(
             [
                 "SELECT",
-                f"{agg_func}({quoted_source}) OVER () AS {quoted_feature},",
-                f"ROW_NUMBER() OVER (ORDER BY rowid) AS {qrn}",
+                f"{agg_func}({quoted_source}) OVER () AS {quoted_feature}",
                 "FROM",
                 f"{quote_ident(data.table_name)}",
-                "ORDER BY",
-                qrn,
             ]
         )
         cursor = data.connection.execute(sql)


### PR DESCRIPTION
## Summary
- Remove unnecessary `ROW_NUMBER() OVER (ORDER BY rowid)` column and `ORDER BY` clause from SQLite global aggregate query
- Global aggregates (`SUM/MIN/MAX/AVG/COUNT OVER ()`) broadcast the same scalar to every row, so ordering is irrelevant
- Simplifies the query from `SELECT agg() OVER () AS f, ROW_NUMBER() OVER (ORDER BY rowid) AS rn FROM t ORDER BY rn` to `SELECT agg() OVER () AS f FROM t`

Addresses item 17 of #74.

## Test plan
- [x] All 22 SQLite aggregation tests pass (19 pass, 3 skipped for unsupported types)
- [x] Full tox suite green (831 passed, mypy strict, ruff, bandit)