### PR TITLE
feat: implement native DuckDB qbin using NTILE and order()

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
@@ -47,7 +47,20 @@ class DuckdbBinning(BinningFeatureGroup):
             result: DuckdbRelation = data.select(_raw_sql=raw_sql)
             return result
 
-        # qbin requires NTILE() with ORDER BY, which reorders rows in DuckDB's
-        # relational API. Blocked until DuckdbRelation exposes a public order() method.
-        # See: https://github.com/mloda-ai/mloda/issues/251
+        if op == "qbin":
+            qrn = quote_ident("__mloda_rn__")
+            expr = (
+                f"CASE WHEN {quoted_source} IS NULL OR isnan({quoted_source}) THEN NULL "
+                f"ELSE LEAST(NTILE({n_bins}) OVER ("
+                f"PARTITION BY CASE WHEN {quoted_source} IS NOT NULL "
+                f"AND NOT isnan({quoted_source}) THEN 1 END "
+                f"ORDER BY {quoted_source}) - 1, {n_bins - 1}) END"
+            )
+            with_rn = data.select(_raw_sql=f"*, ROW_NUMBER() OVER () AS {qrn}")
+            with_qbin = with_rn.select(_raw_sql=f"*, {expr} AS {quoted_feature}")
+            sorted_rel = with_qbin.order(qrn)
+            keep = ", ".join(quote_ident(c) for c in sorted_rel.columns if c != "__mloda_rn__")
+            qbin_result: DuckdbRelation = sorted_rel.select(_raw_sql=keep)
+            return qbin_result
+
         raise ValueError(f"Unsupported binning operation for DuckDB: {op}")

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_duckdb.py
@@ -18,16 +18,7 @@ from mloda.testing.feature_groups.data_operations.row_preserving.binning.binning
 
 
 class TestDuckdbBinning(DuckdbTestMixin, BinningTestBase):
-    """Standard tests inherited from the base class.
-
-    qbin is excluded: DuckdbRelation lacks a public order() method, so NTILE
-    results cannot be re-sorted to original row order without eager materialization.
-    Tracked in https://github.com/mloda-ai/mloda/issues/251.
-    """
-
-    @classmethod
-    def supported_ops(cls) -> set[str]:
-        return {"bin"}
+    """Standard tests inherited from the base class."""
 
     @classmethod
     def implementation_class(cls) -> Any:


### PR DESCRIPTION
## Summary

- Implement quantile-based binning (`qbin`) for DuckDB, now that `DuckdbRelation.order()` is available (mloda-ai/mloda#251)
- Uses `NTILE()` window function with `ROW_NUMBER()`-based row-order restoration via `order()`
- Remove `supported_ops` override from `TestDuckdbBinning`, enabling all 29 inherited qbin tests (previously only 6 bin tests ran)

Closes #112

## Test plan

- [x] All 29 DuckDB binning tests pass (bin + qbin), including cross-framework comparisons with PyArrow reference
- [x] Full tox suite green: 1083 passed, ruff format/check, mypy strict, bandit
- [ ] CI checks pass on GitHub