### PR TITLE
docs: document framework-specific quirks for PyArrow parity

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
@@ -48,6 +48,10 @@ class DuckdbBinning(BinningFeatureGroup):
             return result
 
         if op == "qbin":
+            # PyArrow parity: PyArrow _quantile_bin() assigns bins via index
+            # mapping and naturally preserves row order. DuckDB NTILE()
+            # reorders rows via ORDER BY; tag positions with ROW_NUMBER()
+            # and restore via .order() to match PyArrow output.
             qrn = quote_ident("__mloda_rn__")
             expr = (
                 f"CASE WHEN {quoted_source} IS NULL OR isnan({quoted_source}) THEN NULL "

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
@@ -75,6 +75,9 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
         else:
             raise ValueError(f"Unsupported frame type for DuckDB: {frame_type}")
 
+        # PyArrow parity: the reference preserves input row order. DuckDB
+        # ORDER BY in the window frame reorders rows; tag with ROW_NUMBER(),
+        # compute, then .order(qrn) to restore original order.
         # Step 1: tag rows with original position
         rel = data._relation.project(f"*, ROW_NUMBER() OVER () AS {qrn}")  # nosec
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pandas_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pandas_frame_aggregate.py
@@ -63,7 +63,9 @@ class PandasFrameAggregate(FrameAggregateFeatureGroup):
 
         data = data.sort_values(by=[*partition_by, order_by], na_position="last")
 
-        # Apply mask AFTER sorting so that sort order uses original (unmasked) values.
+        # PyArrow parity: the reference applies masks before aggregation but
+        # sorts on unmasked values. Apply mask AFTER sorting so that sort
+        # order uses original (unmasked) values to match this behavior.
         # This matters when order_by == source_col.
         # Safe to mutate: data was already copied above (data = data.copy()).
         if mask_spec is not None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/duckdb_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/duckdb_offset.py
@@ -67,6 +67,11 @@ class DuckdbOffset(OffsetFeatureGroup):
             return DuckdbRelation(data.connection, result_rel)
         elif offset_type == "first_value":
             offset_expr = f"FIRST_VALUE({quoted_source} IGNORE NULLS)"
+            # PyArrow parity: the reference scans the entire partition for
+            # first/last non-null. DuckDB default ordered-window frame
+            # (UNBOUNDED PRECEDING to CURRENT ROW) would make LAST_VALUE
+            # return the current row. Explicit UNBOUNDED FOLLOWING gives
+            # partition-wide visibility.
             window_clause += " ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"
         elif offset_type == "last_value":
             offset_expr = f"LAST_VALUE({quoted_source} IGNORE NULLS)"
@@ -74,7 +79,9 @@ class DuckdbOffset(OffsetFeatureGroup):
         else:
             raise ValueError(f"Unsupported offset type for DuckDB: {offset_type}")
 
-        # Use query() to preserve original row order
+        # PyArrow parity: the reference returns results in original row
+        # order. DuckDB window functions with ORDER BY reorder rows; tag
+        # positions with ROW_NUMBER() and ORDER BY qrn to restore.
         qrn = quote_ident(_RN_COL)
         sql = (
             f"SELECT *, "  # nosec

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/polars_lazy_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/polars_lazy_offset.py
@@ -30,8 +30,10 @@ class PolarsLazyOffset(OffsetFeatureGroup):
     ) -> pl.LazyFrame:
         """Compute offset using Polars expressions (fully lazy).
 
-        We add a row index, sort within partitions, compute the offset,
-        then restore original row order.
+        PyArrow parity: the reference returns results in original row
+        order. Polars offset operations require sorting by order_by,
+        which reorders rows. We add a row index before sorting and
+        restore order afterward to match the reference.
         """
         # Track original row order
         data = data.with_row_index("__mloda_orig_idx")

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
@@ -60,9 +60,10 @@ class DuckdbRank(RankFeatureGroup):
                 raise ValueError(f"Unsupported rank type for DuckDB: {rank_type}")
             rank_expr = rank_func
 
-        # Use query() with ROW_NUMBER() to preserve original row order.
-        # The _RN_COL column tracks original position, then we
-        # sort by it and drop it to return rows in the original order.
+        # PyArrow parity: the reference computes ranks via Python index
+        # mapping and returns results in original row order. DuckDB window
+        # functions with ORDER BY reorder result rows; tag positions with
+        # ROW_NUMBER() and ORDER BY qrn to restore input row order.
         qrn = quote_ident(_RN_COL)
         if rank_type.startswith(("top_", "bottom_")):
             # rank_expr already contains full window expression with boolean comparison

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/polars_lazy_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/polars_lazy_rank.py
@@ -50,9 +50,11 @@ class PolarsLazyRank(RankFeatureGroup):
     ) -> pl.LazyFrame:
         """Compute rank using Polars expressions (fully lazy).
 
-        NullPolicy.NULLS_LAST: nulls in order_by get the highest rank.
-        Polars rank() returns null for null inputs, so we handle nulls
-        by assigning them a rank of (group_size) or (group_size + 1).
+        PyArrow parity: the reference (and SQL window functions) rank
+        nulls last, assigning null values the highest rank positions as
+        integers. Polars rank() returns null for null inputs, so we
+        manually assign null rows a rank of (non_null_count + 1) to
+        match the reference behavior.
         """
         # Create a helper: is_null flag (0 for non-null, 1 for null) for sorting nulls last
         null_flag = pl.col(order_by).is_null().cast(pl.Int64).alias(_NULL_FLAG_COL)

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/sqlite_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/sqlite_rank.py
@@ -22,6 +22,7 @@ class _BoolCastRelation(SqliteRelation):
     stored as INTEGER.  This wrapper ensures the Arrow table produced by
     ``to_arrow_table()`` uses ``pa.bool_()`` for the designated columns so that
     downstream ``to_pylist()`` returns Python ``True``/``False``.
+    This ensures parity with the PyArrow reference, which returns native bool.
     """
 
     def __init__(self, base: SqliteRelation, bool_columns: set[str]) -> None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
@@ -90,9 +90,16 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
     ) -> DuckdbRelation:
         """Compute FIRST_VALUE/LAST_VALUE with ORDER BY for deterministic results.
 
+        PyArrow parity: PyArrow group_by().aggregate() sees the entire
+        partition at once. DuckDB default ordered-window frame is
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW, which makes
+        LAST_VALUE return the current row instead of the partition-wide
+        last. Explicit ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED
+        FOLLOWING ensures full-partition visibility.
+
         Uses ROW_NUMBER to tag original row positions, computes the window
-        function with an explicit UNBOUNDED frame and ORDER BY clause,
-        then restores original row order.
+        function with the explicit UNBOUNDED frame, then restores original
+        row order.
 
         *source_sql* is a quoted identifier or a ``CASE WHEN`` expression
         when a mask is active.

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
@@ -105,7 +105,13 @@ class PandasWindowAggregation(WindowAggregationFeatureGroup):
         agg_type: str,
         order_by: str,
     ) -> pd.DataFrame:
-        """Compute first/last with order_by by sorting, transforming, then restoring row order."""
+        """Compute first/last with order_by by sorting, transforming, then restoring row order.
+
+        PyArrow parity: the reference sorts within each partition then
+        returns results in original row order. sort_index() after
+        transform restores the original pandas index order, matching
+        PyArrow's row-order guarantee.
+        """
         pandas_func = PANDAS_AGG_FUNCS[agg_type]
         sorted_data = data.sort_values(order_by, na_position="last")
         grouped = null_safe_groupby(sorted_data, partition_by, source_col)

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/polars_lazy_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/polars_lazy_window_aggregation.py
@@ -84,7 +84,9 @@ class PolarsLazyWindowAggregation(WindowAggregationFeatureGroup):
         elif agg_type in _POLARS_AGG_EXPRS:
             raw_expr = _POLARS_AGG_EXPRS[agg_type](actual_source).over(partition_by)
             if agg_type == "sum":
-                # Polars sum() returns 0 for all-null groups; correct to null.
+                # PyArrow parity: PyArrow sum() returns null for all-null
+                # groups. Polars sum() returns 0; correct to null by
+                # checking whether any non-null values exist.
                 has_values = pl.col(actual_source).count().over(partition_by) > 0
                 expr = pl.when(has_values).then(raw_expr).otherwise(None).alias(feature_name)
             else:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/binning/binning.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/binning/binning.py
@@ -435,20 +435,46 @@ class BinningTestBase(DataOpsTestBase):
 
         PyArrow parity: DuckDB NTILE() reorders rows via ORDER BY;
         the ROW_NUMBER + .order() pattern must restore input order.
+
+        Compares (value_int, category) tuples to detect tied-row swaps
+        (rows 8 and 9 both have value_int=15).
         """
         self._skip_if_unsupported("qbin")
         fs = make_feature_set("value_int__qbin_3")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        input_col = self.extract_column(self.test_data, "value_int")
-        output_col = self.extract_column(result, "value_int")
-        assert output_col == input_col
+        input_id = list(
+            zip(
+                self.extract_column(self.test_data, "value_int"),
+                self.extract_column(self.test_data, "category"),
+            )
+        )
+        output_id = list(
+            zip(
+                self.extract_column(result, "value_int"),
+                self.extract_column(result, "category"),
+            )
+        )
+        assert output_id == input_id
 
     def test_row_order_preserved_bin(self) -> None:
-        """Original columns must remain in input row order after bin."""
+        """Original columns must remain in input row order after bin.
+
+        Compares (value_int, category) tuples to detect tied-row swaps.
+        """
         fs = make_feature_set("value_int__bin_3")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        input_col = self.extract_column(self.test_data, "value_int")
-        output_col = self.extract_column(result, "value_int")
-        assert output_col == input_col
+        input_id = list(
+            zip(
+                self.extract_column(self.test_data, "value_int"),
+                self.extract_column(self.test_data, "category"),
+            )
+        )
+        output_id = list(
+            zip(
+                self.extract_column(result, "value_int"),
+                self.extract_column(result, "category"),
+            )
+        )
+        assert output_id == input_id

--- a/mloda/testing/feature_groups/data_operations/row_preserving/binning/binning.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/binning/binning.py
@@ -427,3 +427,28 @@ class BinningTestBase(DataOpsTestBase):
         fs.add(feature)
         with pytest.raises((ValueError, KeyError)):
             self.implementation_class().calculate_feature(self.test_data, fs)
+
+    # -- Row-order preservation ------------------------------------------------
+
+    def test_row_order_preserved_qbin(self) -> None:
+        """Original columns must remain in input row order after qbin.
+
+        PyArrow parity: DuckDB NTILE() reorders rows via ORDER BY;
+        the ROW_NUMBER + .order() pattern must restore input order.
+        """
+        self._skip_if_unsupported("qbin")
+        fs = make_feature_set("value_int__qbin_3")
+        result = self.implementation_class().calculate_feature(self.test_data, fs)
+
+        input_col = self.extract_column(self.test_data, "value_int")
+        output_col = self.extract_column(result, "value_int")
+        assert output_col == input_col
+
+    def test_row_order_preserved_bin(self) -> None:
+        """Original columns must remain in input row order after bin."""
+        fs = make_feature_set("value_int__bin_3")
+        result = self.implementation_class().calculate_feature(self.test_data, fs)
+
+        input_col = self.extract_column(self.test_data, "value_int")
+        output_col = self.extract_column(result, "value_int")
+        assert output_col == input_col

--- a/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
@@ -547,3 +547,19 @@ class FrameAggregateTestBase(DataOpsTestBase):
         assert result_col[1] == 10
         assert result_col[2] == 30
         assert result_col[0] == 130
+
+    # -- Row-order preservation ------------------------------------------------
+
+    def test_row_order_preserved(self) -> None:
+        """Original columns must remain in input row order after frame aggregate.
+
+        PyArrow parity: DuckDB and Pandas sort by order_by for the frame
+        window; the ROW_NUMBER + restore pattern must return rows in
+        input order.
+        """
+        fs = make_feature_set("value_int__sum_rolling_3", ["region"], "value_int")
+        result = self.implementation_class().calculate_feature(self.test_data, fs)
+
+        input_col = self.extract_column(self.test_data, "value_int")
+        output_col = self.extract_column(result, "value_int")
+        assert output_col == input_col

--- a/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
@@ -556,10 +556,23 @@ class FrameAggregateTestBase(DataOpsTestBase):
         PyArrow parity: DuckDB and Pandas sort by order_by for the frame
         window; the ROW_NUMBER + restore pattern must return rows in
         input order.
+
+        Compares (value_int, category) tuples to detect tied-row swaps
+        (rows 8 and 9 both have value_int=15).
         """
         fs = make_feature_set("value_int__sum_rolling_3", ["region"], "value_int")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        input_col = self.extract_column(self.test_data, "value_int")
-        output_col = self.extract_column(result, "value_int")
-        assert output_col == input_col
+        input_id = list(
+            zip(
+                self.extract_column(self.test_data, "value_int"),
+                self.extract_column(self.test_data, "category"),
+            )
+        )
+        output_id = list(
+            zip(
+                self.extract_column(result, "value_int"),
+                self.extract_column(result, "category"),
+            )
+        )
+        assert output_id == input_id

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -343,3 +343,18 @@ class OffsetTestBase(DataOpsTestBase):
         # Lag: [None, 10, 20]
         # Map back: row 0 (ts=None) -> lag=20, row 1 (ts=1) -> lag=None, row 2 (ts=2) -> lag=10
         assert result_col[1] is None  # first in sorted order has no predecessor
+
+    # -- Row-order preservation ------------------------------------------------
+
+    def test_row_order_preserved(self) -> None:
+        """Original columns must remain in input row order after offset.
+
+        PyArrow parity: without the ROW_NUMBER + restore pattern, SQL
+        backends return rows sorted by the window ORDER BY clause.
+        """
+        fs = make_feature_set("value_int__lag_1_offset", ["region"], "value_int")
+        result = self.implementation_class().calculate_feature(self.test_data, fs)
+
+        input_col = self.extract_column(self.test_data, "value_int")
+        output_col = self.extract_column(result, "value_int")
+        assert output_col == input_col

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -351,10 +351,23 @@ class OffsetTestBase(DataOpsTestBase):
 
         PyArrow parity: without the ROW_NUMBER + restore pattern, SQL
         backends return rows sorted by the window ORDER BY clause.
+
+        Compares (value_int, category) tuples to detect tied-row swaps
+        (rows 8 and 9 both have value_int=15).
         """
         fs = make_feature_set("value_int__lag_1_offset", ["region"], "value_int")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        input_col = self.extract_column(self.test_data, "value_int")
-        output_col = self.extract_column(result, "value_int")
-        assert output_col == input_col
+        input_id = list(
+            zip(
+                self.extract_column(self.test_data, "value_int"),
+                self.extract_column(self.test_data, "category"),
+            )
+        )
+        output_id = list(
+            zip(
+                self.extract_column(result, "value_int"),
+                self.extract_column(result, "category"),
+            )
+        )
+        assert output_id == input_id

--- a/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
@@ -509,6 +509,21 @@ class RankTestBase(DataOpsTestBase):
         # Bottom 2 = rows 1 and 2 -> True; rows 0 and 3 -> False
         assert result_col == [False, True, True, False]
 
+    # -- Row-order preservation ------------------------------------------------
+
+    def test_row_order_preserved(self) -> None:
+        """Original non-rank columns must remain in input row order.
+
+        PyArrow parity: without the ROW_NUMBER + restore pattern, SQL
+        backends return rows sorted by the window ORDER BY clause.
+        """
+        fs = make_feature_set("value_int__row_number_ranked", ["region"], "value_int")
+        result = self.implementation_class().calculate_feature(self.test_data, fs)
+
+        input_col = self.extract_column(self.test_data, "value_int")
+        output_col = self.extract_column(result, "value_int")
+        assert output_col == input_col
+
     # -- Helper methods ------------------------------------------------------
 
     def _skip_if_unsupported(self, rank_type: str) -> None:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
@@ -516,13 +516,26 @@ class RankTestBase(DataOpsTestBase):
 
         PyArrow parity: without the ROW_NUMBER + restore pattern, SQL
         backends return rows sorted by the window ORDER BY clause.
+
+        Compares (value_int, category) tuples to detect tied-row swaps
+        (rows 8 and 9 both have value_int=15).
         """
         fs = make_feature_set("value_int__row_number_ranked", ["region"], "value_int")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        input_col = self.extract_column(self.test_data, "value_int")
-        output_col = self.extract_column(result, "value_int")
-        assert output_col == input_col
+        input_id = list(
+            zip(
+                self.extract_column(self.test_data, "value_int"),
+                self.extract_column(self.test_data, "category"),
+            )
+        )
+        output_id = list(
+            zip(
+                self.extract_column(result, "value_int"),
+                self.extract_column(result, "category"),
+            )
+        )
+        assert output_id == input_id
 
     # -- Helper methods ------------------------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -842,20 +842,46 @@ class WindowAggregationTestBase(DataOpsTestBase):
 
         PyArrow parity: DuckDB first/last uses ORDER BY which reorders
         rows; the ROW_NUMBER + .order() pattern must restore input order.
+
+        Compares (value_int, category) tuples to detect tied-row swaps
+        (rows 8 and 9 both have value_int=15).
         """
         self._skip_if_unsupported("first")
         fs = make_feature_set("value_int__first_window", ["region"], "value_int")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        input_col = self.extract_column(self.test_data, "value_int")
-        output_col = self.extract_column(result, "value_int")
-        assert output_col == input_col
+        input_id = list(
+            zip(
+                self.extract_column(self.test_data, "value_int"),
+                self.extract_column(self.test_data, "category"),
+            )
+        )
+        output_id = list(
+            zip(
+                self.extract_column(result, "value_int"),
+                self.extract_column(result, "category"),
+            )
+        )
+        assert output_id == input_id
 
     def test_row_order_preserved_sum(self) -> None:
-        """Original columns must remain in input row order after sum."""
+        """Original columns must remain in input row order after sum.
+
+        Compares (value_int, category) tuples to detect tied-row swaps.
+        """
         fs = make_feature_set("value_int__sum_window", ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        input_col = self.extract_column(self.test_data, "value_int")
-        output_col = self.extract_column(result, "value_int")
-        assert output_col == input_col
+        input_id = list(
+            zip(
+                self.extract_column(self.test_data, "value_int"),
+                self.extract_column(self.test_data, "category"),
+            )
+        )
+        output_id = list(
+            zip(
+                self.extract_column(result, "value_int"),
+                self.extract_column(result, "category"),
+            )
+        )
+        assert output_id == input_id

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -834,3 +834,28 @@ class WindowAggregationTestBase(DataOpsTestBase):
         fs.add(feature)
         with pytest.raises((ValueError, KeyError)):
             self.implementation_class().calculate_feature(self.test_data, fs)
+
+    # -- Row-order preservation ------------------------------------------------
+
+    def test_row_order_preserved_first(self) -> None:
+        """Original columns must remain in input row order after first.
+
+        PyArrow parity: DuckDB first/last uses ORDER BY which reorders
+        rows; the ROW_NUMBER + .order() pattern must restore input order.
+        """
+        self._skip_if_unsupported("first")
+        fs = make_feature_set("value_int__first_window", ["region"], "value_int")
+        result = self.implementation_class().calculate_feature(self.test_data, fs)
+
+        input_col = self.extract_column(self.test_data, "value_int")
+        output_col = self.extract_column(result, "value_int")
+        assert output_col == input_col
+
+    def test_row_order_preserved_sum(self) -> None:
+        """Original columns must remain in input row order after sum."""
+        fs = make_feature_set("value_int__sum_window", ["region"])
+        result = self.implementation_class().calculate_feature(self.test_data, fs)
+
+        input_col = self.extract_column(self.test_data, "value_int")
+        output_col = self.extract_column(result, "value_int")
+        assert output_col == input_col


### PR DESCRIPTION
## Summary

Closes #120

- Add inline "PyArrow parity" comments to 11 framework implementation files explaining 12 non-obvious workarounds that maintain behavioral parity with the PyArrow reference
- Add row-order preservation tests to 5 base test classes (rank, offset, binning, window_aggregation, frame_aggregate), running for all framework implementations automatically

### Documented quirks

| # | Framework | File | Quirk |
|---|-----------|------|-------|
| 1 | DuckDB | `binning/duckdb_binning.py` | ROW_NUMBER + .order() restores row order after NTILE reordering |
| 2 | DuckDB | `rank/duckdb_rank.py` | ROW_NUMBER + ORDER BY restores row order after window ORDER BY |
| 3 | DuckDB | `offset/duckdb_offset.py` | ROW_NUMBER + ORDER BY restores row order |
| 4 | DuckDB | `offset/duckdb_offset.py` | UNBOUNDED frame for first_value/last_value partition-wide visibility |
| 5 | DuckDB | `window_aggregation/duckdb_window_aggregation.py` | UNBOUNDED frame for FIRST_VALUE/LAST_VALUE |
| 6 | DuckDB | `frame_aggregate/duckdb_frame_aggregate.py` | ROW_NUMBER + .order() restores row order |
| 7 | Polars | `rank/polars_lazy_rank.py` | Manual NULLS_LAST: assigns integer ranks to nulls (Polars returns null) |
| 8 | Polars | `offset/polars_lazy_offset.py` | with_row_index + sort restores row order |
| 9 | Polars | `window_aggregation/polars_lazy_window_aggregation.py` | sum=0 correction for all-null groups |
| 10 | SQLite | `rank/sqlite_rank.py` | Boolean cast wrapper for top_N/bottom_N parity |
| 11 | Pandas | `frame_aggregate/pandas_frame_aggregate.py` | Mask applied after sort for unmasked sort order |
| 12 | Pandas | `window_aggregation/pandas_window_aggregation.py` | sort + sort_index restores row order for first/last |

## Test plan

- [x] All 1160 tests pass (143 skipped) with `PYTEST_WORKERS=1 uv run tox`
- [x] ruff format/check, mypy --strict, bandit all pass
- [x] 7 new row-order preservation tests added across 5 base classes
- [x] New tests verify output `value_int` column matches input order after each operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)