### PR TITLE
fix: add polars, pandas, duckdb to dev dependencies so framework tests run

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_pandas.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_pandas.py
@@ -8,8 +8,6 @@ import pytest
 
 pytest.importorskip("pandas")
 
-import pandas as pd
-
 from mloda.community.feature_groups.data_operations.row_preserving.binning.pandas_binning import (
     PandasBinning,
 )
@@ -25,7 +23,3 @@ class TestPandasBinning(PandasTestMixin, BinningTestBase):
     @classmethod
     def implementation_class(cls) -> Any:
         return PandasBinning
-
-    def extract_column(self, result: Any, column_name: str) -> list[Any]:
-        series = result[column_name]
-        return [None if pd.isna(v) else int(v) for v in series.tolist()]

--- a/mloda/testing/feature_groups/data_operations/mixins/polars_lazy.py
+++ b/mloda/testing/feature_groups/data_operations/mixins/polars_lazy.py
@@ -17,7 +17,9 @@ class PolarsLazyTestMixin:
     def create_test_data(self, arrow_table: pa.Table) -> Any:
         import polars as pl
 
-        return pl.from_arrow(arrow_table).lazy()
+        df = pl.from_arrow(arrow_table)
+        assert isinstance(df, pl.DataFrame)
+        return df.lazy()
 
     def extract_column(self, result: Any, column_name: str) -> list[Any]:
         collected = result.collect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dev = [
     "tomli",
     "python-dateutil",
     "types-python-dateutil",
+    "polars",
+    "pandas",
+    "duckdb",
 ]
 
 [tool.ruff]

--- a/tests/test_framework_imports.py
+++ b/tests/test_framework_imports.py
@@ -1,0 +1,28 @@
+"""Verify that compute-framework packages required by tests are installed.
+
+These tests fail loudly (instead of silently skipping) when a framework
+dependency is missing from the dev extras in the root pyproject.toml.
+See: https://github.com/mloda-ai/mloda-registry/issues/136
+"""
+
+from __future__ import annotations
+
+
+def test_polars_importable() -> None:
+    """polars must be installed in the test environment."""
+    import polars  # noqa: F401
+
+
+def test_pandas_importable() -> None:
+    """pandas must be installed in the test environment."""
+    import pandas  # noqa: F401
+
+
+def test_duckdb_importable() -> None:
+    """duckdb must be installed in the test environment."""
+    import duckdb  # noqa: F401
+
+
+def test_pyarrow_importable() -> None:
+    """pyarrow must be installed in the test environment (via mloda)."""
+    import pyarrow  # noqa: F401

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-02T10:41:21.149562169Z"
+exclude-newer = "2026-04-04T13:48:04.922616482Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -951,7 +951,11 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "duckdb" },
     { name = "mypy" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "polars" },
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "python-dateutil" },
@@ -965,8 +969,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
+    { name = "duckdb", marker = "extra == 'dev'" },
     { name = "mloda", specifier = ">=0.6.1" },
     { name = "mypy", marker = "extra == 'dev'" },
+    { name = "pandas", marker = "extra == 'dev'" },
+    { name = "polars", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-dateutil", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary

- Add `polars`, `pandas`, and `duckdb` to root `pyproject.toml` dev dependencies so framework tests actually run in CI instead of being silently skipped via `pytest.importorskip`
- Add `tests/test_framework_imports.py` regression test that fails loudly if any framework dependency is missing
- Fix pre-existing bugs exposed by newly-running tests:
  - Remove buggy `extract_column` override in pandas binning test that crashed on non-integer columns
  - Narrow `pl.from_arrow()` return type in `PolarsLazyTestMixin` to satisfy mypy

## Test plan

- [x] `tests/test_framework_imports.py` verifies polars, pandas, duckdb, pyarrow are importable
- [x] All 10 `test_polars_lazy.py` files now execute (previously silently skipped)
- [x] Full tox suite passes: 2456 passed, 109 skipped
- [x] ruff format/check, mypy --strict, bandit all pass

Closes #136