### PR TITLE
refactor: vectorize PyArrow window_aggregation, offset, and frame_aggregate

### DIFF
--- a/mloda/community/feature_groups/data_operations/pyarrow_aggregation_helpers.py
+++ b/mloda/community/feature_groups/data_operations/pyarrow_aggregation_helpers.py
@@ -1,9 +1,8 @@
 """Shared PyArrow aggregation helpers for data operation feature groups.
 
-PyArrow lacks native group-by / window-function APIs, so these packages use
-Python dict-based grouping with row-by-row .as_py() calls. The helper
-functions below compute scalar aggregates over plain Python lists and are
-shared by pyarrow_group_aggregation and pyarrow_window_aggregation.
+The helper functions below compute scalar aggregates over plain Python lists.
+They are used by frame_aggregate (per-window aggregation) and as a fallback
+for operations that PyArrow's native group_by API does not support directly.
 """
 
 from __future__ import annotations

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyarrow_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyarrow_frame_aggregate.py
@@ -1,4 +1,11 @@
-"""PyArrow implementation for frame aggregate feature groups."""
+"""PyArrow implementation for frame aggregate feature groups.
+
+Uses bulk ``to_pylist()`` extraction (one C++ call per column) instead of
+per-row ``.as_py()`` calls, then performs grouping, sorting, and windowed
+aggregation in pure Python on the extracted lists. The windowing logic
+(rolling, cumulative, expanding, time) is inherently sequential per group
+and cannot be further vectorized with PyArrow's current API.
+"""
 
 from __future__ import annotations
 
@@ -16,14 +23,6 @@ from mloda.community.feature_groups.data_operations.row_preserving.frame_aggrega
 
 
 class PyArrowFrameAggregate(FrameAggregateFeatureGroup):
-    """Pure-Python reference implementation of frame aggregation over PyArrow tables.
-
-    This implementation iterates row-by-row and is O(n * w) per partition (where
-    n is partition size and w is window size). It is designed for correctness
-    testing and small datasets. For production workloads with large tables,
-    prefer the Pandas, Polars, or DuckDB backends which use vectorized operations.
-    """
-
     @classmethod
     def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
         return {PyArrowTable}
@@ -43,19 +42,18 @@ class PyArrowFrameAggregate(FrameAggregateFeatureGroup):
     ) -> pa.Table:
         num_rows = table.num_rows
 
-        keys: list[tuple[Any, ...]] = []
-        for i in range(num_rows):
-            key = tuple(table.column(col)[i].as_py() for col in partition_by)
-            keys.append(key)
+        # Bulk-extract all needed columns (one C++ call each, not N .as_py() calls)
+        partition_lists = {col: table.column(col).to_pylist() for col in partition_by}
+        order_vals = table.column(order_by).to_pylist()
+        source_vals = table.column(source_col).to_pylist()
 
+        # Build group keys from extracted Python lists (no PyArrow calls in loop)
         groups: dict[tuple[Any, ...], list[tuple[int, Any, Any]]] = {}
         for i in range(num_rows):
-            key = keys[i]
-            val = table.column(source_col)[i].as_py()
-            order_val = table.column(order_by)[i].as_py()
+            key = tuple(partition_lists[col][i] for col in partition_by)
             if key not in groups:
                 groups[key] = []
-            groups[key].append((i, order_val, val))
+            groups[key].append((i, order_vals[i], source_vals[i]))
 
         for key in groups:
             groups[key].sort(key=lambda t: (t[1] is None, t[1] if t[1] is not None else 0))

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/pyarrow_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/pyarrow_offset.py
@@ -1,4 +1,9 @@
-"""PyArrow implementation for offset feature groups."""
+"""PyArrow implementation for offset feature groups.
+
+Uses bulk ``to_pylist()`` extraction (one C++ call per column) instead of
+per-row ``.as_py()`` calls, then performs grouping and offset computation
+in pure Python on the extracted lists.
+"""
 
 from __future__ import annotations
 
@@ -31,15 +36,18 @@ class PyArrowOffset(OffsetFeatureGroup):
     ) -> pa.Table:
         num_rows = table.num_rows
 
-        # Build group keys and collect (index, order_value, source_value) per group
+        # Bulk-extract all needed columns (one C++ call each, not N .as_py() calls)
+        partition_lists = {col: table.column(col).to_pylist() for col in partition_by}
+        order_vals = table.column(order_by).to_pylist()
+        source_vals = table.column(source_col).to_pylist()
+
+        # Build group keys from extracted Python lists (no PyArrow calls in loop)
         groups: dict[tuple[Any, ...], list[tuple[int, Any, Any]]] = {}
         for i in range(num_rows):
-            key = tuple(table.column(col)[i].as_py() for col in partition_by)
-            order_val = table.column(order_by)[i].as_py()
-            source_val = table.column(source_col)[i].as_py()
+            key = tuple(partition_lists[col][i] for col in partition_by)
             if key not in groups:
                 groups[key] = []
-            groups[key].append((i, order_val, source_val))
+            groups[key].append((i, order_vals[i], source_vals[i]))
 
         # Sort each group by order_by (nulls last)
         for key in groups:
@@ -49,48 +57,46 @@ class PyArrowOffset(OffsetFeatureGroup):
 
         for key, sorted_rows in groups.items():
             n = len(sorted_rows)
-            source_vals = [row[2] for row in sorted_rows]
+            vals = [row[2] for row in sorted_rows]
 
             if offset_type.startswith("lag_"):
                 offset_n = int(offset_type[len("lag_") :])
                 for pos in range(n):
                     idx = sorted_rows[pos][0]
                     if pos >= offset_n:
-                        result_values[idx] = source_vals[pos - offset_n]
+                        result_values[idx] = vals[pos - offset_n]
 
             elif offset_type.startswith("lead_"):
                 offset_n = int(offset_type[len("lead_") :])
                 for pos in range(n):
                     idx = sorted_rows[pos][0]
                     if pos + offset_n < n:
-                        result_values[idx] = source_vals[pos + offset_n]
+                        result_values[idx] = vals[pos + offset_n]
 
             elif offset_type.startswith("diff_"):
                 offset_n = int(offset_type[len("diff_") :])
                 for pos in range(n):
                     idx = sorted_rows[pos][0]
-                    curr = source_vals[pos]
-                    if pos >= offset_n and curr is not None and source_vals[pos - offset_n] is not None:
-                        result_values[idx] = curr - source_vals[pos - offset_n]
+                    curr = vals[pos]
+                    if pos >= offset_n and curr is not None and vals[pos - offset_n] is not None:
+                        result_values[idx] = curr - vals[pos - offset_n]
 
             elif offset_type.startswith("pct_change_"):
                 offset_n = int(offset_type[len("pct_change_") :])
                 for pos in range(n):
                     idx = sorted_rows[pos][0]
-                    curr = source_vals[pos]
-                    prev = source_vals[pos - offset_n] if pos >= offset_n else None
+                    curr = vals[pos]
+                    prev = vals[pos - offset_n] if pos >= offset_n else None
                     if curr is not None and prev is not None and prev != 0:
                         result_values[idx] = (curr - prev) / prev
 
             elif offset_type == "first_value":
-                # First non-null value in the partition
-                first = next((v for v in source_vals if v is not None), None)
+                first = next((v for v in vals if v is not None), None)
                 for pos in range(n):
                     result_values[sorted_rows[pos][0]] = first
 
             elif offset_type == "last_value":
-                # Last non-null value in the partition
-                last = next((v for v in reversed(source_vals) if v is not None), None)
+                last = next((v for v in reversed(vals) if v is not None), None)
                 for pos in range(n):
                     result_values[sorted_rows[pos][0]] = last
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
@@ -1,18 +1,47 @@
-"""PyArrow implementation for window aggregation feature groups."""
+"""PyArrow implementation for window aggregation feature groups.
+
+Uses PyArrow's native ``Table.group_by().aggregate()`` API for vectorized,
+C++-backed aggregation. The aggregate is computed per partition in C++ and
+then broadcast back to every row via an index-list collected during the
+same group_by call. Median and mode fall back to a list-collect-then-compute
+path because PyArrow has no exact grouped median or grouped mode function.
+"""
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any, Optional, Set, Type, Union
 
 import pyarrow as pa
+import pyarrow.compute as pc
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
-from mloda.community.feature_groups.data_operations.pyarrow_aggregation_helpers import aggregate
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
 )
+
+_IDX_COL = "__mloda_wa_idx__"
+
+_PA_AGG_FUNCS: dict[str, str] = {
+    "sum": "sum",
+    "avg": "mean",
+    "count": "count",
+    "min": "min",
+    "max": "max",
+    "nunique": "count_distinct",
+}
+
+_SAMPLE_STAT_FUNCS: dict[str, str] = {
+    "std": "stddev",
+    "var": "variance",
+}
+
+_ORDERED_FUNCS: dict[str, str] = {
+    "first": "first",
+    "last": "last",
+}
 
 
 class PyArrowWindowAggregation(WindowAggregationFeatureGroup):
@@ -31,37 +60,138 @@ class PyArrowWindowAggregation(WindowAggregationFeatureGroup):
         order_by: Optional[str] = None,
     ) -> pa.Table:
         num_rows = table.num_rows
+        t_with_idx = table.append_column(_IDX_COL, pa.array(range(num_rows)))
 
-        # Build group keys per row (using Python objects so None is a valid key)
-        keys: list[tuple[Any, ...]] = []
-        for i in range(num_rows):
-            key = tuple(table.column(col)[i].as_py() for col in partition_by)
-            keys.append(key)
-
-        # Collect source values per group, preserving row indices
-        groups: dict[tuple[Any, ...], list[tuple[Any, Any]]] = {}
-        for i in range(num_rows):
-            key = keys[i]
-            val = table.column(source_col)[i].as_py()
-            order_val = table.column(order_by)[i].as_py() if order_by else i
-            if key not in groups:
-                groups[key] = []
-            groups[key].append((order_val, val))
-
-        # Compute aggregate per group
-        agg_results: dict[tuple[Any, ...], Any] = {}
-        for key, pairs in groups.items():
-            values = [v for _, v in pairs]
-            if agg_type in ("first", "last") and order_by:
-                sorted_vals = [
-                    v for _, v in sorted(pairs, key=lambda p: (p[0] is None, p[0] if p[0] is not None else 0))
+        if agg_type in _PA_AGG_FUNCS:
+            pa_func = _PA_AGG_FUNCS[agg_type]
+            grouped = t_with_idx.group_by(partition_by).aggregate(
+                [
+                    (source_col, pa_func),
+                    (_IDX_COL, "list"),
                 ]
-                agg_results[key] = aggregate(sorted_vals, agg_type)
+            )
+            agg_col = f"{source_col}_{pa_func}"
+
+        elif agg_type in _SAMPLE_STAT_FUNCS:
+            pa_func = _SAMPLE_STAT_FUNCS[agg_type]
+            grouped = t_with_idx.group_by(partition_by).aggregate(
+                [
+                    (source_col, pa_func, pc.VarianceOptions(ddof=1)),
+                    (_IDX_COL, "list"),
+                ]
+            )
+            agg_col = f"{source_col}_{pa_func}"
+
+        elif agg_type in _ORDERED_FUNCS:
+            return cls._compute_ordered(t_with_idx, feature_name, source_col, partition_by, agg_type, order_by)
+
+        elif agg_type in ("median", "mode"):
+            return cls._compute_via_list(t_with_idx, feature_name, source_col, partition_by, agg_type)
+
+        else:
+            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+
+        return cls._broadcast(table, grouped, agg_col, feature_name, num_rows)
+
+    @classmethod
+    def _compute_ordered(
+        cls,
+        t_with_idx: pa.Table,
+        feature_name: str,
+        source_col: str,
+        partition_by: list[str],
+        agg_type: str,
+        order_by: Optional[str],
+    ) -> pa.Table:
+        pa_func = _ORDERED_FUNCS[agg_type]
+        sort_keys = [(col, "ascending") for col in partition_by]
+        if order_by:
+            sort_keys.append((order_by, "ascending"))
+        indices = pc.sort_indices(t_with_idx, sort_keys=sort_keys, null_placement="at_end")
+        sorted_t = t_with_idx.take(indices)
+
+        grouped = sorted_t.group_by(partition_by, use_threads=False).aggregate(
+            [
+                (source_col, pa_func),
+                (_IDX_COL, "list"),
+            ]
+        )
+        agg_col = f"{source_col}_{pa_func}"
+
+        original_table = t_with_idx.drop_columns([_IDX_COL])
+        return cls._broadcast(original_table, grouped, agg_col, feature_name, original_table.num_rows)
+
+    @classmethod
+    def _compute_via_list(
+        cls,
+        t_with_idx: pa.Table,
+        feature_name: str,
+        source_col: str,
+        partition_by: list[str],
+        agg_type: str,
+    ) -> pa.Table:
+        grouped = t_with_idx.group_by(partition_by).aggregate(
+            [
+                (source_col, "list"),
+                (_IDX_COL, "list"),
+            ]
+        )
+        list_col = f"{source_col}_list"
+        idx_list_col = f"{_IDX_COL}_list"
+
+        num_rows = t_with_idx.num_rows
+        result_values: list[Any] = [None] * num_rows
+
+        for g in range(grouped.num_rows):
+            vals = grouped.column(list_col)[g].as_py()
+            indices = grouped.column(idx_list_col)[g].as_py()
+            non_null = [v for v in vals if v is not None]
+
+            if not non_null:
+                agg_val = None
+            elif agg_type == "median":
+                agg_val = _median(non_null)
             else:
-                agg_results[key] = aggregate(values, agg_type)
+                agg_val = _mode(non_null)
 
-        # Broadcast back to every row
-        result_values = [agg_results[keys[i]] for i in range(num_rows)]
+            for idx in indices:
+                result_values[idx] = agg_val
 
-        new_col = pa.array(result_values)
-        return table.append_column(feature_name, new_col)
+        original_table = t_with_idx.drop_columns([_IDX_COL])
+        return original_table.append_column(feature_name, pa.array(result_values))
+
+    @classmethod
+    def _broadcast(
+        cls,
+        original_table: pa.Table,
+        grouped: pa.Table,
+        agg_col: str,
+        feature_name: str,
+        num_rows: int,
+    ) -> pa.Table:
+        idx_list_col = f"{_IDX_COL}_list"
+        result_values: list[Any] = [None] * num_rows
+
+        for g in range(grouped.num_rows):
+            agg_val = grouped.column(agg_col)[g].as_py()
+            indices = grouped.column(idx_list_col)[g].as_py()
+            for idx in indices:
+                result_values[idx] = agg_val
+
+        return original_table.append_column(feature_name, pa.array(result_values))
+
+
+def _median(values: list[Any]) -> Any:
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    if n % 2 == 0:
+        return (s[mid - 1] + s[mid]) / 2.0
+    return float(s[mid])
+
+
+def _mode(values: list[Any]) -> Any:
+    if not values:
+        return None
+    counts = Counter(values)
+    return counts.most_common(1)[0][0]


### PR DESCRIPTION
## Summary

- **window_aggregation**: Replaced per-row `.as_py()` grouping with PyArrow's native `group_by().aggregate()` API. Aggregation now runs in C++ with results broadcast via an index-list collected during the same group_by call. Python loop runs once per group (G iterations) instead of once per row (N iterations). Median/mode fall back to list-collect-then-compute.
- **offset**: Replaced N individual `.as_py()` calls per column with bulk `to_pylist()` extraction (one C++ call per column). Grouping loop still runs in Python but operates on already-extracted Python lists with zero PyArrow boundary crossings.
- **frame_aggregate**: Same bulk `to_pylist()` approach as offset. Windowing logic (rolling/cumulative/expanding/time) is inherently sequential per group and stays in Python, but data extraction is now bulk.
- Updated `pyarrow_aggregation_helpers.py` docstring to reflect current usage.

Addresses #74 item #10.

## Test plan

- [x] All 28 window_aggregation PyArrow tests pass
- [x] All 16 offset PyArrow tests pass  
- [x] All 23 frame_aggregate PyArrow tests pass (including time window and null handling)
- [x] Full tox suite passes (pytest + ruff + mypy + bandit)
- [x] Cross-framework consistency tests confirm identical results

🤖 Generated with [Claude Code](https://claude.com/claude-code)