### PR TITLE
fix: PyArrow rank DESC sort for non-numeric order_by columns

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pyarrow_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pyarrow_rank.py
@@ -53,7 +53,7 @@ class PyArrowRank(RankFeatureGroup):
 
         # Sort each group by order_by value (nulls last)
         for key in groups:
-            groups[key].sort(key=lambda x: (x[1] is None, x[1] if x[1] is not None else 0))
+            groups[key].sort(key=lambda x: (1,) if x[1] is None else (0, x[1]))
 
         # Compute rank values
         result_values: list[Any] = [0] * num_rows
@@ -115,11 +115,10 @@ class PyArrowRank(RankFeatureGroup):
 
             elif rank_type.startswith("top_"):
                 top_n = int(rank_type[len("top_") :])
-                # Sort DESC for top-N with nulls last
-                desc_rows = sorted(
-                    sorted_rows,
-                    key=lambda x: (x[1] is None, -(x[1]) if x[1] is not None else 0),
-                )
+                # Reverse the ASC-sorted non-null rows to get DESC; keep nulls last
+                non_null = [(idx, val) for idx, val in sorted_rows if val is not None]
+                nulls = [(idx, val) for idx, val in sorted_rows if val is None]
+                desc_rows = non_null[::-1] + nulls
                 for pos, (idx, _) in enumerate(desc_rows):
                     result_values[idx] = pos + 1 <= top_n
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
@@ -475,6 +475,40 @@ class RankTestBase(DataOpsTestBase):
         assert result_col[2] == 2  # ts=2, second
         assert result_col[0] == 3  # ts=None, last (nulls last)
 
+    def test_top_n_string_order_by(self) -> None:
+        """Top 2 with a string order_by column: DESC sort must not use negation."""
+        table = pa.table(
+            {
+                "region": ["A", "A", "A", "A"],
+                "label": ["cherry", "apple", "banana", None],
+            }
+        )
+        data = self.create_test_data(table)
+        fs = make_feature_set("label__top_2_ranked", ["region"], "label")
+        result = self.implementation_class().calculate_feature(data, fs)
+
+        result_col = self.extract_column(result, "label__top_2_ranked")
+        # DESC with nulls last: cherry(0), banana(2), apple(1), None(3)
+        # Top 2 = rows 0 and 2 -> True; rows 1 and 3 -> False
+        assert result_col == [True, False, True, False]
+
+    def test_bottom_n_string_order_by(self) -> None:
+        """Bottom 2 with a string order_by column: ASC sort on non-numeric types."""
+        table = pa.table(
+            {
+                "region": ["A", "A", "A", "A"],
+                "label": ["cherry", "apple", "banana", None],
+            }
+        )
+        data = self.create_test_data(table)
+        fs = make_feature_set("label__bottom_2_ranked", ["region"], "label")
+        result = self.implementation_class().calculate_feature(data, fs)
+
+        result_col = self.extract_column(result, "label__bottom_2_ranked")
+        # ASC with nulls last: apple(1), banana(2), cherry(0), None(3)
+        # Bottom 2 = rows 1 and 2 -> True; rows 0 and 3 -> False
+        assert result_col == [False, True, True, False]
+
     # -- Helper methods ------------------------------------------------------
 
     def _skip_if_unsupported(self, rank_type: str) -> None:


### PR DESCRIPTION
## Summary

- Replace negation-based DESC sort (`-(x[1])`) in PyArrow `top_N` rank with a type-agnostic reverse of the ASC-sorted non-null rows, keeping nulls last
- Clean up the ASC sort key to avoid a type-specific `else 0` sentinel
- Add `test_top_n_string_order_by` and `test_bottom_n_string_order_by` to the shared `RankTestBase`, covering all 6 backends

## Test plan

- [x] `test_top_n_string_order_by` fails before fix (TypeError on negation of str), passes after
- [x] `test_bottom_n_string_order_by` passes before and after (ASC path was functional)
- [x] All 232 rank tests pass across PyArrow, Pandas, Polars, DuckDB, SQLite, and integration
- [x] Full tox suite passes (pytest + ruff + mypy + bandit)

Closes #101