### PR TITLE
fix: add pandas, polars, duckdb to dev dependencies (#135)

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_pandas.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_pandas.py
@@ -8,8 +8,6 @@ import pytest
 
 pytest.importorskip("pandas")
 
-import pandas as pd
-
 from mloda.community.feature_groups.data_operations.row_preserving.binning.pandas_binning import (
     PandasBinning,
 )
@@ -25,7 +23,3 @@ class TestPandasBinning(PandasTestMixin, BinningTestBase):
     @classmethod
     def implementation_class(cls) -> Any:
         return PandasBinning
-
-    def extract_column(self, result: Any, column_name: str) -> list[Any]:
-        series = result[column_name]
-        return [None if pd.isna(v) else int(v) for v in series.tolist()]

--- a/mloda/testing/feature_groups/data_operations/mixins/polars_lazy.py
+++ b/mloda/testing/feature_groups/data_operations/mixins/polars_lazy.py
@@ -17,7 +17,9 @@ class PolarsLazyTestMixin:
     def create_test_data(self, arrow_table: pa.Table) -> Any:
         import polars as pl
 
-        return pl.from_arrow(arrow_table).lazy()
+        df = pl.from_arrow(arrow_table)
+        assert isinstance(df, pl.DataFrame)
+        return df.lazy()
 
     def extract_column(self, result: Any, column_name: str) -> list[Any]:
         collected = result.collect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dev = [
     "tomli",
     "python-dateutil",
     "types-python-dateutil",
+    "pandas",
+    "polars",
+    "duckdb",
 ]
 
 [tool.ruff]

--- a/tests/test_required_deps.py
+++ b/tests/test_required_deps.py
@@ -1,0 +1,35 @@
+"""Verify that compute-framework packages required for testing are installed.
+
+This prevents silent test skipping where pytest.importorskip() causes entire
+test modules to be collected but skipped without any CI failure signal.
+See: https://github.com/mloda-ai/mloda-registry/issues/135
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+REQUIRED_TEST_PACKAGES = [
+    "pandas",
+    "polars",
+    "duckdb",
+]
+
+
+@pytest.mark.parametrize("package", REQUIRED_TEST_PACKAGES)
+def test_required_test_dependency_installed(package: str) -> None:
+    """Each compute-framework package used in tests must be importable.
+
+    If this test fails, the package is missing from the dev dependencies
+    in the root pyproject.toml. Add it to [project.optional-dependencies] dev.
+    """
+    try:
+        importlib.import_module(package)
+    except ImportError:
+        pytest.fail(
+            f"Required test dependency '{package}' is not installed. "
+            f"Add it to [project.optional-dependencies] dev in pyproject.toml."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-02T10:41:21.149562169Z"
+exclude-newer = "2026-04-04T13:44:35.971174151Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -951,7 +951,11 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "duckdb" },
     { name = "mypy" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "polars" },
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "python-dateutil" },
@@ -965,8 +969,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
+    { name = "duckdb", marker = "extra == 'dev'" },
     { name = "mloda", specifier = ">=0.6.1" },
     { name = "mypy", marker = "extra == 'dev'" },
+    { name = "pandas", marker = "extra == 'dev'" },
+    { name = "polars", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-dateutil", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary

- Adds `pandas`, `polars`, and `duckdb` to the root `[project.optional-dependencies] dev` section in `pyproject.toml` so tox installs them and their test files actually execute in CI instead of being silently skipped via `pytest.importorskip()`
- Adds `tests/test_required_deps.py` as a regression guard: a parametrized test that fails explicitly if any required compute-framework package is missing, preventing future silent skipping
- Removes a broken `extract_column` override in the pandas binning test that called `int()` on string column values (a latent bug exposed by pandas tests now running)
- Fixes a pre-existing mypy error in `PolarsLazyTestMixin.create_test_data` by adding a type-narrowing assertion

Closes #135

## Test plan

- [x] `tests/test_required_deps.py` passes (3 parametrized cases: pandas, polars, duckdb)
- [x] Previously-skipped pandas tests now run and pass (e.g. 70 tests in `test_pandas.py` for aggregation)
- [x] Full `tox -e python310` passes: 2455 passed, 109 skipped, ruff/mypy/bandit all green