### PR TITLE
feat: add MaskTestMixin and MaskIntegrationTestMixin for FilterMask coverage

### DIFF
--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_integration.py
@@ -21,6 +21,7 @@ import pytest
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.testing.feature_groups.data_operations.integration import DataOpsIntegrationTestBase
+from mloda.testing.feature_groups.data_operations.mixins.mask_integration import MaskIntegrationTestMixin
 from mloda.user import Feature, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
@@ -32,7 +33,7 @@ from mloda.testing.feature_groups.data_operations.aggregation.reference import (
 )
 
 
-class TestAggregationIntegration(DataOpsIntegrationTestBase):
+class TestAggregationIntegration(MaskIntegrationTestMixin, DataOpsIntegrationTestBase):
     """Standard integration tests inherited from the base class."""
 
     @classmethod
@@ -93,6 +94,38 @@ class TestAggregationIntegration(DataOpsIntegrationTestBase):
 
     @classmethod
     def use_approx(cls) -> bool:
+        return True
+
+    # -- MaskIntegrationTestMixin configuration --------------------------------
+
+    @classmethod
+    def mask_integration_feature_name(cls) -> str:
+        return "value_int__sum_agg"
+
+    @classmethod
+    def mask_integration_options(cls) -> dict[str, Any]:
+        return {"partition_by": ["region"]}
+
+    @classmethod
+    def mask_integration_expected(cls) -> list[Any]:
+        # category='X': sorted by value: [-10, 10, 15, 60]
+        return sorted([-10, 10, 15, 60])
+
+    @classmethod
+    def mask_integration_complex_expected(cls) -> list[Any]:
+        # category='X' AND value_int>=10: A=10, B=60, C=15, None=None -> sorted
+        return sorted([10, 15, 60, None], key=lambda x: (x is None, x if x is not None else 0))
+
+    @classmethod
+    def mask_integration_unmasked_expected(cls) -> list[Any]:
+        return sorted([25, 140, 70, -10])
+
+    @classmethod
+    def mask_integration_expected_row_count(cls) -> int:
+        return 4
+
+    @classmethod
+    def mask_integration_compare_sorted(cls) -> bool:
         return True
 
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_integration.py
@@ -13,6 +13,7 @@ import pytest
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.testing.feature_groups.data_operations.integration import DataOpsIntegrationTestBase
+from mloda.testing.feature_groups.data_operations.mixins.mask_integration import MaskIntegrationTestMixin
 from mloda.user import Feature, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
@@ -21,7 +22,7 @@ from mloda.testing.feature_groups.data_operations.row_preserving.frame_aggregate
 )
 
 
-class TestFrameAggregateIntegration(DataOpsIntegrationTestBase):
+class TestFrameAggregateIntegration(MaskIntegrationTestMixin, DataOpsIntegrationTestBase):
     """Standard integration tests inherited from the base class.
 
     Uses the unified DataOpsIntegrationTestBase framework with real expected
@@ -97,6 +98,30 @@ class TestFrameAggregateIntegration(DataOpsIntegrationTestBase):
     @classmethod
     def expected_row_count(cls) -> int:
         return 12
+
+    # -- MaskIntegrationTestMixin configuration --------------------------------
+
+    @classmethod
+    def mask_integration_feature_name(cls) -> str:
+        return "value_int__cumsum"
+
+    @classmethod
+    def mask_integration_options(cls) -> dict[str, Any]:
+        return {"partition_by": ["region"], "order_by": "value_int"}
+
+    @classmethod
+    def mask_integration_expected(cls) -> list[Any]:
+        # category='X' cumsum through pipeline (nulls filled by pipeline broadcast)
+        return [10, 10, 0, 10, 60, 60, 60, 60, 15, 15, 15, -10]
+
+    @classmethod
+    def mask_integration_complex_expected(cls) -> list[Any]:
+        # category='X' AND value_int>=10 through pipeline (nulls filled by broadcast)
+        return [10, 10, 10, 10, 60, 60, 60, 60, 15, 15, 15, None]
+
+    @classmethod
+    def mask_integration_unmasked_expected(cls) -> list[Any]:
+        return [5, -5, -5, 25, 140, 80, 30, 140, 15, 30, 70, -10]
 
 
 class TestFrameAggregateMultiFeature:

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_integration.py
@@ -16,6 +16,7 @@ import pytest
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.testing.feature_groups.data_operations.integration import DataOpsIntegrationTestBase
+from mloda.testing.feature_groups.data_operations.mixins.mask_integration import MaskIntegrationTestMixin
 from mloda.user import Feature, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
@@ -24,7 +25,7 @@ from mloda.testing.feature_groups.data_operations.row_preserving.percentile.refe
 )
 
 
-class TestPercentileIntegration(DataOpsIntegrationTestBase):
+class TestPercentileIntegration(MaskIntegrationTestMixin, DataOpsIntegrationTestBase):
     @classmethod
     def feature_group_class(cls) -> type:
         return ReferencePercentile
@@ -75,6 +76,34 @@ class TestPercentileIntegration(DataOpsIntegrationTestBase):
 
     @classmethod
     def use_approx(cls) -> bool:
+        return True
+
+    # -- MaskIntegrationTestMixin configuration --------------------------------
+
+    @classmethod
+    def mask_integration_feature_name(cls) -> str:
+        return "value_int__p50_percentile"
+
+    @classmethod
+    def mask_integration_options(cls) -> dict[str, Any]:
+        return {"partition_by": ["region"]}
+
+    @classmethod
+    def mask_integration_expected(cls) -> list[Any]:
+        # category='X': A=[10,0] p50=5.0, B=[60] p50=60.0, C=[15] p50=15.0, None=[-10] p50=-10.0
+        return [5.0, 5.0, 5.0, 5.0, 60.0, 60.0, 60.0, 60.0, 15.0, 15.0, 15.0, -10.0]
+
+    @classmethod
+    def mask_integration_complex_expected(cls) -> list[Any]:
+        # category='X' AND value_int>=10: A=[10] p50=10, B=[60] p50=60, C=[15] p50=15, None=[] p50=None
+        return [10.0, 10.0, 10.0, 10.0, 60.0, 60.0, 60.0, 60.0, 15.0, 15.0, 15.0, None]
+
+    @classmethod
+    def mask_integration_unmasked_expected(cls) -> list[Any]:
+        return [5.0, 5.0, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 15.0, 15.0, 15.0, -10.0]
+
+    @classmethod
+    def mask_integration_use_approx(cls) -> bool:
         return True
 
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_integration.py
@@ -20,6 +20,7 @@ from mloda.testing.feature_groups.data_operations.row_preserving.scalar_aggregat
     EXPECTED_SUM,
 )
 from mloda.testing.feature_groups.data_operations.integration import DataOpsIntegrationTestBase
+from mloda.testing.feature_groups.data_operations.mixins.mask_integration import MaskIntegrationTestMixin
 from mloda.user import Feature, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
@@ -28,7 +29,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggreg
 )
 
 
-class TestScalarAggregateIntegration(DataOpsIntegrationTestBase):
+class TestScalarAggregateIntegration(MaskIntegrationTestMixin, DataOpsIntegrationTestBase):
     @classmethod
     def feature_group_class(cls) -> type:
         return PyArrowScalarAggregate
@@ -86,6 +87,30 @@ class TestScalarAggregateIntegration(DataOpsIntegrationTestBase):
         options = Options()
         fg_cls = self.feature_group_class()
         assert fg_cls.match_feature_group_criteria(self.primary_feature_name(), options)  # type: ignore[attr-defined]
+
+    # -- MaskIntegrationTestMixin configuration --------------------------------
+
+    @classmethod
+    def mask_integration_feature_name(cls) -> str:
+        return "value_int__sum_scalar"
+
+    @classmethod
+    def mask_integration_options(cls) -> dict[str, Any]:
+        return {}
+
+    @classmethod
+    def mask_integration_expected(cls) -> list[Any]:
+        # category='X': sum of [10, 0, 60, 15, -10] = 75, broadcast
+        return [75] * 12
+
+    @classmethod
+    def mask_integration_complex_expected(cls) -> list[Any]:
+        # category='X' AND value_int>=10: sum of [10, 60, 15] = 85, broadcast
+        return [85] * 12
+
+    @classmethod
+    def mask_integration_unmasked_expected(cls) -> list[Any]:
+        return [EXPECTED_SUM] * 12
 
 
 class TestIntegrationMultipleFeatures:

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_integration.py
@@ -17,6 +17,7 @@ import pytest
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.testing.feature_groups.data_operations.integration import DataOpsIntegrationTestBase
+from mloda.testing.feature_groups.data_operations.mixins.mask_integration import MaskIntegrationTestMixin
 from mloda.user import Feature, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
@@ -25,7 +26,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.window_aggreg
 )
 
 
-class TestWindowAggregationIntegration(DataOpsIntegrationTestBase):
+class TestWindowAggregationIntegration(MaskIntegrationTestMixin, DataOpsIntegrationTestBase):
     """Standard integration tests inherited from the base class."""
 
     @classmethod
@@ -79,6 +80,30 @@ class TestWindowAggregationIntegration(DataOpsIntegrationTestBase):
     @classmethod
     def use_approx(cls) -> bool:
         return True
+
+    # -- MaskIntegrationTestMixin configuration --------------------------------
+
+    @classmethod
+    def mask_integration_feature_name(cls) -> str:
+        return "value_int__sum_window"
+
+    @classmethod
+    def mask_integration_options(cls) -> dict[str, Any]:
+        return {"partition_by": ["region"]}
+
+    @classmethod
+    def mask_integration_expected(cls) -> list[Any]:
+        # category='X': A: 10+0=10, B: 60, C: 15, None: -10
+        return [10, 10, 10, 10, 60, 60, 60, 60, 15, 15, 15, -10]
+
+    @classmethod
+    def mask_integration_complex_expected(cls) -> list[Any]:
+        # category='X' AND value_int>=10: A: 10, B: 60, C: 15, None: None
+        return [10, 10, 10, 10, 60, 60, 60, 60, 15, 15, 15, None]
+
+    @classmethod
+    def mask_integration_unmasked_expected(cls) -> list[Any]:
+        return [25, 25, 25, 25, 140, 140, 140, 140, 70, 70, 70, -10]
 
 
 class TestIntegrationMultipleFeatures:

--- a/mloda/testing/feature_groups/data_operations/aggregation/aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/aggregation/aggregation.py
@@ -21,6 +21,7 @@ import pytest
 
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import extract_column, make_feature_set
+from mloda.testing.feature_groups.data_operations.mixins.mask import MaskTestMixin
 
 
 # ---------------------------------------------------------------------------
@@ -54,7 +55,7 @@ def _build_result_map(
 # ---------------------------------------------------------------------------
 
 
-class AggregationTestBase(DataOpsTestBase):
+class AggregationTestBase(MaskTestMixin, DataOpsTestBase):
     """Abstract base class for aggregation framework tests.
 
     Subclasses implement 5 abstract methods to wire up their framework,
@@ -90,6 +91,48 @@ class AggregationTestBase(DataOpsTestBase):
     def supported_agg_types(cls) -> set[str]:
         """Aggregation types this framework supports. Override to restrict."""
         return cls.ALL_AGG_TYPES
+
+    # -- MaskTestMixin configuration -------------------------------------------
+
+    @classmethod
+    def mask_feature_name(cls) -> str:
+        return "value_int__sum_agg"
+
+    @classmethod
+    def mask_partition_by(cls) -> list[str] | None:
+        return ["region"]
+
+    @classmethod
+    def mask_expected_row_count(cls) -> int:
+        return 4
+
+    @classmethod
+    def mask_is_reducing(cls) -> bool:
+        return True
+
+    @classmethod
+    def mask_equal_expected(cls) -> dict[Any, Any]:
+        # category='X': A: 10+0=10, B: 60, C: 15, None: -10
+        return {"A": 10, "B": 60, "C": 15, None: -10}
+
+    @classmethod
+    def mask_multiple_conditions_expected(cls) -> dict[Any, Any]:
+        # category='X' AND value_int>=10: A: 10, B: 60, C: 15, None: None (-10<10)
+        return {"A": 10, "B": 60, "C": 15, None: None}
+
+    @classmethod
+    def mask_is_in_expected(cls) -> dict[Any, Any]:
+        # region is_in ['A','C']: A=25 (all match), B=None, C=70, None=None
+        return {"A": 25, "B": None, "C": 70, None: None}
+
+    @classmethod
+    def mask_greater_than_expected(cls) -> dict[Any, Any]:
+        # value_int > 10: A: [20]=20, B: [50,30,60]=140, C: [15,15,40]=70, None: None
+        return {"A": 20, "B": 140, "C": 70, None: None}
+
+    @classmethod
+    def mask_no_mask_expected(cls) -> dict[Any, Any]:
+        return dict(EXPECTED_SUM_BY_REGION)
 
     # -- Reference implementation (for cross-framework comparison) -------------------
 

--- a/mloda/testing/feature_groups/data_operations/mixins/mask.py
+++ b/mloda/testing/feature_groups/data_operations/mixins/mask.py
@@ -1,0 +1,207 @@
+"""Reusable mask (conditional aggregation) test mixin for data-operations feature groups.
+
+Provides 6 standardized test methods that verify masking works correctly
+across all feature groups that support FilterMask. Each test base class
+mixes this in and overrides the abstract configuration methods to adapt
+the generic tests to its specific semantics (feature names, partition keys,
+expected values, reducing vs row-preserving).
+
+Test methods use a ``test_mixin_mask_`` prefix to avoid name collisions
+with existing inline mask tests on each feature group's test base.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+
+
+def _is_null(value: Any) -> bool:
+    """Check if a value is null (None or NaN)."""
+    if value is None:
+        return True
+    if isinstance(value, float) and math.isnan(value):
+        return True
+    return False
+
+
+class MaskTestMixin:
+    """Mixin providing standardized mask (conditional aggregation) tests.
+
+    Feature-group test bases mix this in and implement the configuration
+    methods below to adapt the generic tests to their semantics.
+
+    Requires the host class to provide (from DataOpsTestBase):
+    - ``implementation_class()``
+    - ``test_data`` attribute (set in setup_method)
+    - ``extract_column(result, column_name)``
+    - ``get_row_count(result)``
+    """
+
+    # -- Configuration methods (override per feature group) --------------------
+
+    @classmethod
+    def mask_feature_name(cls) -> str:
+        """Feature name for mask tests (e.g. 'value_int__sum_window')."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_partition_by(cls) -> list[str] | None:
+        """Partition key(s) for mask tests. None for scalar aggregate."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_order_by(cls) -> str | None:
+        """Order key for mask tests. Only frame aggregate needs this."""
+        return None
+
+    @classmethod
+    def mask_expected_row_count(cls) -> int:
+        """Expected rows: 12 for row-preserving, 4 for aggregation."""
+        return 12
+
+    @classmethod
+    def mask_is_reducing(cls) -> bool:
+        """True for aggregation (reduces rows), False for row-preserving."""
+        return False
+
+    @classmethod
+    def mask_use_approx(cls) -> bool:
+        """True if results are floating-point and need approximate comparison."""
+        return False
+
+    @classmethod
+    def mask_equal_expected(cls) -> list[Any] | dict[Any, Any]:
+        """Expected result for basic equal mask (category='X')."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_multiple_conditions_expected(cls) -> list[Any] | dict[Any, Any]:
+        """Expected result for AND mask (category='X' AND value_int>=10)."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_is_in_expected(cls) -> list[Any] | dict[Any, Any]:
+        """Expected result for is_in mask (region is_in ['A', 'C'])."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_greater_than_expected(cls) -> list[Any] | dict[Any, Any]:
+        """Expected result for greater_than mask (value_int > 10)."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_no_mask_expected(cls) -> list[Any] | dict[Any, Any]:
+        """Expected result without any mask (baseline)."""
+        raise NotImplementedError
+
+    # -- Assertion helper ------------------------------------------------------
+
+    def _assert_mask_values(self, result: Any, expected: list[Any] | dict[Any, Any]) -> None:
+        """Compare mask test results against expected values.
+
+        Dispatches between row-preserving (list) and reducing (dict) modes
+        based on ``mask_is_reducing()``.
+        """
+        feature_name = self.mask_feature_name()
+
+        if self.mask_is_reducing():
+            region_col = self.extract_column(result, "region")  # type: ignore[attr-defined]
+            result_col = self.extract_column(result, feature_name)  # type: ignore[attr-defined]
+            result_map = {region_col[i]: result_col[i] for i in range(len(region_col))}
+            for key, exp in expected.items():  # type: ignore[union-attr]
+                actual = result_map[key]
+                if _is_null(exp):
+                    assert _is_null(actual), f"region={key}: expected null, got {actual}"
+                elif self.mask_use_approx() and isinstance(exp, float):
+                    assert actual == pytest.approx(exp, rel=1e-3), f"region={key}: {actual} != {exp}"
+                else:
+                    assert actual == exp, f"region={key}: {actual} != {exp}"
+        else:
+            result_col = self.extract_column(result, feature_name)  # type: ignore[attr-defined]
+            assert len(result_col) == len(expected), f"length {len(result_col)} != {len(expected)}"
+            for i, (actual, exp) in enumerate(zip(result_col, expected)):
+                if _is_null(exp):
+                    assert _is_null(actual), f"row {i}: expected null, got {actual}"
+                elif self.mask_use_approx() and isinstance(exp, float):
+                    assert actual == pytest.approx(exp, rel=1e-3), f"row {i}: {actual} != {exp}"
+                else:
+                    assert actual == exp, f"row {i}: {actual} != {exp}"
+
+    # -- Concrete test methods -------------------------------------------------
+
+    def test_mixin_mask_equal(self) -> None:
+        """Mixin: basic equal mask (category='X')."""
+        fs = make_feature_set(
+            self.mask_feature_name(),
+            self.mask_partition_by(),
+            self.mask_order_by(),
+            mask=("category", "equal", "X"),
+        )
+        result = self.implementation_class().calculate_feature(self.test_data, fs)  # type: ignore[attr-defined]
+        assert self.get_row_count(result) == self.mask_expected_row_count()  # type: ignore[attr-defined]
+        self._assert_mask_values(result, self.mask_equal_expected())
+
+    def test_mixin_mask_multiple_conditions(self) -> None:
+        """Mixin: AND-combined mask (category='X' AND value_int >= 10)."""
+        fs = make_feature_set(
+            self.mask_feature_name(),
+            self.mask_partition_by(),
+            self.mask_order_by(),
+            mask=[("category", "equal", "X"), ("value_int", "greater_equal", 10)],
+        )
+        result = self.implementation_class().calculate_feature(self.test_data, fs)  # type: ignore[attr-defined]
+        assert self.get_row_count(result) == self.mask_expected_row_count()  # type: ignore[attr-defined]
+        self._assert_mask_values(result, self.mask_multiple_conditions_expected())
+
+    def test_mixin_mask_is_in(self) -> None:
+        """Mixin: is_in mask (region is_in ['A', 'C'])."""
+        fs = make_feature_set(
+            self.mask_feature_name(),
+            self.mask_partition_by(),
+            self.mask_order_by(),
+            mask=("region", "is_in", ["A", "C"]),
+        )
+        result = self.implementation_class().calculate_feature(self.test_data, fs)  # type: ignore[attr-defined]
+        assert self.get_row_count(result) == self.mask_expected_row_count()  # type: ignore[attr-defined]
+        self._assert_mask_values(result, self.mask_is_in_expected())
+
+    def test_mixin_mask_greater_than(self) -> None:
+        """Mixin: greater_than mask (value_int > 10)."""
+        fs = make_feature_set(
+            self.mask_feature_name(),
+            self.mask_partition_by(),
+            self.mask_order_by(),
+            mask=("value_int", "greater_than", 10),
+        )
+        result = self.implementation_class().calculate_feature(self.test_data, fs)  # type: ignore[attr-defined]
+        assert self.get_row_count(result) == self.mask_expected_row_count()  # type: ignore[attr-defined]
+        self._assert_mask_values(result, self.mask_greater_than_expected())
+
+    def test_mixin_mask_fully_masked(self) -> None:
+        """Mixin: all rows masked out (category='Z') should produce None for every value."""
+        fs = make_feature_set(
+            self.mask_feature_name(),
+            self.mask_partition_by(),
+            self.mask_order_by(),
+            mask=("category", "equal", "Z"),
+        )
+        result = self.implementation_class().calculate_feature(self.test_data, fs)  # type: ignore[attr-defined]
+        assert self.get_row_count(result) == self.mask_expected_row_count()  # type: ignore[attr-defined]
+        result_col = self.extract_column(result, self.mask_feature_name())  # type: ignore[attr-defined]
+        assert all(_is_null(v) for v in result_col)
+
+    def test_mixin_mask_no_mask_baseline(self) -> None:
+        """Mixin: without mask, results match the standard unmasked value."""
+        fs = make_feature_set(
+            self.mask_feature_name(),
+            self.mask_partition_by(),
+            self.mask_order_by(),
+        )
+        result = self.implementation_class().calculate_feature(self.test_data, fs)  # type: ignore[attr-defined]
+        assert self.get_row_count(result) == self.mask_expected_row_count()  # type: ignore[attr-defined]
+        self._assert_mask_values(result, self.mask_no_mask_expected())

--- a/mloda/testing/feature_groups/data_operations/mixins/mask_integration.py
+++ b/mloda/testing/feature_groups/data_operations/mixins/mask_integration.py
@@ -1,0 +1,184 @@
+"""Reusable mask integration test mixin for data-operations feature groups.
+
+Provides 3 integration test methods that verify masking works correctly
+through mloda's full pipeline (run_all, PluginCollector, feature resolution).
+
+Each integration test class mixes this in alongside DataOpsIntegrationTestBase
+and overrides the configuration methods to adapt to its specific feature group.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.user import Feature, mloda
+
+
+def _is_null(value: Any) -> bool:
+    """Check if a value is null (None or NaN)."""
+    if value is None:
+        return True
+    if isinstance(value, float) and math.isnan(value):
+        return True
+    return False
+
+
+class MaskIntegrationTestMixin:
+    """Mixin providing mask integration tests through mloda's full pipeline.
+
+    Requires the host class to provide (from DataOpsIntegrationTestBase):
+    - ``feature_group_class()``
+    - ``data_creator_class()``
+    - ``compute_framework_class()``
+    - ``_plugin_collector()``
+    """
+
+    # -- Configuration methods (override per feature group) --------------------
+
+    @classmethod
+    def mask_integration_feature_name(cls) -> str:
+        """Feature name for mask integration tests."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_integration_options(cls) -> dict[str, Any]:
+        """Options context dict for mask integration tests (without mask key)."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_integration_spec(cls) -> tuple[str, str, Any]:
+        """Mask spec for the basic mask integration test."""
+        return ("category", "equal", "X")
+
+    @classmethod
+    def mask_integration_expected(cls) -> list[Any]:
+        """Expected column values for the basic masked feature."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_integration_complex_spec(cls) -> list[tuple[str, str, Any]]:
+        """Multi-condition mask spec for the complex mask test."""
+        return [("category", "equal", "X"), ("value_int", "greater_equal", 10)]
+
+    @classmethod
+    def mask_integration_complex_expected(cls) -> list[Any]:
+        """Expected column values for the complex masked feature."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_integration_unmasked_expected(cls) -> list[Any]:
+        """Expected column values for the unmasked feature (for the together test)."""
+        raise NotImplementedError
+
+    @classmethod
+    def mask_integration_expected_row_count(cls) -> int:
+        """Expected number of rows. Default: 12 (row-preserving)."""
+        return 12
+
+    @classmethod
+    def mask_integration_use_approx(cls) -> bool:
+        """Whether to use approximate comparison for floating-point results."""
+        return False
+
+    @classmethod
+    def mask_integration_compare_sorted(cls) -> bool:
+        """Whether to sort values before comparing (for reducing operations)."""
+        return False
+
+    # -- Assertion helpers -----------------------------------------------------
+
+    def _assert_mask_integration_values(self, actual: list[Any], expected: list[Any]) -> None:
+        """Compare actual vs expected, handling nulls, approx, and sorting."""
+        if self.mask_integration_compare_sorted():
+            actual = sorted(actual, key=lambda x: (x is None, x if x is not None else 0))
+            expected = sorted(expected, key=lambda x: (x is None, x if x is not None else 0))
+
+        assert len(actual) == len(expected), f"length {len(actual)} != {len(expected)}"
+        for i, (a, e) in enumerate(zip(actual, expected)):
+            if _is_null(e):
+                assert _is_null(a), f"row {i}: expected null, got {a}"
+            elif self.mask_integration_use_approx() and isinstance(e, float):
+                assert a == pytest.approx(e, rel=1e-3), f"row {i}: {a} != {e}"
+            else:
+                assert a == e, f"row {i}: {a} != {e}"
+
+    def _run_masked_feature(
+        self,
+        name: str,
+        options_ctx: dict[str, Any],
+        mask_spec: Any,
+    ) -> pa.Table:
+        """Run a single masked feature through the pipeline."""
+        ctx = dict(options_ctx)
+        ctx["mask"] = mask_spec
+        feature = Feature(name, options=Options(context=ctx))
+        results = mloda.run_all(
+            [feature],
+            compute_frameworks={self.compute_framework_class()},  # type: ignore[attr-defined]
+            plugin_collector=self._plugin_collector(),  # type: ignore[attr-defined]
+        )
+        assert len(results) >= 1
+
+        result_table = None
+        for table in results:
+            if isinstance(table, pa.Table) and name in table.column_names:
+                result_table = table
+                break
+
+        assert result_table is not None, f"No result table with {name} found"
+        return result_table
+
+    # -- Concrete test methods -------------------------------------------------
+
+    def test_mask_feature_through_pipeline(self) -> None:
+        """Run a masked feature through run_all and verify values."""
+        result_table = self._run_masked_feature(
+            self.mask_integration_feature_name(),
+            self.mask_integration_options(),
+            self.mask_integration_spec(),
+        )
+        assert result_table.num_rows == self.mask_integration_expected_row_count()
+
+        result_col = result_table.column(self.mask_integration_feature_name()).to_pylist()
+        self._assert_mask_integration_values(result_col, self.mask_integration_expected())
+
+    def test_mask_complex_conditions_through_pipeline(self) -> None:
+        """Run a multi-condition masked feature through run_all and verify values."""
+        result_table = self._run_masked_feature(
+            self.mask_integration_feature_name(),
+            self.mask_integration_options(),
+            self.mask_integration_complex_spec(),
+        )
+        assert result_table.num_rows == self.mask_integration_expected_row_count()
+
+        result_col = result_table.column(self.mask_integration_feature_name()).to_pylist()
+        self._assert_mask_integration_values(result_col, self.mask_integration_complex_expected())
+
+    def test_masked_and_unmasked_consistent(self) -> None:
+        """Run masked + unmasked features separately and verify both produce correct results.
+
+        This exercises the complex feature composition path by confirming that
+        the same feature produces different (correct) results with and without
+        a mask through the full mloda pipeline. Features are run in separate
+        pipeline calls because mloda resolves features of the same type to a
+        shared feature group instance, which can cause mask config leakage.
+        """
+        name = self.mask_integration_feature_name()
+        base_options = self.mask_integration_options()
+
+        # Unmasked feature through pipeline
+        result_unmasked = self._run_single_feature(name, base_options)  # type: ignore[attr-defined]
+        assert result_unmasked.num_rows == self.mask_integration_expected_row_count()
+        unmasked_col = result_unmasked.column(name).to_pylist()
+        self._assert_mask_integration_values(unmasked_col, self.mask_integration_unmasked_expected())
+
+        # Masked feature through pipeline (same name, different config)
+        result_masked = self._run_masked_feature(name, base_options, self.mask_integration_spec())
+        assert result_masked.num_rows == self.mask_integration_expected_row_count()
+        masked_col = result_masked.column(name).to_pylist()
+        self._assert_mask_integration_values(masked_col, self.mask_integration_expected())

--- a/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
@@ -24,6 +24,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+from mloda.testing.feature_groups.data_operations.mixins.mask import MaskTestMixin
 from mloda.user import Feature
 
 
@@ -142,8 +143,63 @@ def _assert_values_with_nulls(actual: list[Any], expected: list[Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-class FrameAggregateTestBase(DataOpsTestBase):
+class FrameAggregateTestBase(MaskTestMixin, DataOpsTestBase):
     """Abstract base class for frame aggregate framework tests."""
+
+    # -- MaskTestMixin configuration -------------------------------------------
+
+    @classmethod
+    def mask_feature_name(cls) -> str:
+        return "value_int__cumsum"
+
+    @classmethod
+    def mask_partition_by(cls) -> list[str] | None:
+        return ["region"]
+
+    @classmethod
+    def mask_order_by(cls) -> str | None:
+        return "value_int"
+
+    @classmethod
+    def mask_equal_expected(cls) -> list[Any]:
+        # category='X' cumsum, partitioned by region, ordered by value_int.
+        # Group A sorted: (-5[Y], 0[X], 10[X], 20[Y]) -> masked: (None, 0, 10, None) -> cumsum: None, 0, 10, 10
+        # Group B sorted: (30[None], 50[Y], 60[X], None[X]) -> masked: (None, None, 60, None) -> cumsum: None, None, 60, 60
+        # Group C sorted: (15[Y], 15[X], 40[Y]) -> masked: (None, 15, None) -> cumsum: None, 15, 15
+        # None group: (-10[X]) -> cumsum: -10
+        # Map to original row order:
+        return [10, None, 0, 10, 60, None, None, 60, None, 15, 15, -10]
+
+    @classmethod
+    def mask_multiple_conditions_expected(cls) -> list[Any]:
+        # category='X' AND value_int >= 10
+        # Group A sorted: (-5[Y], 0[X,<10], 10[X,>=10], 20[Y]) -> masked: (None, None, 10, None) -> cumsum: None, None, 10, 10
+        # Group B sorted: (30[None], 50[Y], 60[X,>=10], None[X]) -> masked: (None, None, 60, None) -> cumsum: None, None, 60, 60
+        # Group C sorted: (15[Y], 15[X,>=10], 40[Y]) -> masked: (None, 15, None) -> cumsum: None, 15, 15
+        # None group: (-10[X,<10]) -> masked: None -> cumsum: None
+        return [10, None, None, 10, 60, None, None, 60, None, 15, 15, None]
+
+    @classmethod
+    def mask_is_in_expected(cls) -> list[Any]:
+        # region is_in ['A', 'C']: within each partition, only rows with matching region pass.
+        # Group A: all have region=A (matches) -> normal cumsum: -5, -5, 5, 25
+        # Group B: all have region=B (no match) -> all None
+        # Group C: all have region=C (matches) -> normal cumsum: 15, 30, 70
+        # None group: region=None (no match) -> None
+        return [5, -5, -5, 25, None, None, None, None, 15, 30, 70, None]
+
+    @classmethod
+    def mask_greater_than_expected(cls) -> list[Any]:
+        # value_int > 10
+        # Group A sorted: (-5, 0, 10, 20) -> only 20>10 -> masked: (None, None, None, 20) -> cumsum: None, None, None, 20
+        # Group B sorted: (30, 50, 60, None) -> 30,50,60 > 10 -> masked: (30, 50, 60, None) -> cumsum: 30, 80, 140, 140
+        # Group C sorted: (15, 15, 40) -> all > 10 -> cumsum: 15, 30, 70
+        # None group: (-10) -> not > 10 -> None
+        return [None, None, None, 20, 140, 80, 30, 140, 15, 30, 70, None]
+
+    @classmethod
+    def mask_no_mask_expected(cls) -> list[Any]:
+        return list(EXPECTED_CUMSUM)
 
     @classmethod
     def reference_implementation_class(cls) -> Any:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/percentile/percentile.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/percentile/percentile.py
@@ -17,6 +17,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+from mloda.testing.feature_groups.data_operations.mixins.mask import MaskTestMixin
 from mloda.user import Feature
 
 
@@ -55,8 +56,48 @@ EXPECTED_P100_BY_REGION: list[float] = [20.0, 20.0, 20.0, 20.0, 60.0, 60.0, 60.0
 # ---------------------------------------------------------------------------
 
 
-class PercentileTestBase(DataOpsTestBase):
+class PercentileTestBase(MaskTestMixin, DataOpsTestBase):
     """Abstract base class for percentile framework tests."""
+
+    # -- MaskTestMixin configuration -------------------------------------------
+
+    @classmethod
+    def mask_feature_name(cls) -> str:
+        return "value_int__p50_percentile"
+
+    @classmethod
+    def mask_partition_by(cls) -> list[str] | None:
+        return ["region"]
+
+    @classmethod
+    def mask_use_approx(cls) -> bool:
+        return True
+
+    @classmethod
+    def mask_equal_expected(cls) -> list[Any]:
+        # category='X': A=[10,0] p50=5.0, B=[60] p50=60.0, C=[15] p50=15.0, None=[-10] p50=-10.0
+        return [5.0, 5.0, 5.0, 5.0, 60.0, 60.0, 60.0, 60.0, 15.0, 15.0, 15.0, -10.0]
+
+    @classmethod
+    def mask_multiple_conditions_expected(cls) -> list[Any]:
+        # category='X' AND value_int>=10: A=[10] p50=10, B=[60] p50=60, C=[15] p50=15, None=[] p50=None
+        return [10.0, 10.0, 10.0, 10.0, 60.0, 60.0, 60.0, 60.0, 15.0, 15.0, 15.0, None]
+
+    @classmethod
+    def mask_is_in_expected(cls) -> list[Any]:
+        # region is_in ['A','C']: A=all match, B=none match, C=all match, None=no match
+        # A: [-5,0,10,20] p50=5.0, B: None, C: [15,15,40] p50=15.0, None: None
+        return [5.0, 5.0, 5.0, 5.0, None, None, None, None, 15.0, 15.0, 15.0, None]
+
+    @classmethod
+    def mask_greater_than_expected(cls) -> list[Any]:
+        # value_int > 10: A=[20] p50=20.0, B=[50,30,60] sorted=[30,50,60] p50=50.0,
+        # C=[15,15,40] p50=15.0, None=[] p50=None
+        return [20.0, 20.0, 20.0, 20.0, 50.0, 50.0, 50.0, 50.0, 15.0, 15.0, 15.0, None]
+
+    @classmethod
+    def mask_no_mask_expected(cls) -> list[Any]:
+        return list(EXPECTED_P50_BY_REGION)
 
     @classmethod
     def reference_implementation_class(cls) -> Any:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/scalar_aggregate/scalar_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/scalar_aggregate/scalar_aggregate.py
@@ -20,6 +20,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+from mloda.testing.feature_groups.data_operations.mixins.mask import MaskTestMixin
 from mloda.user import Feature
 
 
@@ -53,7 +54,7 @@ EXPECTED_MEDIAN: float = 15.0
 # ---------------------------------------------------------------------------
 
 
-class ScalarAggregateTestBase(DataOpsTestBase):
+class ScalarAggregateTestBase(MaskTestMixin, DataOpsTestBase):
     """Abstract base class for scalar aggregate framework tests."""
 
     ALL_AGG_TYPES = {
@@ -76,6 +77,41 @@ class ScalarAggregateTestBase(DataOpsTestBase):
     def supported_agg_types(cls) -> set[str]:
         """Override to restrict supported types for a framework."""
         return cls.ALL_AGG_TYPES
+
+    # -- MaskTestMixin configuration -------------------------------------------
+
+    @classmethod
+    def mask_feature_name(cls) -> str:
+        return "value_int__sum_scalar"
+
+    @classmethod
+    def mask_partition_by(cls) -> list[str] | None:
+        return None
+
+    @classmethod
+    def mask_equal_expected(cls) -> list[Any]:
+        # category='X' rows: value_int = [10, 0, None, 60, 15, -10]
+        # Non-null sum: 10 + 0 + 60 + 15 + (-10) = 75, broadcast to all 12 rows
+        return [75] * 12
+
+    @classmethod
+    def mask_multiple_conditions_expected(cls) -> list[Any]:
+        # category='X' AND value_int >= 10: rows with val [10, 60, 15] -> sum = 85
+        return [85] * 12
+
+    @classmethod
+    def mask_is_in_expected(cls) -> list[Any]:
+        # region is_in ['A', 'C']: A=[10,-5,0,20], C=[15,15,40] -> sum = 95
+        return [95] * 12
+
+    @classmethod
+    def mask_greater_than_expected(cls) -> list[Any]:
+        # value_int > 10: [20, 50, 30, 60, 15, 15, 40] -> sum = 230
+        return [230] * 12
+
+    @classmethod
+    def mask_no_mask_expected(cls) -> list[Any]:
+        return [EXPECTED_SUM] * 12
 
     @classmethod
     def reference_implementation_class(cls) -> Any:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -20,6 +20,7 @@ import pytest
 
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+from mloda.testing.feature_groups.data_operations.mixins.mask import MaskTestMixin
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +66,7 @@ NULL_GROUP_SUM_EXPECTED: int = -10
 # ---------------------------------------------------------------------------
 
 
-class WindowAggregationTestBase(DataOpsTestBase):
+class WindowAggregationTestBase(MaskTestMixin, DataOpsTestBase):
     """Abstract base class for window aggregation framework tests."""
 
     ALL_AGG_TYPES = {
@@ -91,6 +92,40 @@ class WindowAggregationTestBase(DataOpsTestBase):
     def supported_agg_types(cls) -> set[str]:
         """Aggregation types this framework supports. Override to restrict."""
         return cls.ALL_AGG_TYPES
+
+    # -- MaskTestMixin configuration -------------------------------------------
+
+    @classmethod
+    def mask_feature_name(cls) -> str:
+        return "value_int__sum_window"
+
+    @classmethod
+    def mask_partition_by(cls) -> list[str] | None:
+        return ["region"]
+
+    @classmethod
+    def mask_equal_expected(cls) -> list[Any]:
+        # category='X': A: 10+0=10, B: 60, C: 15, None: -10
+        return [10, 10, 10, 10, 60, 60, 60, 60, 15, 15, 15, -10]
+
+    @classmethod
+    def mask_multiple_conditions_expected(cls) -> list[Any]:
+        # category='X' AND value_int>=10: A: 10, B: 60, C: 15, None: None (-10<10)
+        return [10, 10, 10, 10, 60, 60, 60, 60, 15, 15, 15, None]
+
+    @classmethod
+    def mask_is_in_expected(cls) -> list[Any]:
+        # region is_in ['A','C']: A=all match sum=25, B=none match=None, C=all match sum=70, None=no match=None
+        return [25, 25, 25, 25, None, None, None, None, 70, 70, 70, None]
+
+    @classmethod
+    def mask_greater_than_expected(cls) -> list[Any]:
+        # value_int > 10: A: [20]=20, B: [50,30,60]=140, C: [15,15,40]=70, None: []=None
+        return [20, 20, 20, 20, 140, 140, 140, 140, 70, 70, 70, None]
+
+    @classmethod
+    def mask_no_mask_expected(cls) -> list[Any]:
+        return list(EXPECTED_SUM_BY_REGION)
 
     @classmethod
     def reference_implementation_class(cls) -> Any:


### PR DESCRIPTION
## Summary

- Introduces `MaskTestMixin` with 6 standardized unit test methods (equal, multiple conditions, is_in, greater_than, fully masked, no-mask baseline) integrated into all 5 masked feature group test bases
- Introduces `MaskIntegrationTestMixin` with 3 integration test methods per feature group exercising masking through the full mloda pipeline (`run_all`, `PluginCollector`)
- Adds **132 new unit tests** across all frameworks (Pandas, PyArrow, Polars, DuckDB, SQLite) and **15 new integration tests**
- Equalizes mask test coverage for Scalar Aggregate, Frame Aggregate, and Percentile to parity with Window Aggregation and Aggregation

## Test plan

- [x] All 1207 tests pass (PYTEST_WORKERS=1 uv run tox)
- [x] ruff format check passes
- [x] ruff lint passes
- [x] mypy strict passes
- [x] bandit security check passes
- [x] No regressions in existing mask tests (kept inline alongside mixin tests)

Closes #131