### PR TITLE
chore: update mloda dependency to 0.6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,3 +40,5 @@ jobs:
     - name: Run tox
       run: tox -e ${{ matrix.toxenv }}
       timeout-minutes: 3
+      env:
+        PYTEST_WORKERS: "0"

--- a/config/packages.toml
+++ b/config/packages.toml
@@ -3,7 +3,7 @@
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/registry"
 
 [packages.mloda-testing]
@@ -14,23 +14,23 @@ optional_dependencies = { dev = ["pytest"] }
 
 [packages.mloda-community]
 description = "All community plugins for mloda"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/community"
 
 [packages.mloda-enterprise]
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/enterprise"
 
 [packages.mloda-community-example]
 description = "Example community FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/community/feature_groups/example"
 optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-example-b"] }
 
 [packages.mloda-enterprise-example]
 description = "Example enterprise FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/enterprise/feature_groups/example"
 
 [packages.mloda-community-example-a]
@@ -45,29 +45,29 @@ path = "mloda/community/feature_groups/example/example_b"
 
 [packages.mloda-community-compute-frameworks-example]
 description = "Example community ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/community/compute_frameworks/example"
 
 [packages.mloda-community-extenders-example]
 description = "Example community Extender plugin for mloda"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/community/extenders/example"
 
 [packages.mloda-enterprise-compute-frameworks-example]
 description = "Example enterprise ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/enterprise/compute_frameworks/example"
 
 [packages.mloda-enterprise-extenders-example]
 description = "Example enterprise Extender plugin for mloda"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/enterprise/extenders/example"
 
 # --- Data Operations ---
 
 [packages.mloda-community-data-operations]
 description = "Shared base classes for data operation feature groups"
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 path = "mloda/community/feature_groups/data_operations"
 optional_dependencies = { all = ["mloda-community-window-aggregation", "mloda-community-aggregation", "mloda-community-rank", "mloda-community-offset", "mloda-community-frame-aggregate", "mloda-community-scalar-aggregate", "mloda-community-datetime", "mloda-community-string", "mloda-community-binning", "mloda-community-percentile"] }
 

--- a/docs/guides/11-create-extender.md
+++ b/docs/guides/11-create-extender.md
@@ -36,11 +36,11 @@ Q3: Need state with ParallelizationMode.MULTIPROCESSING?
 ## Example
 
 ```python
-from typing import Any, Set
+from typing import Any
 from mloda.steward import Extender, ExtenderHook
 
 class MyExtender(Extender):
-    def wraps(self) -> Set[ExtenderHook]:
+    def wraps(self) -> set[ExtenderHook]:
         return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
 
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:

--- a/docs/guides/compute-framework-patterns/01-stateless-eager.md
+++ b/docs/guides/compute-framework-patterns/01-stateless-eager.md
@@ -20,7 +20,7 @@ Stateless eager frameworks execute operations immediately in-memory.
 ## Complete Example
 
 ```python
-from typing import Any, Set, Type
+from typing import Any
 from mloda.provider import ComputeFramework, BaseMergeEngine, BaseFilterEngine
 
 try:
@@ -41,16 +41,16 @@ class MyEagerFramework(ComputeFramework):
         return ml.DataFrame  # Return TYPE, not instance
 
     @classmethod
-    def merge_engine(cls) -> Type[BaseMergeEngine]:
+    def merge_engine(cls) -> type[BaseMergeEngine]:
         from my_plugin.my_merge_engine import MyMergeEngine
         return MyMergeEngine
 
     @classmethod
-    def filter_engine(cls) -> Type[BaseFilterEngine]:
+    def filter_engine(cls) -> type[BaseFilterEngine]:
         from my_plugin.my_filter_engine import MyFilterEngine
         return MyFilterEngine
 
-    def transform(self, data: Any, feature_names: Set[str]) -> Any:
+    def transform(self, data: Any, feature_names: set[str]) -> Any:
         if isinstance(data, dict):
             return ml.DataFrame.from_dict(data)
         raise ValueError(f"Data type {type(data)} not supported")

--- a/docs/guides/compute-framework-patterns/02-stateless-lazy.md
+++ b/docs/guides/compute-framework-patterns/02-stateless-lazy.md
@@ -31,7 +31,7 @@ def select_data_by_column_names(self, data, selected_feature_names):
     _selected = self.identify_naming_convention(selected_feature_names, column_names)
     return data.select(list(_selected)).collect()  # Materialize HERE
 
-def transform(self, data: Any, feature_names: Set[str]) -> Any:
+def transform(self, data: Any, feature_names: set[str]) -> Any:
     if isinstance(data, dict):
         return pl.LazyFrame(data)  # LazyFrame, not DataFrame
     if isinstance(data, pl.DataFrame):

--- a/docs/guides/compute-framework-patterns/03-stateful-connection.md
+++ b/docs/guides/compute-framework-patterns/03-stateful-connection.md
@@ -22,7 +22,7 @@ Stateful frameworks require a connection or session object to operate.
 Only this method is added:
 
 ```python
-def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
     """CRITICAL: Set or validate connection object."""
     if self.framework_connection_object is None:
         if framework_connection_object is not None:
@@ -38,7 +38,7 @@ def set_framework_connection_object(self, framework_connection_object: Optional[
 And `transform()` must check connection:
 
 ```python
-def transform(self, data: Any, feature_names: Set[str]) -> Any:
+def transform(self, data: Any, feature_names: set[str]) -> Any:
     if self.framework_connection_object is None:
         raise ValueError("Connection not set.")
     # Use connection for conversion...

--- a/docs/guides/compute-framework-patterns/04-zero-dependency.md
+++ b/docs/guides/compute-framework-patterns/04-zero-dependency.md
@@ -36,13 +36,13 @@ class MyZeroDependencyFramework(ComputeFramework):
 
     def set_column_names(self) -> None:
         # Must iterate rows to get all keys
-        all_columns: Set[str] = set()
+        all_columns: set[str] = set()
         for row in self.data:
             if isinstance(row, dict):
                 all_columns.update(row.keys())
         self.column_names = all_columns
 
-    def transform(self, data: Any, feature_names: Set[str]) -> List[Dict[str, Any]]:
+    def transform(self, data: Any, feature_names: set[str]) -> list[dict[str, Any]]:
         if isinstance(data, dict):
             # Columnar dict to row-based list
             if all(isinstance(v, list) for v in data.values()):

--- a/docs/guides/compute-framework-patterns/05-data-lake.md
+++ b/docs/guides/compute-framework-patterns/05-data-lake.md
@@ -22,7 +22,7 @@ Data lake frameworks work with catalog-based table formats for large-scale data.
 Flexible connection - accepts catalog or table:
 
 ```python
-def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
     if self.framework_connection_object is None and framework_connection_object is not None:
         if hasattr(framework_connection_object, "load_table"):
             self.framework_connection_object = framework_connection_object  # Catalog
@@ -36,14 +36,14 @@ Merge typically not supported:
 
 ```python
 @classmethod
-def merge_engine(cls) -> Type[BaseMergeEngine]:
+def merge_engine(cls) -> type[BaseMergeEngine]:
     raise NotImplementedError("Use catalog-level operations for merging.")
 ```
 
 PyArrow as interchange format:
 
 ```python
-def transform(self, data: Any, feature_names: Set[str]) -> Any:
+def transform(self, data: Any, feature_names: set[str]) -> Any:
     if isinstance(data, dict):
         return pa.Table.from_pydict(data)  # PyArrow interchange
     if isinstance(data, (IcebergTable, pa.Table)):

--- a/docs/guides/compute-framework-patterns/08-framework-transformer.md
+++ b/docs/guides/compute-framework-patterns/08-framework-transformer.md
@@ -32,7 +32,7 @@ Pandas ←→ PyArrow ←→ Polars
 ## Complete Example
 
 ```python
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import BaseTransformer
 
 try:
@@ -70,7 +70,7 @@ class MyPyArrowTransformer(BaseTransformer):
         return data.to_arrow()  # MyFramework → PyArrow
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         return mf.from_arrow(data)  # PyArrow → MyFramework
 ```
 
@@ -95,7 +95,7 @@ For frameworks needing a connection (like Spark):
 
 ```python
 @classmethod
-def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
     if framework_connection_object is None:
         raise ValueError("SparkSession required")
     return framework_connection_object.createDataFrame(data.to_pandas())

--- a/docs/guides/compute-framework-patterns/09-testing-guide.md
+++ b/docs/guides/compute-framework-patterns/09-testing-guide.md
@@ -38,7 +38,7 @@ class TestMyFilterEngine(FilterEngineTestMixin):
     def sample_data(self) -> Any:
         return my_lib.DataFrame({"str_col": ["a", "b"], "int_col": [1, 5]})
 
-    def get_column_values(self, result, column) -> List[Any]:
+    def get_column_values(self, result, column) -> list[Any]:
         return result[column].tolist()
 ```
 
@@ -51,14 +51,14 @@ from tests.test_plugins.compute_framework.test_tooling.multi_index.multi_index_t
 
 class TestMyMergeEngine(MultiIndexMergeEngineTestBase):
     @classmethod
-    def merge_engine_class(cls) -> Type[BaseMergeEngine]:
+    def merge_engine_class(cls) -> type[BaseMergeEngine]:
         return MyMergeEngine
 
     @classmethod
-    def framework_type(cls) -> Type[Any]:
+    def framework_type(cls) -> type[Any]:
         return my_lib.DataFrame
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return None  # Or connection for stateful frameworks
 ```
 
@@ -71,13 +71,13 @@ from tests.test_plugins.compute_framework.test_tooling.dataframe_test_base impor
 
 class TestMyFrameworkMerge(DataFrameTestBase):
     @classmethod
-    def framework_class(cls) -> Type[Any]:
+    def framework_class(cls) -> type[Any]:
         return MyFramework
 
     def create_dataframe(self, data: dict) -> Any:
         return my_lib.DataFrame(data)
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return None
 ```
 

--- a/docs/guides/feature-group-patterns/01-root-features.md
+++ b/docs/guides/feature-group-patterns/01-root-features.md
@@ -18,7 +18,7 @@ Root features have no input dependencies - they are pipeline entry points.
 ## Complete Example
 
 ```python
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.provider import BaseInputData, FeatureSet
 
@@ -32,7 +32,7 @@ class MyRootFeature(FeatureGroup):
     """Load data from external source."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return MyInputData()
 
     @classmethod
@@ -63,7 +63,7 @@ class OrderSyntheticData(FeatureGroup):
     """Generate synthetic order data."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"order_id", "product_id", "quantity"})
 
     @classmethod

--- a/docs/guides/feature-group-patterns/02-derived-features.md
+++ b/docs/guides/feature-group-patterns/02-derived-features.md
@@ -18,7 +18,7 @@ Derived features transform existing features with a static name (no naming patte
 ## Complete Example
 
 ```python
-from typing import Any, Optional, Set
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.user import Feature, Options, FeatureName
 from mloda.provider import FeatureSet
@@ -27,7 +27,7 @@ from mloda.provider import FeatureSet
 class DoubledValue(FeatureGroup):
     """Double the source_column value."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.not_typed("source_column")}
 
     @classmethod

--- a/docs/guides/feature-group-patterns/03-chained-features.md
+++ b/docs/guides/feature-group-patterns/03-chained-features.md
@@ -20,7 +20,7 @@ Chained features use naming patterns like `price__scaled` for reusable transform
 ## Complete Example
 
 ```python
-from typing import Any, Optional, Set
+from typing import Any
 from mloda.provider import DefaultOptionKeys, FeatureChainParserMixin, FeatureGroup, FeatureSet
 from mloda.user import Feature, Options, FeatureName
 
@@ -55,11 +55,11 @@ class MeanImputedFeature(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         for feature in features.features:
-            name = feature.get_name()
+            name = feature.name
 
             # Resolve operation from name or config (handles both paths)
             method = cls._resolve_operation(feature, "imputation_method")
-            source = next(iter(feature.options.get_in_features())).get_name()
+            source = next(iter(feature.options.get_in_features())).name
 
             col = data[source]
             data[name] = col.fillna(col.mean() if method == "mean" else col.median())

--- a/docs/guides/feature-group-patterns/04-multi-input-features.md
+++ b/docs/guides/feature-group-patterns/04-multi-input-features.md
@@ -19,7 +19,7 @@ Multi-input features combine two or more inputs using the `&` separator in the f
 ## Complete Example
 
 ```python
-from typing import Any, Optional, Set
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.user import Feature, Options, FeatureName
 from mloda.provider import FeatureSet
@@ -32,8 +32,8 @@ class DiffFeature(FeatureGroup):
     def match_feature_group_criteria(cls, feature_name: str, options: Options) -> bool:
         return "&" in feature_name and feature_name.endswith("__diff")
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
-        base = feature_name.name.replace("__diff", "")
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        base = str(feature_name).replace("__diff", "")
         a, b = base.split("&")
         return {Feature.not_typed(a), Feature.not_typed(b)}
 

--- a/docs/guides/feature-group-patterns/05-multi-output-features.md
+++ b/docs/guides/feature-group-patterns/05-multi-output-features.md
@@ -19,7 +19,7 @@ Multi-output features produce multiple columns using the `~` separator (e.g., `e
 ## Complete Example
 
 ```python
-from typing import Any, Optional, Set, Dict
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.user import Feature, Options, FeatureName
 from mloda.provider import FeatureSet
@@ -32,12 +32,12 @@ class StatsFeature(FeatureGroup):
     def match_feature_group_criteria(cls, feature_name: str, options: Any) -> bool:
         return feature_name.endswith("__stats")
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
-        source = feature_name.name.replace("__stats", "")
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        source = str(feature_name).replace("__stats", "")
         return {Feature.not_typed(source)}
 
     @classmethod
-    def calculate_feature(cls, data: Any, features: FeatureSet) -> Dict[str, Any]:
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> dict[str, Any]:
         feature_name = features.name_of_one_feature.name
         source = feature_name.replace("__stats", "")
         col = data[source]
@@ -97,7 +97,7 @@ Consumers can depend on all columns or specific sub-columns:
 class SpecificSubColumnConsumer(FeatureGroup):
     """Consume only embedding~1 from a multi-column feature."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("embedding~1")}  # Only this sub-column
 
     @classmethod

--- a/docs/guides/feature-group-patterns/06-artifact-features.md
+++ b/docs/guides/feature-group-patterns/06-artifact-features.md
@@ -19,7 +19,7 @@ Artifact features save and load fitted state (scalers, models) between runs.
 ## Complete Example
 
 ```python
-from typing import Any, Optional, Set, Type
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureChainParserMixin, BaseArtifact, FeatureSet
 from mloda.user import Feature, Options, FeatureName
@@ -31,14 +31,14 @@ class ScalerArtifact(BaseArtifact):
     """Store fitted scaler params (mean, std)."""
 
     @classmethod
-    def custom_saver(cls, features: FeatureSet, artifact: Any) -> Optional[str]:
+    def custom_saver(cls, features: FeatureSet, artifact: Any) -> str | None:
         path = f"/tmp/scaler_{features.name_of_one_feature.name}.pkl"
         with open(path, "wb") as f:
             pickle.dump(artifact, f)
         return path
 
     @classmethod
-    def custom_loader(cls, features: FeatureSet) -> Optional[Any]:
+    def custom_loader(cls, features: FeatureSet) -> Any | None:
         path = f"/tmp/scaler_{features.name_of_one_feature.name}.pkl"
         if Path(path).exists():
             with open(path, "rb") as f:
@@ -52,11 +52,11 @@ class StandardScaledFeature(FeatureChainParserMixin, FeatureGroup):
     PREFIX_PATTERN = r"^.+__standard_scaled$"
 
     @staticmethod
-    def artifact() -> Optional[Type[BaseArtifact]]:
+    def artifact() -> type[BaseArtifact] | None:
         return ScalerArtifact
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
-        source = feature_name.name.replace("__standard_scaled", "")
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        source = str(feature_name).replace("__standard_scaled", "")
         return {Feature.not_typed(source)}
 
     @classmethod

--- a/docs/guides/feature-group-patterns/07-index-features.md
+++ b/docs/guides/feature-group-patterns/07-index-features.md
@@ -18,7 +18,7 @@ Index features require specific columns for ordering, grouping, or joining.
 ## Complete Example
 
 ```python
-from typing import Any, Optional, Set, List
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureChainParserMixin, FeatureSet
 from mloda.user import Feature, Options, FeatureName, Index
@@ -33,11 +33,11 @@ class LagFeature(FeatureChainParserMixin, FeatureGroup):
     MAX_IN_FEATURES = 1
 
     @classmethod
-    def index_columns(cls) -> Optional[List[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("timestamp",))]
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
-        source = feature_name.name.rsplit("__lag_", 1)[0]
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        source = str(feature_name).rsplit("__lag_", 1)[0]
         return {Feature.not_typed(source), Feature.not_typed("timestamp")}
 
     @classmethod
@@ -85,7 +85,7 @@ Index(("user_id", "date"))
 **Multiple indexes (primary + foreign keys)**
 ```python
 @classmethod
-def index_columns(cls) -> List[Index]:
+def index_columns(cls) -> list[Index]:
     return [
         Index(("order_id",)),       # Primary key
         Index(("customer_id",)),    # Foreign key

--- a/docs/guides/feature-group-patterns/08-links-joins.md
+++ b/docs/guides/feature-group-patterns/08-links-joins.md
@@ -19,7 +19,7 @@ Join feature groups to combine data from different sources.
 ## Complete Example
 
 ```python
-from typing import Any, Optional, Set
+from typing import Any
 from mloda.user import Link, JoinSpec, Index, Feature, FeatureName, Options
 from mloda.provider import FeatureGroup, FeatureSet
 
@@ -27,7 +27,7 @@ from mloda.provider import FeatureGroup, FeatureSet
 class OrderWithCustomer(FeatureGroup):
     """Join orders with customer data."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         link = Link.inner_on(OrderFeatureGroup, CustomerFeatureGroup)
         return {
             Feature(name="order_value", link=link),
@@ -115,7 +115,7 @@ feature = Feature(name="order_value", link=link, index=Index(("order_id",)))
 ## Via input_features()
 
 ```python
-def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
     link = Link.left(
         JoinSpec(OrderFeatureGroup, Index(("order_id",))),
         JoinSpec(CustomerFeatureGroup, Index(("customer_id",)))

--- a/docs/guides/feature-group-patterns/09-framework-specific.md
+++ b/docs/guides/feature-group-patterns/09-framework-specific.md
@@ -12,13 +12,13 @@ Framework-specific features restrict computation to certain frameworks.
 
 | Method | Behavior |
 |--------|----------|
-| `compute_framework_rule()` | Returns `Union[bool, Set[Type[ComputeFramework]]]` |
+| `compute_framework_rule()` | Returns `set[type[ComputeFramework]] | None` |
 | Default | `True` = any framework allowed |
 
 ## Complete Example
 
 ```python
-from typing import Any, Union, Set, Type
+from typing import Any
 from mloda.provider import FeatureGroup, ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda.user import Feature, Options, FeatureName
@@ -29,10 +29,10 @@ class PandasGroupMean(FeatureGroup):
     """Group mean using Pandas-only API."""
 
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.not_typed("value"), Feature.not_typed("category")}
 
     @classmethod

--- a/docs/guides/feature-group-patterns/12-calculate-feature.md
+++ b/docs/guides/feature-group-patterns/12-calculate-feature.md
@@ -34,7 +34,7 @@ def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
 @classmethod
 def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
     for feature in features.features:
-        name = feature.get_name()
+        name = feature.name
         # Access options per feature
         threshold = feature.options.get("threshold") or 0.5
         data[name] = data["source"] > threshold
@@ -49,11 +49,11 @@ Chained feature groups (using `FeatureChainParserMixin`) often need to extract a
 @classmethod
 def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
     for feature in features.features:
-        name = feature.get_name()
+        name = feature.name
 
         # Resolves from PREFIX_PATTERN match or options["imputation_method"]
         method = cls._resolve_operation(feature, "imputation_method")
-        source = next(iter(feature.options.get_in_features())).get_name()
+        source = next(iter(feature.options.get_in_features())).name
 
         col = data[source]
         data[name] = col.fillna(col.mean() if method == "mean" else col.median())

--- a/docs/guides/feature-group-patterns/13-feature-naming.md
+++ b/docs/guides/feature-group-patterns/13-feature-naming.md
@@ -36,7 +36,7 @@ Define a set of supported feature names.
 ```python
 class HolidayFeature(FeatureGroup):
     @classmethod
-    def feature_names_supported(cls) -> Set[str]:
+    def feature_names_supported(cls) -> set[str]:
         return {"is_holiday", "is_weekend", "is_business_day"}
 ```
 
@@ -73,7 +73,7 @@ Modify the feature name after matching (rarely needed).
 ```python
 def set_feature_name(self, options: Options, feature_name: FeatureName) -> FeatureName:
     # Example: normalize to lowercase
-    return FeatureName(feature_name.name.lower())
+    return FeatureName(str(feature_name).lower())
 ```
 
 ---

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -39,7 +39,7 @@ def match_feature_group_criteria(
     cls,
     feature_name: str,
     options: Options,
-    data_access_collection: Optional[DataAccessCollection] = None,
+    data_access_collection: DataAccessCollection | None = None,
 ) -> bool:
     return feature_name.endswith("_score")
 ```
@@ -113,8 +113,8 @@ def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
     for feature in features.features:
         # Resolves from PREFIX_PATTERN or options["my_method"]
         method = cls._resolve_operation(feature, cls.MY_METHOD)
-        source = next(iter(feature.options.get_in_features())).get_name()
-        data[feature.get_name()] = apply_transform(data[source], method)
+        source = next(iter(feature.options.get_in_features())).name
+        data[feature.name] = apply_transform(data[source], method)
     return data
 ```
 

--- a/docs/guides/feature-group-patterns/16-validators.md
+++ b/docs/guides/feature-group-patterns/16-validators.md
@@ -11,20 +11,18 @@ How to validate input and output data in feature groups.
 
 ```python
 @classmethod
-def validate_input_features(cls, data: Any, features: FeatureSet) -> Optional[bool]:
+def validate_input_features(cls, data: Any, features: FeatureSet) -> None:
     if data["my_input"].isnull().any():
         raise ValueError("Input contains null values")
-    return True
 ```
 
 ## Output Validation
 
 ```python
 @classmethod
-def validate_output_features(cls, data: Any, features: FeatureSet) -> Optional[bool]:
+def validate_output_features(cls, data: Any, features: FeatureSet) -> None:
     if len(data[cls.get_class_name()]) != 3:
         raise ValueError("Output should have 3 elements")
-    return True
 ```
 
 ## Using BaseValidator
@@ -35,9 +33,9 @@ For reusable validation logic (e.g., with Pandera):
 from mloda.provider import BaseValidator
 
 class MyValidator(BaseValidator):
-    def validate(self, data) -> Optional[bool]:
-        # Custom validation logic
-        return True
+    def validate(self, data) -> None:
+        if not valid:
+            raise ValueError("Descriptive validation failure message")
 ```
 
 ## Full Documentation

--- a/docs/guides/feature-group-patterns/17-data-connection-matching.md
+++ b/docs/guides/feature-group-patterns/17-data-connection-matching.md
@@ -12,7 +12,7 @@ How to match feature groups against data connections.
 `ConnectionMatcherMixin` checks if a feature group can handle a request based on the available data connection.
 
 ```python
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup, ConnectionMatcherMixin
 from mloda.user import DataAccessCollection, Options
 
@@ -22,8 +22,8 @@ class DatabaseFeature(ConnectionMatcherMixin, FeatureGroup):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         if data_access_collection and data_access_collection.has_connection("my_database"):
             return data_access_collection.get("my_database")
@@ -48,7 +48,7 @@ class CsvFeature(FeatureGroup):
     @classmethod
     def match_feature_group_criteria(
         cls, feature_name: str, options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if data_access_collection is None or not data_access_collection.folders:
             return False
@@ -60,7 +60,7 @@ class CsvFeature(FeatureGroup):
 
 ```python
 @classmethod
-def match_subclass_data_access(cls, data_access: Any, feature_names: List[str], options: Options) -> Any:
+def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
     ...
 ```
 

--- a/docs/guides/feature-group-patterns/18-datatypes.md
+++ b/docs/guides/feature-group-patterns/18-datatypes.md
@@ -63,7 +63,7 @@ from mloda.user import DataType, Feature
 
 class UserCount(FeatureGroup):
     @classmethod
-    def return_data_type_rule(cls, feature: Feature) -> Optional[DataType]:
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
         return DataType.INT64
 ```
 

--- a/mloda/community/compute_frameworks/example/community_example_compute_framework.py
+++ b/mloda/community/compute_frameworks/example/community_example_compute_framework.py
@@ -1,6 +1,5 @@
 """Community Example ComputeFramework implementation."""
 
-from typing import Optional, Set
 from uuid import UUID, uuid4
 
 from mloda.user import ParallelizationMode
@@ -16,7 +15,7 @@ class CommunityExampleComputeFramework(ComputeFramework):
         mode: ParallelizationMode = ParallelizationMode.SYNC,
         children_if_root: frozenset[UUID] = frozenset(),
         uuid: UUID = uuid4(),
-        function_extender: Optional[Set[Extender]] = None,
+        function_extender: set[Extender] | None = None,
     ) -> None:
         """Initialize with default values for minimal instantiation."""
         super().__init__(mode, children_if_root, uuid, function_extender)

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example community ComputeFramework plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/compute_frameworks/example/tests/test_community_example_compute_framework.py
+++ b/mloda/community/compute_frameworks/example/tests/test_community_example_compute_framework.py
@@ -1,7 +1,5 @@
 """Tests for CommunityExampleComputeFramework."""
 
-import pytest
-
 from mloda.provider import ComputeFramework
 
 

--- a/mloda/community/extenders/example/community_example_extender.py
+++ b/mloda/community/extenders/example/community_example_extender.py
@@ -1,6 +1,6 @@
 """Community Example Extender implementation."""
 
-from typing import Any, Set
+from typing import Any
 
 from mloda.steward import Extender, ExtenderHook
 
@@ -8,7 +8,7 @@ from mloda.steward import Extender, ExtenderHook
 class CommunityExampleExtender(Extender):
     """Community Example Extender for demonstrating plugin structure."""
 
-    def wraps(self) -> Set[ExtenderHook]:
+    def wraps(self) -> set[ExtenderHook]:
         """Return the set of hooks this extender wraps."""
         return set()
 

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example community Extender plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/extenders/example/tests/test_community_example_extender.py
+++ b/mloda/community/extenders/example/tests/test_community_example_extender.py
@@ -1,7 +1,5 @@
 """Tests for CommunityExampleExtender."""
 
-import pytest
-
 from mloda.steward import Extender
 
 

--- a/mloda/community/feature_groups/data_operations/aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
@@ -165,9 +166,9 @@ class AggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         raise ValueError(f"Could not extract aggregation type from feature name: {feature_name}")
 
     @classmethod
-    def _extract_aggregation_type(cls, feature: Any) -> str:
+    def _extract_aggregation_type(cls, feature: Feature) -> str:
         """Extract aggregation type from feature (string-based or config-based)."""
-        feature_name = feature.get_name()
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
@@ -188,7 +189,7 @@ class AggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
 
             source_features = cls._extract_source_features(feature)
             source_col = source_features[0]

--- a/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -37,7 +37,7 @@ _DUCKDB_AGG_FUNCS: dict[str, str] = {
 
 class DuckdbAggregation(AggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/aggregation/pandas_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/pandas_aggregation.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -22,7 +20,7 @@ from mloda.community.feature_groups.data_operations.pandas_helpers import (
 
 class PandasAggregation(AggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/aggregation/polars_lazy_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/polars_lazy_aggregation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 import polars as pl
 
@@ -36,7 +36,7 @@ _POLARS_AGG_EXPRS: dict[str, Any] = {
 
 class PolarsLazyAggregation(AggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
@@ -6,8 +6,6 @@ C++-backed aggregation.
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pyarrow as pa
 import pyarrow.compute as pc
 
@@ -48,7 +46,7 @@ _ORDERED_FUNCS: dict[str, str] = {
 
 class PyArrowAggregation(AggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
@@ -26,7 +25,7 @@ _SQLITE_AGG_FUNCS: dict[str, str] = {
 
 class SqliteAggregation(AggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SqliteFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/pandas_helpers.py
+++ b/mloda/community/feature_groups/data_operations/pandas_helpers.py
@@ -71,7 +71,11 @@ def apply_null_safe_agg(
     """
     ddof = _DDOF_BY_AGG_TYPE.get(agg_type)
     if ddof is not None:
-        func = lambda x, _d=ddof, _f=pandas_func: getattr(x, _f)(ddof=_d)
+        _ddof: int = ddof
+
+        def func(x: Any, _d: int = _ddof, _f: str = pandas_func) -> Any:
+            return getattr(x, _f)(ddof=_d)
+
         return getattr(grouped, method)(func)
 
     kwargs: dict[str, Any] = {}

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Shared base classes for data operation feature groups"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Set
+from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
@@ -65,8 +65,8 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         raise ValueError(f"Could not extract binning parameters from feature name: {feature_name}")
 
     @classmethod
-    def _extract_binning_params(cls, feature: Any) -> tuple[str, int]:
-        feature_name = feature.get_name()
+    def _extract_binning_params(cls, feature: Feature) -> tuple[str, int]:
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
@@ -81,8 +81,8 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         cls._validate_n_bins(n_bins, feature_name)
         return str(op), n_bins
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
-        _feature_name = feature_name.name if isinstance(feature_name, FeatureName) else feature_name
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        _feature_name = str(feature_name)
 
         prefix_patterns = self._get_prefix_patterns()
         operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
@@ -97,8 +97,8 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return set(in_features_set)
 
     @classmethod
-    def _extract_source_features(cls, feature: Feature) -> List[str]:
-        feature_name = feature.get_name()
+    def _extract_source_features(cls, feature: Feature) -> list[str]:
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
 
         operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
@@ -107,14 +107,14 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             return [source_feature]
 
         in_features_set = feature.options.get_in_features()
-        return [f.get_name() for f in in_features_set]
+        return [str(f.name) for f in in_features_set]
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
 
             source_features = cls._extract_source_features(feature)
             source_col = source_features[0]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -16,7 +16,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.binning.base 
 
 class DuckdbBinning(BinningFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pandas_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pandas_binning.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -17,7 +16,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.binning.base 
 
 class PandasBinning(BinningFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/polars_lazy_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/polars_lazy_binning.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import polars as pl
 
 from mloda.provider import ComputeFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.binning.base 
 
 class PolarsLazyBinning(BinningFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pyarrow_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pyarrow_binning.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -17,7 +17,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.binning.base 
 
 class PyArrowBinning(BinningFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/sqlite_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/sqlite_binning.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
@@ -16,7 +15,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.binning.base 
 
 class SqliteBinning(BinningFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SqliteFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
@@ -114,8 +114,8 @@ class DateTimeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         raise ValueError(f"Could not extract datetime operation from feature name: {feature_name}")
 
     @classmethod
-    def _extract_datetime_op(cls, feature: Any) -> str:
-        feature_name = feature.get_name()
+    def _extract_datetime_op(cls, feature: Feature) -> str:
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
@@ -125,8 +125,8 @@ class DateTimeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             raise ValueError(f"Could not extract datetime operation for {feature_name}")
         return str(op)
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        _feature_name = feature_name.name if isinstance(feature_name, FeatureName) else feature_name
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        _feature_name = str(feature_name)
 
         prefix_patterns = self._get_prefix_patterns()
         operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
@@ -140,7 +140,7 @@ class DateTimeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        feature_name = feature.get_name()
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
 
         operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
@@ -149,14 +149,14 @@ class DateTimeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             return [source_feature]
 
         in_features_set = feature.options.get_in_features()
-        return [f.get_name() for f in in_features_set]
+        return [str(f.name) for f in in_features_set]
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
 
             source_features = cls._extract_source_features(feature)
             source_col = source_features[0]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/duckdb_datetime.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/duckdb_datetime.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -32,7 +32,7 @@ _DUCKDB_DATETIME_EXPRS: dict[str, str] = {
 
 class DuckdbDateTimeExtraction(DateTimeFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pandas_datetime.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pandas_datetime.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.datetime.base
 
 class PandasDateTimeExtraction(DateTimeFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/polars_lazy_datetime.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/polars_lazy_datetime.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import polars as pl
 
 from mloda.provider import ComputeFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.datetime.base
 
 class PolarsLazyDateTimeExtraction(DateTimeFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyarrow_datetime.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyarrow_datetime.py
@@ -6,8 +6,6 @@ avoiding row-by-row Python loops for performance on large datasets.
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pyarrow as pa
 import pyarrow.compute as pc
 
@@ -21,7 +19,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.datetime.base
 
 class PyArrowDateTimeExtraction(DateTimeFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/sqlite_datetime.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/sqlite_datetime.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
@@ -31,7 +29,7 @@ _SQLITE_DATETIME_EXPRS: dict[str, str] = {
 
 class SqliteDateTimeExtraction(DateTimeFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SqliteFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_integration.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from typing import Any
 
 import pyarrow as pa
-import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, List, Optional, Set
+from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -99,7 +99,7 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # expanding). This value is a placeholder to satisfy the mixin contract.
     PREFIX_PATTERN = r".*__([\w]+)_rolling_\d+$"
 
-    SUPPORTED_FRAME_TYPES: Set[str] = {"rolling", "time", "cumulative", "expanding"}
+    SUPPORTED_FRAME_TYPES: set[str] = {"rolling", "time", "cumulative", "expanding"}
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
@@ -156,9 +156,9 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         },
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Parse input features from the four frame patterns or config fallback."""
-        name = feature_name.name if isinstance(feature_name, FeatureName) else str(feature_name)
+        name = str(feature_name)
         parsed = self._parse_frame_feature(name)
         if parsed is not None:
             return {Feature(parsed["source_col"])}
@@ -166,17 +166,17 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return set(in_features_set)
 
     @classmethod
-    def _extract_source_features(cls, feature: Feature) -> List[str]:
+    def _extract_source_features(cls, feature: Feature) -> list[str]:
         """Extract source features from the four frame patterns or config fallback."""
-        name = feature.get_name()
+        name = feature.name
         parsed = cls._parse_frame_feature(name)
         if parsed is not None:
             return [parsed["source_col"]]
         in_features_set = feature.options.get_in_features()
-        return [f.get_name() for f in in_features_set]
+        return [str(f.name) for f in in_features_set]
 
     @classmethod
-    def _parse_frame_feature(cls, feature_name: str) -> Optional[dict[str, Any]]:
+    def _parse_frame_feature(cls, feature_name: str) -> dict[str, Any] | None:
         """Parse a frame aggregate feature name into its components.
 
         Returns a dict with keys: source_col, agg_type, frame_type, frame_size, frame_unit.
@@ -241,7 +241,7 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         - For cumulative/expanding: agg in _CUMULATIVE_OPS (same as _AGGREGATION_TYPES)
         - For time: frame_unit in _TIME_UNITS
         """
-        name = str(feature_name.name if hasattr(feature_name, "name") else feature_name)
+        name = str(feature_name)
 
         parsed = cls._parse_frame_feature(name)
 
@@ -284,9 +284,9 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return True
 
     @classmethod
-    def _extract_params(cls, feature: Any) -> dict[str, Any]:
+    def _extract_params(cls, feature: Feature) -> dict[str, Any]:
         """Extract all frame aggregate parameters from a feature."""
-        feature_name = feature.get_name()
+        feature_name = feature.name
         parsed = cls._parse_frame_feature(feature_name)
 
         if parsed is not None:
@@ -317,7 +317,7 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
             params = cls._extract_params(feature)
 
             table = cls._compute_frame(
@@ -344,8 +344,8 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         order_by: str,
         agg_type: str,
         frame_type: str,
-        frame_size: Optional[int] = None,
-        frame_unit: Optional[str] = None,
+        frame_size: int | None = None,
+        frame_unit: str | None = None,
     ) -> Any:
         """Subclasses must implement the actual frame computation."""
         raise NotImplementedError

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set, Type, Union
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -31,7 +30,7 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
     SUPPORTED_FRAME_TYPES = {"rolling", "cumulative", "expanding"}
 
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod
@@ -44,8 +43,8 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
         order_by: str,
         agg_type: str,
         frame_type: str,
-        frame_size: Optional[int] = None,
-        frame_unit: Optional[str] = None,
+        frame_size: int | None = None,
+        frame_unit: str | None = None,
     ) -> DuckdbRelation:
         agg_func = _DUCKDB_AGG_FUNCS.get(agg_type)
         if agg_func is None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pandas_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pandas_frame_aggregate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional, Set, Type, Union
-
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -30,7 +28,7 @@ class PandasFrameAggregate(FrameAggregateFeatureGroup):
     SUPPORTED_FRAME_TYPES = {"rolling", "cumulative", "expanding"}
 
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod
@@ -43,8 +41,8 @@ class PandasFrameAggregate(FrameAggregateFeatureGroup):
         order_by: str,
         agg_type: str,
         frame_type: str,
-        frame_size: Optional[int] = None,
-        frame_unit: Optional[str] = None,
+        frame_size: int | None = None,
+        frame_unit: str | None = None,
     ) -> pd.DataFrame:
         pandas_func = _PANDAS_FRAME_AGG_FUNCS.get(agg_type)
         if pandas_func is None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/polars_lazy_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/polars_lazy_frame_aggregate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set, Type, Union
 
 import polars as pl
 
@@ -20,7 +19,7 @@ class PolarsLazyFrameAggregate(FrameAggregateFeatureGroup):
     SUPPORTED_FRAME_TYPES = {"rolling", "cumulative", "expanding"}
 
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod
@@ -33,8 +32,8 @@ class PolarsLazyFrameAggregate(FrameAggregateFeatureGroup):
         order_by: str,
         agg_type: str,
         frame_type: str,
-        frame_size: Optional[int] = None,
-        frame_unit: Optional[str] = None,
+        frame_size: int | None = None,
+        frame_unit: str | None = None,
     ) -> pl.LazyFrame:
         # Tag rows with original position
         data = data.with_row_index(_RN_COL)

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/sqlite_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/sqlite_frame_aggregate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set, Type, Union
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
@@ -26,7 +25,7 @@ class SqliteFrameAggregate(FrameAggregateFeatureGroup):
     SUPPORTED_FRAME_TYPES = {"rolling", "cumulative", "expanding"}
 
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SqliteFramework}
 
     @classmethod
@@ -39,8 +38,8 @@ class SqliteFrameAggregate(FrameAggregateFeatureGroup):
         order_by: str,
         agg_type: str,
         frame_type: str,
-        frame_size: Optional[int] = None,
-        frame_unit: Optional[str] = None,
+        frame_size: int | None = None,
+        frame_unit: str | None = None,
     ) -> SqliteRelation:
         agg_func = _SQLITE_AGG_FUNCS.get(agg_type)
         if agg_func is None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
@@ -171,9 +172,9 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         raise ValueError(f"Could not extract offset type from feature name: {feature_name}")
 
     @classmethod
-    def _extract_offset_type(cls, feature: Any) -> str:
+    def _extract_offset_type(cls, feature: Feature) -> str:
         """Extract offset type from feature (string-based or config-based)."""
-        feature_name = feature.get_name()
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
@@ -189,7 +190,7 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
 
             source_features = cls._extract_source_features(feature)
             source_col = source_features[0]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/duckdb_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/duckdb_offset.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
@@ -18,7 +16,7 @@ _RN_COL = "__mloda_orig_rn__"
 
 class DuckdbOffset(OffsetFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/pandas_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/pandas_offset.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -17,7 +15,7 @@ from mloda.community.feature_groups.data_operations.pandas_helpers import null_s
 
 class PandasOffset(OffsetFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/polars_lazy_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/polars_lazy_offset.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
 
 import polars as pl
 
@@ -16,7 +15,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.offset.base i
 
 class PolarsLazyOffset(OffsetFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/sqlite_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/sqlite_offset.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.offset.base i
 
 class SqliteOffset(OffsetFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SqliteFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_sqlite.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_sqlite.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sqlite3
 from typing import Any
 
-import pyarrow as pa
 import pytest
 
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Set
+from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
@@ -75,7 +75,7 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     }
 
     @classmethod
-    def _parse_percentile_from_config(cls, operation_config: str) -> Optional[float]:
+    def _parse_percentile_from_config(cls, operation_config: str) -> float | None:
         """Parse a pN operation config into a float 0.0-1.0, or None if invalid."""
         n = int(operation_config[1:])
         if 0 <= n <= 100:
@@ -127,7 +127,7 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return True
 
     @classmethod
-    def _resolve_percentile(cls, feature_name: Any, options: Any) -> Optional[float]:
+    def _resolve_percentile(cls, feature_name: Any, options: Any) -> float | None:
         """Extract percentile as float from feature name or options."""
         name = str(feature_name)
         prefix_patterns = cls._get_prefix_patterns()
@@ -158,9 +158,9 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         raise ValueError(f"Could not extract percentile value from feature name: {feature_name}")
 
     @classmethod
-    def _extract_percentile(cls, feature: Any) -> float:
+    def _extract_percentile(cls, feature: Feature) -> float:
         """Extract percentile float from feature (name first, then options)."""
-        feature_name = feature.get_name()
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
@@ -172,9 +172,9 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             raise ValueError(f"Could not extract percentile for {feature_name}")
         return float(percentile)
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Parse input features from feature name or options."""
-        _feature_name = feature_name.name if isinstance(feature_name, FeatureName) else feature_name
+        _feature_name = str(feature_name)
 
         prefix_patterns = self._get_prefix_patterns()
         operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
@@ -187,14 +187,14 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return set(in_features_set)
 
     @classmethod
-    def _extract_source_features(cls, feature: Feature) -> List[str]:
+    def _extract_source_features(cls, feature: Feature) -> list[str]:
         """Extract and validate the single source feature for percentile.
 
         Returns a one-element list containing the source column name.
         Raises ValueError if more than one source feature is found, since
         this package only supports single-column percentile computation.
         """
-        feature_name = feature.get_name()
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
 
         operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
@@ -203,7 +203,7 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             return [source_feature]
 
         in_features_set = feature.options.get_in_features()
-        source_names = [f.get_name() for f in in_features_set]
+        source_names: list[str] = [str(f.name) for f in in_features_set]
 
         if len(source_names) > cls.MAX_IN_FEATURES:
             raise ValueError(
@@ -223,7 +223,7 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
 
             source_features = cls._extract_source_features(feature)
             source_col = source_features[0]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/duckdb_percentile.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/duckdb_percentile.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -16,7 +16,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.percentile.ba
 
 class DuckdbPercentile(PercentileFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/pandas_percentile.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/pandas_percentile.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.percentile.ba
 
 class PandasPercentile(PercentileFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/polars_lazy_percentile.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/polars_lazy_percentile.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import polars as pl
 
 from mloda.provider import ComputeFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.percentile.ba
 
 class PolarsLazyPercentile(PercentileFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
@@ -188,9 +189,9 @@ class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         raise ValueError(f"Could not extract rank type from feature name: {feature_name}")
 
     @classmethod
-    def _extract_rank_type(cls, feature: Any) -> str:
+    def _extract_rank_type(cls, feature: Feature) -> str:
         """Extract rank type from feature (string-based or config-based)."""
-        feature_name = feature.get_name()
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
@@ -211,7 +212,7 @@ class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
 
             rank_type = cls._extract_rank_type(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -25,7 +25,7 @@ _DUCKDB_RANK_FUNCS: dict[str, str] = {
 
 class DuckdbRank(RankFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pandas_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pandas_rank.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -23,7 +21,7 @@ _PANDAS_RANK_METHODS: dict[str, str] = {
 
 class PandasRank(RankFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/polars_lazy_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/polars_lazy_rank.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
 
 import polars as pl
 
@@ -18,7 +17,7 @@ _NULL_FLAG_COL = "__mloda_rank_null_flag__"
 
 class PolarsLazyRank(RankFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/sqlite_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/sqlite_rank.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
 
 import pyarrow as pa
 
@@ -50,7 +49,7 @@ _SQLITE_RANK_FUNCS: dict[str, str] = {
 
 class SqliteRank(RankFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SqliteFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
@@ -12,7 +12,7 @@ column and fills every row with that scalar result.
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Set
+from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
@@ -73,8 +73,8 @@ class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         raise ValueError(f"Could not extract aggregation type from feature name: {feature_name}")
 
     @classmethod
-    def _extract_aggregation_type(cls, feature: Any) -> str:
-        feature_name = feature.get_name()
+    def _extract_aggregation_type(cls, feature: Feature) -> str:
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
@@ -84,8 +84,8 @@ class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             raise ValueError(f"Could not extract aggregation type for {feature_name}")
         return str(agg_type)
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
-        _feature_name = feature_name.name if isinstance(feature_name, FeatureName) else feature_name
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        _feature_name = str(feature_name)
 
         prefix_patterns = self._get_prefix_patterns()
         operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
@@ -98,14 +98,14 @@ class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return set(in_features_set)
 
     @classmethod
-    def _extract_source_features(cls, feature: Feature) -> List[str]:
+    def _extract_source_features(cls, feature: Feature) -> list[str]:
         """Extract and validate the single source feature for aggregation.
 
         Returns a one-element list containing the source column name.
         Raises ValueError if more than one source feature is found, since
         this package only supports single-column aggregation.
         """
-        feature_name = feature.get_name()
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
 
         operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
@@ -114,7 +114,7 @@ class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             return [source_feature]
 
         in_features_set = feature.options.get_in_features()
-        source_names = [f.get_name() for f in in_features_set]
+        source_names: list[str] = [str(f.name) for f in in_features_set]
 
         if len(source_names) > cls.MAX_IN_FEATURES:
             raise ValueError(
@@ -135,7 +135,7 @@ class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
 
             source_features = cls._extract_source_features(feature)
             source_col = source_features[0]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/duckdb_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/duckdb_scalar_aggregate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -32,7 +32,7 @@ _DUCKDB_AGG_FUNCS: dict[str, str] = {
 
 class DuckdbScalarAggregate(ScalarAggregateFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pandas_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pandas_scalar_aggregate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggreg
 
 class PandasScalarAggregate(ScalarAggregateFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/polars_lazy_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/polars_lazy_scalar_aggregate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import polars as pl
 
 from mloda.provider import ComputeFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggreg
 
 class PolarsLazyScalarAggregate(ScalarAggregateFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyarrow_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyarrow_scalar_aggregate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -17,7 +16,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggreg
 
 class PyArrowScalarAggregate(ScalarAggregateFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/sqlite_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/sqlite_scalar_aggregate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
@@ -25,7 +23,7 @@ _SQLITE_AGG_FUNCS: dict[str, str] = {
 
 class SqliteScalarAggregate(ScalarAggregateFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SqliteFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
@@ -188,7 +188,7 @@ class TestSingleColumnEnforcement:
         result = instance.input_features(options, FeatureName("value_int__sum_scalar"))
         assert result is not None
         assert len(result) == 1
-        names = {f.get_name() for f in result}
+        names = {f.name for f in result}
         assert names == {"value_int"}
 
     def test_input_features_returns_single_feature_for_option_config(self) -> None:
@@ -202,7 +202,7 @@ class TestSingleColumnEnforcement:
         result = instance.input_features(options, FeatureName("my_max_result"))
         assert result is not None
         assert len(result) == 1
-        names = {f.get_name() for f in result}
+        names = {f.name for f in result}
         assert names == {"revenue"}
 
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_security.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_security.py
@@ -13,7 +13,6 @@ from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
     AGGREGATION_TYPES,
-    ScalarAggregateFeatureGroup,
 )
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pyarrow_scalar_aggregate import (
     PyArrowScalarAggregate,

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
@@ -179,7 +180,7 @@ class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return True
 
     @classmethod
-    def _resolve_agg_type(cls, feature_name: Any, options: Any) -> Optional[str]:
+    def _resolve_agg_type(cls, feature_name: Any, options: Any) -> str | None:
         """Extract agg_type from feature name or options for validation."""
         name = str(feature_name)
         prefix_patterns = cls._get_prefix_patterns()
@@ -201,9 +202,9 @@ class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         raise ValueError(f"Could not extract aggregation type from feature name: {feature_name}")
 
     @classmethod
-    def _extract_aggregation_type(cls, feature: Any) -> str:
+    def _extract_aggregation_type(cls, feature: Feature) -> str:
         """Extract aggregation type from feature (string-based or config-based)."""
-        feature_name = feature.get_name()
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
@@ -224,7 +225,7 @@ class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
 
             source_features = cls._extract_source_features(feature)
             source_col = source_features[0]
@@ -244,7 +245,7 @@ class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str] = None,
+        order_by: str | None = None,
     ) -> Any:
         """Subclasses must implement the actual window computation."""
         raise NotImplementedError

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set, Type, Union
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -39,7 +39,7 @@ _RN_COL = "__mloda_rn__"
 
 class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod
@@ -50,7 +50,7 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str] = None,
+        order_by: str | None = None,
     ) -> DuckdbRelation:
         # Safety: _raw_sql is composed entirely from quote_ident()-quoted identifiers
         # and hardcoded SQL function names from _DUCKDB_AGG_FUNCS. No user-controlled
@@ -80,7 +80,7 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str] = None,
+        order_by: str | None = None,
     ) -> DuckdbRelation:
         """Compute FIRST_VALUE/LAST_VALUE with ORDER BY for deterministic results.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional, Set, Type, Union
-
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -22,7 +20,7 @@ from mloda.community.feature_groups.data_operations.pandas_helpers import (
 
 class PandasWindowAggregation(WindowAggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod
@@ -33,7 +31,7 @@ class PandasWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str] = None,
+        order_by: str | None = None,
     ) -> pd.DataFrame:
         """Compute a window aggregation using pandas groupby().transform()."""
         if agg_type == "mode":

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/polars_lazy_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/polars_lazy_window_aggregation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set, Type, Union
+from typing import Any
 
 import polars as pl
 
@@ -35,7 +35,7 @@ _POLARS_AGG_EXPRS: dict[str, Any] = {
 
 class PolarsLazyWindowAggregation(WindowAggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod
@@ -46,7 +46,7 @@ class PolarsLazyWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str] = None,
+        order_by: str | None = None,
     ) -> pl.LazyFrame:
         """Compute a window aggregation using Polars .over() expressions (fully lazy)."""
         if agg_type == "mode":
@@ -66,7 +66,7 @@ class PolarsLazyWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str],
+        order_by: str | None,
         feature_name: str,
     ) -> pl.Expr:
         """Build a Polars expression for first/last with deterministic ordering."""

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
@@ -8,7 +8,7 @@ same group_by call.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set, Type, Union
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -49,7 +49,7 @@ _ORDERED_FUNCS: dict[str, str] = {
 
 class PyArrowWindowAggregation(WindowAggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod
@@ -60,7 +60,7 @@ class PyArrowWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str] = None,
+        order_by: str | None = None,
     ) -> pa.Table:
         num_rows = table.num_rows
         t_with_idx = table.append_column(_IDX_COL, pa.array(range(num_rows)))
@@ -101,7 +101,7 @@ class PyArrowWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str],
+        order_by: str | None,
     ) -> pa.Table:
         pa_func = _ORDERED_FUNCS[agg_type]
         sort_keys = [(col, "ascending") for col in partition_by]

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set, Type, Union
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
@@ -26,7 +25,7 @@ _SQLITE_AGG_FUNCS: dict[str, str] = {
 
 class SqliteWindowAggregation(WindowAggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SqliteFramework}
 
     @classmethod
@@ -37,7 +36,7 @@ class SqliteWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str] = None,
+        order_by: str | None = None,
     ) -> SqliteRelation:
         """Execute the aggregation as a SQL window function."""
         agg_func = _SQLITE_AGG_FUNCS.get(agg_type)

--- a/mloda/community/feature_groups/data_operations/string/base.py
+++ b/mloda/community/feature_groups/data_operations/string/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
@@ -95,9 +96,9 @@ class StringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         raise ValueError(f"Could not extract string operation from feature name: {feature_name}")
 
     @classmethod
-    def _extract_string_op(cls, feature: Any) -> str:
+    def _extract_string_op(cls, feature: Feature) -> str:
         """Extract string operation from feature (string-based or config-based)."""
-        feature_name = feature.get_name()
+        feature_name = feature.name
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
@@ -113,7 +114,7 @@ class StringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         table = data
 
         for feature in features.features:
-            feature_name = feature.get_name()
+            feature_name = feature.name
 
             source_features = cls._extract_source_features(feature)
             source_col = source_features[0]

--- a/mloda/community/feature_groups/data_operations/string/duckdb_string.py
+++ b/mloda/community/feature_groups/data_operations/string/duckdb_string.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -25,7 +25,7 @@ _DUCKDB_STRING_EXPRS: dict[str, str] = {
 
 class DuckdbStringOps(StringFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {DuckDBFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/string/pandas_string.py
+++ b/mloda/community/feature_groups/data_operations/string/pandas_string.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pandas as pd
 
 from mloda.provider import ComputeFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.string.base import (
 
 class PandasStringOps(StringFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/string/polars_lazy_string.py
+++ b/mloda/community/feature_groups/data_operations/string/polars_lazy_string.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import polars as pl
 
 from mloda.provider import ComputeFramework
@@ -16,7 +14,7 @@ from mloda.community.feature_groups.data_operations.string.base import (
 
 class PolarsLazyStringOps(StringFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PolarsLazyDataFrame}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/string/pyarrow_string.py
+++ b/mloda/community/feature_groups/data_operations/string/pyarrow_string.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 import pyarrow as pa
 import pyarrow.compute as pc
 
@@ -25,7 +23,7 @@ _PYARROW_STRING_FUNCS: dict[str, str] = {
 
 class PyArrowStringOps(StringFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/string/sqlite_string.py
+++ b/mloda/community/feature_groups/data_operations/string/sqlite_string.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Set, Type, Union
-
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
@@ -25,7 +23,7 @@ _SQLITE_STRING_EXPRS: dict[str, str] = {
 
 class SqliteStringOps(StringFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SqliteFramework}
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/string/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_integration.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 from typing import Any
 
 import pyarrow as pa
-import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example community FeatureGroup plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "All community plugins for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/enterprise/compute_frameworks/example/enterprise_example_compute_framework.py
+++ b/mloda/enterprise/compute_frameworks/example/enterprise_example_compute_framework.py
@@ -1,6 +1,5 @@
 """Enterprise Example ComputeFramework implementation."""
 
-from typing import Optional, Set
 from uuid import UUID, uuid4
 
 from mloda.user import ParallelizationMode
@@ -16,7 +15,7 @@ class EnterpriseExampleComputeFramework(ComputeFramework):
         mode: ParallelizationMode = ParallelizationMode.SYNC,
         children_if_root: frozenset[UUID] = frozenset(),
         uuid: UUID = uuid4(),
-        function_extender: Optional[Set[Extender]] = None,
+        function_extender: set[Extender] | None = None,
     ) -> None:
         """Initialize with default values for minimal instantiation."""
         super().__init__(mode, children_if_root, uuid, function_extender)

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example enterprise ComputeFramework plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/compute_frameworks/example/tests/test_enterprise_example_compute_framework.py
+++ b/mloda/enterprise/compute_frameworks/example/tests/test_enterprise_example_compute_framework.py
@@ -1,7 +1,5 @@
 """Tests for EnterpriseExampleComputeFramework."""
 
-import pytest
-
 from mloda.provider import ComputeFramework
 
 

--- a/mloda/enterprise/extenders/example/enterprise_example_extender.py
+++ b/mloda/enterprise/extenders/example/enterprise_example_extender.py
@@ -1,6 +1,6 @@
 """Enterprise Example Extender implementation."""
 
-from typing import Any, Set
+from typing import Any
 
 from mloda.steward import Extender, ExtenderHook
 
@@ -8,7 +8,7 @@ from mloda.steward import Extender, ExtenderHook
 class EnterpriseExampleExtender(Extender):
     """An example enterprise extender that demonstrates the Extender pattern."""
 
-    def wraps(self) -> Set[ExtenderHook]:
+    def wraps(self) -> set[ExtenderHook]:
         """Return the hooks this extender wraps."""
         return set()
 

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example enterprise Extender plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/extenders/example/tests/test_enterprise_example_extender.py
+++ b/mloda/enterprise/extenders/example/tests/test_enterprise_example_extender.py
@@ -1,7 +1,5 @@
 """Tests for EnterpriseExampleExtender."""
 
-import pytest
-
 from mloda.steward import Extender
 
 

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Example enterprise FeatureGroup plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.12"
 description = "Plugin discovery and search for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.5.7"]
+dependencies = ["mloda>=0.6.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/testing/data_creator/base.py
+++ b/mloda/testing/data_creator/base.py
@@ -10,7 +10,7 @@ data source in mloda's pipeline.
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
-from typing import Any, Optional, Set, Type, Union
+from typing import Any
 
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
@@ -26,7 +26,7 @@ class DataOperationsTestDataCreator(FeatureGroup):
     Use directly in PluginCollector sets for integration tests.
     """
 
-    compute_framework: Type[ComputeFramework] = PyArrowTable
+    compute_framework: type[ComputeFramework] = PyArrowTable
 
     NULL_POSITIONS: dict[str, set[int]] = {
         "region": {11},
@@ -42,7 +42,7 @@ class DataOperationsTestDataCreator(FeatureGroup):
     }
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(set(cls.get_raw_data().keys()))
 
     @classmethod
@@ -111,7 +111,7 @@ class DataOperationsTestDataCreator(FeatureGroup):
         return cls.get_raw_data()
 
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {cls.compute_framework}
 
     @classmethod

--- a/mloda/testing/feature_groups/data_operations/aggregation/reference.py
+++ b/mloda/testing/feature_groups/data_operations/aggregation/reference.py
@@ -10,7 +10,7 @@ because PyArrow has no exact grouped median or grouped mode function.
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any, Set, Type, Union
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -52,7 +52,7 @@ _ORDERED_FUNCS: dict[str, str] = {
 
 class ReferenceAggregation(AggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod

--- a/mloda/testing/feature_groups/data_operations/integration.py
+++ b/mloda/testing/feature_groups/data_operations/integration.py
@@ -34,9 +34,7 @@ import pyarrow as pa
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.user import Feature, PluginCollector, mloda
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
 
 class DataOpsIntegrationTestBase(ABC):

--- a/mloda/testing/feature_groups/data_operations/row_preserving/binning/binning.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/binning/binning.py
@@ -303,7 +303,6 @@ class BinningTestBase(DataOpsTestBase):
 
     def test_all_null_column(self) -> None:
         """All-null column should produce all-null bin assignments."""
-        all_null_data = {"value_int": [None, None, None]}
         arrow_table = pa.table({"value_int": pa.array([None, None, None], type=pa.int64())})
         test_data = self.create_test_data(arrow_table)
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/reference.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/reference.py
@@ -9,7 +9,7 @@ extracted lists.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set, Type, Union
+from typing import Any
 
 import pyarrow as pa
 
@@ -24,7 +24,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.frame_aggrega
 
 class ReferenceFrameAggregate(FrameAggregateFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod
@@ -37,8 +37,8 @@ class ReferenceFrameAggregate(FrameAggregateFeatureGroup):
         order_by: str,
         agg_type: str,
         frame_type: str,
-        frame_size: Optional[int] = None,
-        frame_unit: Optional[str] = None,
+        frame_size: int | None = None,
+        frame_unit: str | None = None,
     ) -> pa.Table:
         num_rows = table.num_rows
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/reference.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/reference.py
@@ -6,7 +6,7 @@ comparison baseline in test suites.
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 import pyarrow as pa
 
@@ -20,7 +20,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.offset.base i
 
 class ReferenceOffset(OffsetFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod

--- a/mloda/testing/feature_groups/data_operations/row_preserving/percentile/reference.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/percentile/reference.py
@@ -8,7 +8,7 @@ PyArrow's quantile function.
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -25,7 +25,7 @@ _IDX_COL = "__mloda_pctl_idx__"
 
 class ReferencePercentile(PercentileFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod

--- a/mloda/testing/feature_groups/data_operations/row_preserving/rank/reference.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/rank/reference.py
@@ -6,7 +6,7 @@ comparison baseline in test suites.
 
 from __future__ import annotations
 
-from typing import Any, Set, Type, Union
+from typing import Any
 
 import pyarrow as pa
 
@@ -20,7 +20,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.rank.base imp
 
 class ReferenceRank(RankFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod

--- a/mloda/testing/feature_groups/data_operations/row_preserving/scalar_aggregate/scalar_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/scalar_aggregate/scalar_aggregate.py
@@ -19,7 +19,7 @@ import pytest
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
-from mloda.testing.feature_groups.data_operations.helpers import extract_column, make_feature_set
+from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
 from mloda.user import Feature
 
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/reference.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/reference.py
@@ -11,7 +11,7 @@ function.
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any, Optional, Set, Type, Union
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -52,7 +52,7 @@ _ORDERED_FUNCS: dict[str, str] = {
 
 class ReferenceWindowAggregation(WindowAggregationFeatureGroup):
     @classmethod
-    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFramework]]]:
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PyArrowTable}
 
     @classmethod
@@ -63,7 +63,7 @@ class ReferenceWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str] = None,
+        order_by: str | None = None,
     ) -> pa.Table:
         num_rows = table.num_rows
         t_with_idx = table.append_column(_IDX_COL, pa.array(range(num_rows)))
@@ -107,7 +107,7 @@ class ReferenceWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
         agg_type: str,
-        order_by: Optional[str],
+        order_by: str | None,
     ) -> pa.Table:
         pa_func = _ORDERED_FUNCS[agg_type]
         sort_keys = [(col, "ascending") for col in partition_by]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Development workspace for mloda registry packages"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "mloda>=0.5.7",
+    "mloda>=0.6.0",
 ]
 authors = [
     { name = "Tom Kaltofen", email = "info@mloda.ai" }
@@ -31,6 +31,12 @@ dev = [
 
 [tool.ruff]
 line-length = 120
+
+[tool.ruff.lint]
+extend-select = ["UP006", "UP007"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/**" = ["E402"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,14 @@ usedevelop = true
 extras = dev
 passenv =
     USE_TOX_LOCK
+    PYTEST_WORKERS
 allowlist_externals = sh, bandit
 setenv =
     USE_TOX_LOCK = {env:USE_TOX_LOCK:}
 commands =
     sh -c "if [ -n \"$USE_TOX_LOCK\" ]; then flock /shared/tox.lock pytest -n {env:PYTEST_WORKERS:2}; else pytest -n {env:PYTEST_WORKERS:2}; fi"
-    ruff format --line-length 120 .
+    ruff format --check --line-length 120 .
+    ruff check .
     mypy --strict --ignore-missing-imports .
     bandit -c pyproject.toml -r -q .
 

--- a/uv.lock
+++ b/uv.lock
@@ -234,13 +234,13 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.5.7"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/6c/34f3ddf56b541c0c48c823c6b1b65bb0eb0ecdf57321ec74358bef2357a5/mloda-0.5.7-py3-none-any.whl", hash = "sha256:a3b3b815eba16de065ebe63d13258574ab770c574a46ab7e17a7f7402f37b856", size = 389162, upload-time = "2026-03-30T18:15:15.59Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/28/445544d11cc05553b1725c9ffea714d116d53bf24866ac19d3d57e6783b4/mloda-0.6.0-py3-none-any.whl", hash = "sha256:cbb55b89c1fceaca9354121f8bd956eec75d7130247bc875f3f9ff9fe5a0c037", size = 402774, upload-time = "2026-04-06T19:18:52.961Z" },
 ]
 
 [[package]]
@@ -252,7 +252,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.5.7" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.6.0" }]
 
 [[package]]
 name = "mloda-community-aggregation"
@@ -370,7 +370,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.7" },
+    { name = "mloda", specifier = ">=0.6.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -404,7 +404,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.7" },
+    { name = "mloda", specifier = ">=0.6.0" },
     { name = "mloda-community-aggregation", marker = "extra == 'all'" },
     { name = "mloda-community-binning", marker = "extra == 'all'" },
     { name = "mloda-community-datetime", marker = "extra == 'all'" },
@@ -462,7 +462,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.7" },
+    { name = "mloda", specifier = ">=0.6.0" },
     { name = "mloda-community-example-a", marker = "extra == 'all'" },
     { name = "mloda-community-example-b", marker = "extra == 'all'" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
@@ -530,7 +530,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.7" },
+    { name = "mloda", specifier = ">=0.6.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -843,7 +843,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.5.7" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.6.0" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
@@ -861,7 +861,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.7" },
+    { name = "mloda", specifier = ">=0.6.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -883,7 +883,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.7" },
+    { name = "mloda", specifier = ">=0.6.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -905,7 +905,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.7" },
+    { name = "mloda", specifier = ">=0.6.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -927,7 +927,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.5.7" },
+    { name = "mloda", specifier = ">=0.6.0" },
     { name = "mloda-testing", marker = "extra == 'dev'", editable = "mloda/testing" },
     { name = "pytest", marker = "extra == 'dev'" },
 ]
@@ -958,7 +958,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
-    { name = "mloda", specifier = ">=0.5.7" },
+    { name = "mloda", specifier = ">=0.6.0" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary

- Update mloda dependency from `>=0.5.7` to `>=0.6.0` across all packages
- Adopt all breaking API changes from mloda 0.6.0 (all 23 migration items audited)
- Strengthen the tox pipeline with `ruff check`, `--check` mode formatting, and reliable CI test execution

## Key changes

**Breaking API fixes (118 files):**
- Replace removed `Feature.get_name()` with `Feature.name` (32 call sites)
- Replace removed `FeatureName.name` with `str(feature_name)` (6 locations)
- Update `compute_framework_rule()` return type to `set[type[ComputeFramework]] | None` (52 files)
- Modernize all typing imports to PEP 585/604 syntax

**Type safety improvements:**
- Replace `feature: Any` with `feature: Feature` in 10 `_extract_*` methods
- Add `ruff check` with UP006/UP007 rules to prevent old-style typing regression

**Pipeline hardening:**
- `ruff format --check` instead of silent reformatting
- `ruff check` gate added between format and mypy
- `PYTEST_WORKERS=0` in CI to prevent SQLite xdist concurrency failures

**Documentation:**
- Update validator guide to raise-on-failure contract
- Modernize type annotations across all 21 plugin development guides

## Test plan

- [x] `uv run tox -r` passes (1083 passed, 135 skipped)
- [x] `ruff check` clean (UP006/UP007 enforced)
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean (242 files, 0 errors)
- [x] `bandit` clean
- [x] All 23 MIGRATION-0.6.0.md items verified