### PR TITLE
docs: add required_when, type_validator, and validation_function guides

### DIFF
--- a/docs/guides/feature-group-patterns/03-chained-features.md
+++ b/docs/guides/feature-group-patterns/03-chained-features.md
@@ -95,6 +95,16 @@ When your feature group supports multiple method variants (e.g., different scali
 
 Use specific keys (not generic `operation_type`) to avoid collisions between feature group types. See [Feature Matching](14-feature-matching.md#discriminator-keys-for-configuration-based-matching) for the full pattern.
 
+### Advanced PROPERTY_MAPPING Features
+
+PROPERTY_MAPPING supports additional capabilities that reduce boilerplate in `match_feature_group_criteria` overrides:
+
+- **`required_when`**: Declare options that are only required under certain conditions via a predicate callable.
+- **`type_validator`**: Validate raw option values with a callable (e.g., check that a value is a list of strings). Does not require `strict_validation`.
+- **`validation_function`**: Validate individual parsed values when `strict_validation` is enabled (e.g., check that a value is a positive integer).
+
+See [Feature Matching: Conditional Requirements](14-feature-matching.md#conditional-requirements-with-required_when) for full details, examples, and a comparison table.
+
 ## Test
 
 ```python

--- a/docs/guides/feature-group-patterns/11-options.md
+++ b/docs/guides/feature-group-patterns/11-options.md
@@ -58,6 +58,16 @@ feature = Feature("price__scaled", Options(
 
 Use propagation sparingly—most context should remain local. Common use cases include trace IDs for debugging, tenant identifiers, or configuration that genuinely needs to flow through the entire pipeline.
 
+## Validation and Conditional Requirements
+
+When using `PROPERTY_MAPPING` with `FeatureChainParserMixin`, you can declare validation rules and conditional requirements directly on option entries:
+
+- **`validation_function`**: Validate individual option values with a callable (requires `strict_validation: True`).
+- **`type_validator`**: Validate raw option values with a callable (no `strict_validation` needed). Useful for composite types like lists or dicts.
+- **`required_when`**: Make an option conditionally required based on a predicate callable.
+
+See [Feature Matching: Conditional Requirements](14-feature-matching.md#conditional-requirements-with-required_when) for full details, examples, and a comparison table.
+
 ## Full Documentation
 
 See [Options API](https://mloda-ai.github.io/mloda/in_depth/options/) for detailed patterns.

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -127,6 +127,165 @@ def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
 
 ---
 
+## Conditional Requirements with `required_when`
+
+Some PROPERTY_MAPPING entries should only be required under certain conditions. For example, an `order_by` column might only be needed when the aggregation type is `first` or `last`, but not for `sum` or `avg`.
+
+Use `DefaultOptionKeys.required_when` to attach a predicate callable to a mapping entry. The predicate receives the effective `Options` object and returns `True` when the option is required.
+
+```python
+from mloda.user import Options
+from mloda_plugins.feature_group.experimental.default_options_key import DefaultOptionKeys
+
+_ORDER_DEPENDENT = {"first", "last"}
+
+def _needs_order_by(options: Options) -> bool:
+    """order_by is required when aggregation_type is first or last."""
+    return options.get("aggregation_type") in _ORDER_DEPENDENT
+
+PROPERTY_MAPPING = {
+    "aggregation_type": {
+        "sum": "Sum", "avg": "Average", "first": "First", "last": "Last",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: True,
+    },
+    "order_by": {
+        "explanation": "Column to order by within each partition",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: False,
+        DefaultOptionKeys.required_when: _needs_order_by,
+    },
+}
+```
+
+### How It Works
+
+1. The base parser treats entries with `required_when` as optional (skips the required check).
+2. After basic matching succeeds, `match_feature_group_criteria` evaluates each `required_when` predicate.
+3. For string-based features, the operation value parsed from the feature name (e.g., `first` from `source__first_aggr`) is merged into the effective options, so predicates see values from both the feature name and explicit options.
+4. If the predicate returns `True` and the option value is absent, matching returns `False`.
+
+### Before and After
+
+Without `required_when`, you must override `match_feature_group_criteria` to manually check conditions:
+
+```python
+# Before: manual override with boilerplate
+@classmethod
+def match_feature_group_criteria(cls, feature_name, options, _dac=None):
+    if not super().match_feature_group_criteria(feature_name, options, _dac):
+        return False
+    agg_type = cls._resolve_agg_type(feature_name, options)
+    if agg_type in {"first", "last"}:
+        order_by = options.get("order_by")
+        if not isinstance(order_by, str):
+            return False
+    return True
+```
+
+With `required_when`, the mixin handles this automatically:
+
+```python
+# After: declarative, no override needed
+PROPERTY_MAPPING = {
+    "aggregation_type": { ... },
+    "order_by": {
+        "explanation": "Column to order by",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: False,
+        DefaultOptionKeys.required_when: _needs_order_by,
+    },
+}
+# match_feature_group_criteria inherited from mixin, no override required
+```
+
+### Predicate Contract
+
+- Signature: `(Options) -> bool`
+- Must be callable (non-callable predicates are skipped with a warning)
+- Non-bool truthy values are treated as `True`
+- Should be pure (no side effects)
+
+---
+
+## Type Validation with `type_validator`
+
+Use `DefaultOptionKeys.type_validator` to validate the raw option value with a callable. Unlike `validation_function`, this does not require `strict_validation` and operates on the whole option value before any unpacking.
+
+After basic matching and `required_when` checks succeed, `match_feature_group_criteria` calls each `type_validator`. If the validator returns a falsy value, matching returns `False`. If the validator raises `TypeError`, `ValueError`, or `AttributeError`, the value is treated as invalid.
+
+```python
+from mloda_plugins.feature_group.experimental.default_options_key import DefaultOptionKeys
+
+def _is_list_of_strings(value):
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+PROPERTY_MAPPING = {
+    "partition_by": {
+        "explanation": "Columns to partition by",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: False,
+        DefaultOptionKeys.type_validator: _is_list_of_strings,
+    },
+    "window_size": {
+        "explanation": "Number of rows in the rolling window",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: True,
+        DefaultOptionKeys.type_validator: lambda x: isinstance(x, int) and x > 0,
+    },
+}
+```
+
+### Key Differences from `validation_function`
+
+| Aspect | `type_validator` | `validation_function` |
+|--------|-----------------|----------------------|
+| Requires `strict_validation` | No | Yes |
+| Validates | Raw option value (whole) | Individual parsed elements |
+| Failure mode | Returns `False` (soft rejection) | Raises `ValueError` |
+| Runs during | `match_feature_group_criteria` (after basic match) | Base parser property validation |
+| Use case | Composite types (lists, dicts, ranges) | Membership-style checks on single values |
+
+When both are present on the same entry, `validation_function` runs first (during base parsing), then `type_validator` runs second (during mixin matching).
+
+---
+
+## Custom Validation with `validation_function`
+
+Use `DefaultOptionKeys.validation_function` to validate individual option values with a callable instead of checking membership against a fixed set of allowed values. This requires `strict_validation: True`.
+
+When the validation function is present, it is called instead of checking whether the value exists in the mapping dict. The function receives each individual parsed value and must return `True` if valid. Returning `False` raises a `ValueError`, which the mixin catches and converts to a `False` match result.
+
+```python
+from mloda_plugins.feature_group.experimental.default_options_key import DefaultOptionKeys
+
+PROPERTY_MAPPING = {
+    "window_size": {
+        "explanation": "Number of rows in the rolling window",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: True,
+        DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
+    },
+    "threshold": {
+        "explanation": "Cutoff value for filtering",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: True,
+        DefaultOptionKeys.validation_function: lambda x: isinstance(x, (int, float)) and 0.0 <= x <= 1.0,
+    },
+}
+```
+
+### When to Use Each Validation Approach
+
+| Approach | Use When | Example |
+|----------|----------|---------|
+| Enumerated values | Fixed set of valid string values | `"sum"`, `"avg"`, `"min"` |
+| `validation_function` | Open-ended single values, `strict_validation` is `True` | positive integers, float ranges |
+| `type_validator` | Composite types, no `strict_validation` needed | list of strings, nested dicts |
+| `required_when` | Option is conditionally required | `order_by` only when aggregation is `first` |
+
+---
+
 ## Matching vs Naming
 
 | Concept | Method | Purpose |


### PR DESCRIPTION
## Summary

- Add documentation for `required_when` conditional requirements, `type_validator` composite type validation, and `validation_function` element-level validation in PROPERTY_MAPPING to the feature matching guide (14)
- Include before/after examples, predicate contract details, and a comparison table showing when to use each approach
- Add cross-references from the chained features guide (03) and options guide (11) to the new sections
- All documentation verified against actual mloda core implementation (PRs #240 and #241)

Closes #57
Closes #65
Closes #66
Closes #70
Closes #72
Supersedes #71

## Test plan

- [x] `uv run tox` passes (831 tests, ruff, mypy, bandit clean)
- [ ] Review that code examples are accurate against mloda core implementation
- [ ] Verify cross-reference links resolve correctly