### PR TITLE
refactor: replace Python-list binning with native framework ops

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from typing import Any, List, Optional, Set
 
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -135,44 +134,3 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         n_bins: int,
     ) -> Any:
         raise NotImplementedError
-
-    @classmethod
-    def _equal_width_binning(cls, values: list[Any], non_null: list[Any], n_bins: int) -> list[Any]:
-        """Assign each value to an equal-width bin using left-closed intervals [a, b)."""
-        min_val = min(non_null)
-        max_val = max(non_null)
-
-        result: list[Any] = []
-        for val in values:
-            if val is None or (isinstance(val, float) and math.isnan(val)):
-                result.append(None)
-                continue
-            if min_val == max_val:
-                result.append(0)
-                continue
-            bin_width = (max_val - min_val) / n_bins
-            bin_idx = int((val - min_val) / bin_width)
-            if bin_idx >= n_bins:
-                bin_idx = n_bins - 1
-            result.append(bin_idx)
-        return result
-
-    @classmethod
-    def _quantile_binning(cls, values: list[Any], n_bins: int) -> list[Any]:
-        """Rank-based quantile binning matching NTILE semantics.
-
-        Rows are sorted by value and divided into n_bins roughly equal groups.
-        For N non-null values, rank r (0-based) maps to bin = r * n_bins // N.
-        Ties receive consecutive ranks (same value may span two bins at a boundary).
-        """
-        indexed = [
-            (v, i) for i, v in enumerate(values) if v is not None and not (isinstance(v, float) and math.isnan(v))
-        ]
-        indexed.sort(key=lambda pair: pair[0])
-        n = len(indexed)
-
-        result: list[Any] = [None] * len(values)
-        for rank, (_, orig_idx) in enumerate(indexed):
-            result[orig_idx] = rank * n_bins // n
-
-        return result

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
@@ -32,23 +32,22 @@ class DuckdbBinning(BinningFeatureGroup):
         quoted_feature = quote_ident(feature_name)
 
         if op == "bin":
+            not_nan = f"NOT isnan({quoted_source})"
+            min_expr = f"MIN({quoted_source}) FILTER (WHERE {not_nan}) OVER ()"
+            max_expr = f"MAX({quoted_source}) FILTER (WHERE {not_nan}) OVER ()"
             expr = (
-                f"CASE WHEN {quoted_source} IS NULL THEN NULL "
-                f"WHEN MAX({quoted_source}) OVER () = MIN({quoted_source}) OVER () THEN 0 "
+                f"CASE WHEN {quoted_source} IS NULL OR isnan({quoted_source}) THEN NULL "
+                f"WHEN {max_expr} = {min_expr} THEN 0 "
                 f"ELSE LEAST(CAST(FLOOR("
-                f"({quoted_source} - MIN({quoted_source}) OVER ()) / "
-                f"NULLIF((MAX({quoted_source}) OVER () - MIN({quoted_source}) OVER ()) / {n_bins}.0, 0)"
+                f"({quoted_source} - {min_expr}) / "
+                f"NULLIF(({max_expr} - {min_expr}) / {n_bins}.0, 0)"
                 f") AS INTEGER), {n_bins - 1}) END"
             )
             raw_sql = f"*, {expr} AS {quoted_feature}"
             result: DuckdbRelation = data.select(_raw_sql=raw_sql)
             return result
 
-        if op == "qbin":
-            arrow_table = data.to_arrow_table()
-            values = arrow_table.column(source_col).to_pylist()
-            result_values = cls._quantile_binning(values, n_bins)
-            qbin_result: DuckdbRelation = data.append_column(feature_name, result_values)
-            return qbin_result
-
+        # qbin requires NTILE() with ORDER BY, which reorders rows in DuckDB's
+        # relational API. Blocked until DuckdbRelation exposes a public order() method.
+        # See: https://github.com/mloda-ai/mloda/issues/251
         raise ValueError(f"Unsupported binning operation for DuckDB: {op}")

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pandas_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pandas_binning.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Set, Type, Union
 
+import numpy as np
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -37,12 +38,23 @@ class PandasBinning(BinningFeatureGroup):
             return data
 
         if op == "bin":
-            non_null_vals = col[non_null_mask].tolist()
-            result = cls._equal_width_binning(col.tolist(), non_null_vals, n_bins)
-            data[feature_name] = pd.Series(result, dtype="Int64")
+            col_min = col[non_null_mask].min()
+            col_max = col[non_null_mask].max()
+            bin_width = (col_max - col_min) / n_bins
+
+            if col_min == col_max:
+                result = pd.array([0 if m else pd.NA for m in non_null_mask], dtype="Int64")
+            else:
+                bin_idx = np.floor((col - col_min) / bin_width)
+                bin_idx = bin_idx.clip(upper=n_bins - 1)
+                result = bin_idx.astype("Int64")
+
+            data[feature_name] = result
         elif op == "qbin":
-            result = cls._quantile_binning(col.tolist(), n_bins)
-            data[feature_name] = pd.Series(result, dtype="Int64")
+            n = non_null_mask.sum()
+            rank = col.rank(method="first", na_option="keep") - 1
+            result = (rank * n_bins // n).astype("Int64")
+            data[feature_name] = result
         else:
             raise ValueError(f"Unsupported binning operation: {op}")
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/polars_lazy_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/polars_lazy_binning.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Set, Type, Union
 
 import polars as pl
 
@@ -28,22 +28,42 @@ class PolarsLazyBinning(BinningFeatureGroup):
         op: str,
         n_bins: int,
     ) -> pl.LazyFrame:
-        collected = data.collect()
-        col = collected[source_col]
-        values = col.to_list()
-        non_null = [v for v in values if v is not None]
-
-        if not non_null:
-            result_values: list[Any] = [None] * len(values)
-            result_series = pl.Series(feature_name, result_values, dtype=pl.Int64)
-            return collected.with_columns(result_series).lazy()
-
         if op == "bin":
-            result_values = cls._equal_width_binning(values, non_null, n_bins)
+            expr = cls._build_bin_expr(source_col, n_bins)
         elif op == "qbin":
-            result_values = cls._quantile_binning(values, n_bins)
+            expr = cls._build_qbin_expr(source_col, n_bins)
         else:
             raise ValueError(f"Unsupported binning operation: {op}")
 
-        result_series = pl.Series(feature_name, result_values, dtype=pl.Int64)
-        return collected.with_columns(result_series).lazy()
+        return data.with_columns(expr.alias(feature_name))
+
+    @classmethod
+    def _build_bin_expr(cls, source_col: str, n_bins: int) -> pl.Expr:
+        col = pl.col(source_col).fill_nan(None)
+        col_min = col.min()
+        col_max = col.max()
+        col_range = col_max - col_min
+
+        safe_width = pl.when(col_range == 0).then(pl.lit(1.0)).otherwise(col_range.cast(pl.Float64) / n_bins)
+
+        raw_bin = ((col - col_min) / safe_width).floor()
+
+        clamped = pl.when(raw_bin >= n_bins).then(pl.lit(n_bins - 1).cast(pl.Float64)).otherwise(raw_bin)
+
+        return (
+            pl.when(col.is_null())
+            .then(pl.lit(None, dtype=pl.Int64))
+            .when(col_min == col_max)
+            .then(pl.lit(0, dtype=pl.Int64))
+            .otherwise(clamped.cast(pl.Int64))
+        )
+
+    @classmethod
+    def _build_qbin_expr(cls, source_col: str, n_bins: int) -> pl.Expr:
+        col = pl.col(source_col).fill_nan(None)
+        rank_expr = col.rank("ordinal") - 1
+        count_expr = col.count()
+
+        bin_expr = (rank_expr * n_bins) // count_expr
+
+        return pl.when(col.is_null()).then(pl.lit(None, dtype=pl.Int64)).otherwise(bin_expr).cast(pl.Int64)

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pyarrow_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pyarrow_binning.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Set, Type, Union
 
 import pyarrow as pa
+import pyarrow.compute as pc
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
@@ -28,21 +29,60 @@ class PyArrowBinning(BinningFeatureGroup):
         op: str,
         n_bins: int,
     ) -> pa.Table:
-        values = table.column(source_col).to_pylist()
+        col = table.column(source_col)
 
-        non_null = [v for v in values if v is not None]
+        nan_mask = pc.is_nan(col)
+        if pc.any(nan_mask).as_py():
+            col = pc.if_else(nan_mask, None, col)
 
-        if not non_null:
-            result_values: list[Any] = [None] * len(values)
-            new_col = pa.array(result_values, type=pa.int64())
-            return table.append_column(feature_name, new_col)
+        non_null_count = pc.sum(pc.cast(pc.is_valid(col), pa.int64())).as_py()
+
+        if non_null_count == 0:
+            null_col = pa.array([None] * len(col), type=pa.int64())
+            return table.append_column(feature_name, null_col)
 
         if op == "bin":
-            result_values = cls._equal_width_binning(values, non_null, n_bins)
+            result_array = cls._equal_width_bin(col, n_bins)
         elif op == "qbin":
-            result_values = cls._quantile_binning(values, n_bins)
+            result_array = cls._quantile_bin(col, n_bins, non_null_count)
         else:
             raise ValueError(f"Unsupported binning operation: {op}")
 
-        new_col = pa.array(result_values, type=pa.int64())
-        return table.append_column(feature_name, new_col)
+        return table.append_column(feature_name, result_array)
+
+    @classmethod
+    def _equal_width_bin(cls, col: pa.ChunkedArray, n_bins: int) -> pa.Array:
+        col_min = pc.min(col)
+        col_max = pc.max(col)
+
+        if pc.equal(col_min, col_max).as_py():
+            result = pc.if_else(pc.is_null(col), None, 0)
+            return pc.cast(result, pa.int64())
+
+        bin_width = pc.divide(
+            pc.subtract(col_max, col_min).cast(pa.float64()),
+            pa.scalar(n_bins, type=pa.float64()),
+        )
+
+        shifted = pc.subtract(col.cast(pa.float64()), col_min.cast(pa.float64()))
+        raw_bin = pc.floor(pc.divide(shifted, bin_width))
+
+        max_bin = pa.scalar(n_bins - 1, type=pa.float64())
+        clamped = pc.min_element_wise(raw_bin, max_bin)
+
+        result = pc.if_else(pc.is_null(col), None, clamped)
+        return pc.cast(result, pa.int64())
+
+    @classmethod
+    def _quantile_bin(cls, col: pa.ChunkedArray, n_bins: int, non_null_count: int) -> pa.Array:
+        indices = pc.sort_indices(col, null_placement="at_end")
+        n = non_null_count
+
+        result_values: list[Any] = [None] * len(col)
+
+        for rank in range(n):
+            original_idx = indices[rank].as_py()
+            bin_val = rank * n_bins // n
+            result_values[original_idx] = bin_val
+
+        return pa.array(result_values, type=pa.int64())

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_duckdb.py
@@ -18,7 +18,16 @@ from mloda.testing.feature_groups.data_operations.row_preserving.binning.binning
 
 
 class TestDuckdbBinning(DuckdbTestMixin, BinningTestBase):
-    """Standard tests inherited from the base class."""
+    """Standard tests inherited from the base class.
+
+    qbin is excluded: DuckdbRelation lacks a public order() method, so NTILE
+    results cannot be re-sorted to original row order without eager materialization.
+    Tracked in https://github.com/mloda-ai/mloda/issues/251.
+    """
+
+    @classmethod
+    def supported_ops(cls) -> set[str]:
+        return {"bin"}
 
     @classmethod
     def implementation_class(cls) -> Any:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/binning/binning.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/binning/binning.py
@@ -72,6 +72,10 @@ class BinningTestBase(DataOpsTestBase):
     """Abstract base class for binning framework tests."""
 
     @classmethod
+    def supported_ops(cls) -> set[str]:
+        return {"bin", "qbin"}
+
+    @classmethod
     def pyarrow_implementation_class(cls) -> Any:
         from mloda.community.feature_groups.data_operations.row_preserving.binning.pyarrow_binning import (
             PyArrowBinning,
@@ -137,6 +141,7 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_qbin_3_value_int(self) -> None:
         """Quantile binning of value_int into 3 bins."""
+        self._skip_if_unsupported("qbin")
         fs = make_feature_set("value_int__qbin_3")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -148,6 +153,7 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_qbin_5_value_int(self) -> None:
         """Quantile binning of value_int into 5 bins."""
+        self._skip_if_unsupported("qbin")
         fs = make_feature_set("value_int__qbin_5")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -159,6 +165,7 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_qbin_null_propagation(self) -> None:
         """Null values produce null qbin assignments."""
+        self._skip_if_unsupported("qbin")
         fs = make_feature_set("value_int__qbin_3")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -167,6 +174,7 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_qbin_values_in_range(self) -> None:
         """All non-null qbin values must be in [0, n_bins-1]."""
+        self._skip_if_unsupported("qbin")
         fs = make_feature_set("value_int__qbin_5")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -187,10 +195,12 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_cross_framework_qbin_3(self) -> None:
         """qbin_3 must match PyArrow reference."""
+        self._skip_if_unsupported("qbin")
         self._compare_with_pyarrow("value_int__qbin_3")
 
     def test_cross_framework_qbin_5(self) -> None:
         """qbin_5 must match PyArrow reference."""
+        self._skip_if_unsupported("qbin")
         self._compare_with_pyarrow("value_int__qbin_5")
 
     # -- Edge case tests -----------------------------------------------------
@@ -221,6 +231,7 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_qbin_all_identical_values(self) -> None:
         """Quantile binning with all identical values should produce bin 0."""
+        self._skip_if_unsupported("qbin")
         identical_data = {"value_int": [5, 5, 5, 5, 5]}
         arrow_table = pa.table(identical_data)
         test_data = self.create_test_data(arrow_table)
@@ -240,6 +251,7 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_qbin_single_value(self) -> None:
         """Quantile binning with a single value."""
+        self._skip_if_unsupported("qbin")
         single_data = {"value_int": [42]}
         arrow_table = pa.table(single_data)
         test_data = self.create_test_data(arrow_table)
@@ -264,6 +276,7 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_qbin_n_bins_1(self) -> None:
         """qbin with n_bins=1: all non-null values should map to bin 0."""
+        self._skip_if_unsupported("qbin")
         fs = make_feature_set("value_int__qbin_1")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -302,6 +315,7 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_all_null_column_qbin(self) -> None:
         """All-null column should produce all-null qbin assignments."""
+        self._skip_if_unsupported("qbin")
         arrow_table = pa.table({"value_int": pa.array([None, None, None], type=pa.int64())})
         test_data = self.create_test_data(arrow_table)
 
@@ -330,6 +344,44 @@ class BinningTestBase(DataOpsTestBase):
 
         result_col = self.extract_column(result, "value_int__bin_3")
         assert result_col == [0, 1, 2, 2]
+
+    # -- NaN handling tests ----------------------------------------------------
+
+    def test_nan_treated_as_null_bin(self) -> None:
+        """NaN values in float columns must be treated as null for bin.
+
+        Data: [1.0, NaN, 3.0, 5.0, 7.0]
+        Non-null (NaN excluded): [1.0, 3.0, 5.0, 7.0]
+        min=1.0, max=7.0, range=6.0, width=2.0
+        val=1: (1-1)/2=0.0 -> 0, val=NaN: None, val=3: (3-1)/2=1.0 -> 1,
+        val=5: (5-1)/2=2.0 -> 2, val=7: (7-1)/2=3.0 -> clamped to 2
+        """
+        arrow_table = pa.table({"value_int": pa.array([1.0, float("nan"), 3.0, 5.0, 7.0])})
+        test_data = self.create_test_data(arrow_table)
+
+        fs = make_feature_set("value_int__bin_3")
+        result = self.implementation_class().calculate_feature(test_data, fs)
+
+        result_col = self.extract_column(result, "value_int__bin_3")
+        assert result_col == [0, None, 1, 2, 2]
+
+    def test_nan_treated_as_null_qbin(self) -> None:
+        """NaN values in float columns must be treated as null for qbin.
+
+        Data: [1.0, NaN, 3.0, 5.0, 7.0]
+        Non-null sorted: [1.0, 3.0, 5.0, 7.0], N=4, n_bins=3
+        rank 0 -> 0*3//4=0, rank 1 -> 3//4=0,
+        rank 2 -> 6//4=1, rank 3 -> 9//4=2
+        """
+        self._skip_if_unsupported("qbin")
+        arrow_table = pa.table({"value_int": pa.array([1.0, float("nan"), 3.0, 5.0, 7.0])})
+        test_data = self.create_test_data(arrow_table)
+
+        fs = make_feature_set("value_int__qbin_3")
+        result = self.implementation_class().calculate_feature(test_data, fs)
+
+        result_col = self.extract_column(result, "value_int__qbin_3")
+        assert result_col == [0, None, 0, 1, 2]
 
     # -- Option-based config tests -------------------------------------------
 


### PR DESCRIPTION
## Summary
- Remove shared `_equal_width_binning()` and `_quantile_binning()` Python-list methods from `base.py`
- Rewrite all 4 non-SQL backends with native framework operations:
  - **Pandas**: vectorized `np.floor` arithmetic (bin), `Series.rank()` (qbin)
  - **Polars Lazy**: pure expression-based, no `.collect()`, stays fully lazy
  - **PyArrow**: `pyarrow.compute` kernels (bin), `pc.sort_indices` (qbin)
  - **DuckDB**: bin stays native SQL; qbin disabled (see below)
- Add NaN-as-null handling to PyArrow (`pc.is_nan`), Polars (`fill_nan`), and DuckDB (`isnan()`)
- Add `supported_ops` skip mechanism to `BinningTestBase` for partial framework support
- Add 10 new NaN handling tests (bin + qbin across all 5 frameworks)

## DuckDB qbin blocked
DuckDB qbin requires `NTILE()` with `ORDER BY`, which reorders rows in the relational API. `DuckdbRelation` has no public `order()` method to restore original row order without eager materialization.

- https://github.com/mloda-ai/mloda/issues/251 - add `DuckdbRelation.order()`
- https://github.com/mloda-ai/mloda-registry/issues/112 - implement DuckDB qbin once the API exists

## Test plan
- [x] 176 binning tests pass, 11 DuckDB qbin tests correctly skipped
- [x] Full tox suite: 1198 passed, ruff/mypy/bandit clean
- [x] Cross-framework comparison tests confirm identical results across backends