### PR TITLE
fix: normalize DuckDB class naming and guard pc.quantile result access

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
@@ -27,7 +27,7 @@ _DUCKDB_AGG_FUNCS: dict[str, str] = {
 _RN_COL = "__mloda_rn__"
 
 
-class DuckDBFrameAggregate(FrameAggregateFeatureGroup):
+class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
     SUPPORTED_FRAME_TYPES = {"rolling", "cumulative", "expanding"}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_duckdb.py
@@ -17,13 +17,13 @@ from mloda.testing.feature_groups.data_operations.row_preserving.frame_aggregate
 )
 
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.duckdb_frame_aggregate import (
-    DuckDBFrameAggregate,
+    DuckdbFrameAggregate,
 )
 
 
-class TestDuckDBFrameAggregate(DuckdbTestMixin, FrameAggregateTestBase):
+class TestDuckdbFrameAggregate(DuckdbTestMixin, FrameAggregateTestBase):
     """Unified tests inherited from the base class."""
 
     @classmethod
     def implementation_class(cls) -> Any:
-        return DuckDBFrameAggregate
+        return DuckdbFrameAggregate

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyarrow_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyarrow_scalar_aggregate.py
@@ -50,6 +50,8 @@ class PyArrowScalarAggregate(ScalarAggregateFeatureGroup):
             result = pc.variance(column, ddof=1).as_py()
         elif agg_type == "median":
             q_result = pc.quantile(column, q=0.5)
+            if len(q_result) == 0:
+                raise ValueError("pc.quantile returned an empty result for median computation")
             result = q_result[0].as_py()
         else:
             raise ValueError(f"Unsupported aggregation type: {agg_type}")

--- a/mloda/testing/feature_groups/data_operations/row_preserving/percentile/reference.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/percentile/reference.py
@@ -61,6 +61,10 @@ class ReferencePercentile(PercentileFeatureGroup):
             else:
                 arr = pa.array(non_null, type=pa.float64())
                 q_result = pc.quantile(arr, q=percentile)
+                if len(q_result) == 0:
+                    raise ValueError(
+                        f"pc.quantile returned an empty result for q={percentile} on {len(non_null)} non-null values"
+                    )
                 agg_val = q_result[0].as_py()
 
             for idx in indices:


### PR DESCRIPTION
## Summary

Addresses items **#16** and **#18** from #74.

- **#16 - Inconsistent DuckDB class naming**: Renamed `DuckDBFrameAggregate` (uppercase DB) to `DuckdbFrameAggregate` (lowercase b), matching the convention used by every other DuckDB class in this repo (`DuckdbWindowAggregation`, `DuckdbOffset`, `DuckdbRank`, `DuckdbAggregation`, `DuckdbScalarAggregate`, `DuckdbBinning`, `DuckdbPercentile`, `DuckdbDateTimeExtraction`, `DuckdbStringOps`). Updated the test class and import accordingly.

- **#18 - PyArrow quantile API assumption is fragile**: Added a `len()` guard before indexing into `pc.quantile()` results in both `pyarrow_scalar_aggregate.py` (median computation) and the percentile test reference implementation. If the result array is unexpectedly empty, a clear `ValueError` is raised instead of an opaque `IndexError`.

## Files changed

| File | Change |
|------|--------|
| `duckdb_frame_aggregate.py` | `DuckDBFrameAggregate` -> `DuckdbFrameAggregate` |
| `tests/test_duckdb.py` (frame_aggregate) | Updated import, test class name, and return value |
| `pyarrow_scalar_aggregate.py` | Added empty-result guard on `pc.quantile()` for median |
| `reference.py` (percentile) | Added empty-result guard on `pc.quantile()` |

## Test plan

- [x] Full `uv run tox` passes (1083 passed, 135 skipped)
- [x] `ruff format` clean
- [x] `mypy --strict` clean
- [x] `bandit` clean
- [x] Verified no remaining `class DuckDB[A-Z]` patterns in repo (only external `DuckDBFramework` from mloda_plugins)
- [x] Verified all `pc.quantile()` call sites now have empty-result guards