### PR TITLE
docs: add data operation patterns guides (closes #121)

### DIFF
--- a/docs/guides/data-operation-patterns/01-overview.md
+++ b/docs/guides/data-operation-patterns/01-overview.md
@@ -1,0 +1,78 @@
+# Overview
+
+Data operations are feature groups that transform existing columns using declarative feature names. They ship in `mloda.community` and run unchanged across every supported compute framework.
+
+**What**: Three categories of built-in feature groups: row-preserving analytics, row-reducing aggregations, and element-wise string transforms.
+**When**: You want common analytic transforms (binning, windows, rolling aggregates, group-bys, string cleanup) without writing a custom feature group.
+**Why**: A single feature name like `value_int__sum_agg` produces the same result on PyArrow, Pandas, Polars, DuckDB, and SQLite. Users pick the framework; the operation contract is identical.
+**Where**: `mloda/community/feature_groups/data_operations/{row_preserving,aggregation,string}/`.
+**How**: Request the operation as a feature (e.g. `value_int__p95_percentile`), pass any extra parameters via `Options(context=...)`, and call `mloda.run_all()`.
+
+---
+
+## The three categories
+
+| Category | Location | Row behavior | Examples |
+|---|---|---|---|
+| Row-preserving | `row_preserving/` | Output row count and order match input | binning, window aggregation, rank, offset, percentile, scalar aggregate, frame aggregate, datetime |
+| Aggregation | `aggregation/` | Reduces to one row per group | sum, avg, count, min, max, std, var, median, mode, nunique, first, last |
+| String | `string/` | Row-preserving, element-wise on strings | upper, lower, trim, length, reverse |
+
+Row-preserving is the largest category because analytic transforms that broadcast a computed value back onto each row (ranks, running totals, bin labels) all share the same invariant.
+
+---
+
+## Naming patterns
+
+Every data operation encodes its parameters directly in the feature name. The prefix pattern is how the matcher locates the right feature group.
+
+| Category | Pattern | Example |
+|---|---|---|
+| Aggregation | `{col}__{agg}_agg` | `value_int__sum_agg` |
+| Window aggregation | `{col}__{agg}_window` | `value_int__avg_window` |
+| Scalar aggregate | `{col}__{agg}_scalar` | `value_int__max_scalar` |
+| Rank | `{col}__{rank_type}_ranked` | `score__dense_rank_ranked` |
+| Offset | `{col}__{offset_type}_offset` | `value__lag_1_offset` |
+| Percentile | `{col}__p{N}_percentile` | `latency__p95_percentile` |
+| Frame aggregate | multiple forms | `value__sum_rolling_3`, `value__avg_7_day_window`, `value__cumsum`, `value__expanding_avg` |
+| Binning | `{col}__{bin_op}_{N}` | `value_int__bin_5`, `value_int__qbin_10` |
+| DateTime | `{col}__{part}` | `ts__year`, `ts__dayofweek` |
+| String | `{col}__{str_op}` | `name__upper`, `text__length` |
+
+The full pattern regex for each category lives in the corresponding `base.py`. For example:
+
+```python
+from mloda.community.feature_groups.data_operations.aggregation.base import AggregationFeatureGroup
+from mloda.community.feature_groups.data_operations.string.base import StringFeatureGroup
+
+AggregationFeatureGroup.PREFIX_PATTERN  # r".*__([\w]+)_agg$"
+StringFeatureGroup.PREFIX_PATTERN       # r".+__(upper|lower|trim|length|reverse)$"
+```
+
+---
+
+## A minimal example
+
+```python
+from mloda.user import Feature, Options, PluginLoader, mloda
+
+PluginLoader.all()
+
+features = [
+    Feature("value_int__sum_agg", Options(context={"partition_by": ["region"]})),
+    Feature("value_int__p95_percentile", Options(context={"partition_by": ["region"]})),
+    Feature("name__upper"),
+]
+
+result = mloda.run_all(features, compute_frameworks={"PandasDataFrame"})
+```
+
+Each feature name resolves to one of the built-in data-operation feature groups. The `partition_by` option is consumed by the base class; no framework-specific code runs in user space.
+
+---
+
+## Where to go next
+
+- [Row-preserving contract](02-row-preserving-contract.md) explains the central invariant that shapes most of this section.
+- [Reference implementation pattern](03-reference-implementation.md) explains why PyArrow is the source of truth.
+- [Adding a new data operation](10-adding-new-operation.md) is the end-to-end recipe if you want to extend this system.

--- a/docs/guides/data-operation-patterns/02-row-preserving-contract.md
+++ b/docs/guides/data-operation-patterns/02-row-preserving-contract.md
@@ -1,0 +1,104 @@
+# Row-Preserving Contract
+
+Row-preserving operations must return an output whose row count and row order match the input. This invariant is what lets users chain analytic transforms without surprise reshuffles.
+
+**What**: For every row-preserving operation, `len(output) == len(input)` and row *i* in the output corresponds to row *i* in the input.
+**When**: Applies to every feature group under `data_operations/row_preserving/`: binning, window aggregation, rank, offset, percentile, scalar aggregate, frame aggregate, datetime.
+**Why**: Row-preserving ops broadcast a computed value back onto each row. If the framework reorders rows (some SQL window functions do), downstream joins on index position break silently.
+**Where**: The contract is enforced by cross-framework tests. Row count and row order are both asserted in `DataOpsTestBase._compare_with_reference`.
+**How**: Each framework implementation must return rows in the same order they came in. If the native operator reorders (DuckDB `NTILE`), the implementation records original positions and restores them.
+
+---
+
+## What the contract asserts
+
+`mloda/testing/feature_groups/data_operations/base.py` contains `_compare_with_reference`, which is the shared harness every row-preserving test uses:
+
+```python
+# Paraphrased from DataOpsTestBase
+result = self.implementation_class().calculate_feature(self.test_data, fs)
+ref    = self.reference_implementation_class().calculate_feature(self._arrow_table, fs)
+
+result_col = self.extract_column(result, feature_name)
+ref_col    = _extract_column(ref, feature_name)
+
+assert len(result_col) == len(ref_col), f"row count mismatch"
+assert result_col == ref_col            # exact match (or pytest.approx for floats)
+```
+
+Two assertions, one invariant:
+
+1. **Row count**: `len(result_col) == len(ref_col)`.
+2. **Row order**: element-wise equality against the reference (PyArrow). Non-matching row order fails the second assertion even if the multiset of values is identical.
+
+---
+
+## Per-framework notes
+
+| Framework | Default behavior | Workaround needed? |
+|---|---|---|
+| PyArrow | Operates on columnar arrays by index; naturally preserves row order | No |
+| Pandas | Index-aligned assignments (`df[col] = ...`) preserve order | No, as long as you avoid `groupby(...).apply()` patterns that reset index |
+| Polars (lazy) | `pl.when/then/otherwise` and `over(...)` preserve order | No |
+| SQLite | SQL result order is undefined unless `ORDER BY` is specified, but the implementations re-select columns rather than applying `ORDER BY` | No |
+| DuckDB | Most operators preserve order. `NTILE()` reorders by its `ORDER BY` clause | Yes, see below |
+
+---
+
+## The DuckDB NTILE workaround
+
+DuckDB's `NTILE()` window function requires an `ORDER BY` clause and emits rows in that order, not in input order. PyArrow's rank-based `qbin` assigns labels by index and preserves the original sequence. To make the two match, DuckDB tags each input row with `ROW_NUMBER() OVER ()` before the window runs, then re-sorts on that column to restore the original sequence.
+
+From `mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py`:
+
+```python
+# PyArrow parity: PyArrow _quantile_bin() assigns bins via index
+# mapping and naturally preserves row order. DuckDB NTILE()
+# reorders rows via ORDER BY; tag positions with ROW_NUMBER()
+# and restore via .order() to match PyArrow output.
+qrn = quote_ident("__mloda_rn__")
+with_rn   = data.select(_raw_sql=f"*, ROW_NUMBER() OVER () AS {qrn}")
+with_qbin = with_rn.select(_raw_sql=f"*, {expr} AS {quoted_feature}")
+sorted_rel = with_qbin.order(qrn)
+# drop __mloda_rn__ from the final projection
+```
+
+This pattern generalizes. Any time a framework's native operator reorders rows, the implementation must record positions before the operator runs and restore them afterward.
+
+---
+
+## How to verify a new implementation honors the contract
+
+Write the test by inheriting from the operation's test base and the relevant framework mixin. You do not need to add row-count assertions yourself; they are inherited from `DataOpsTestBase`.
+
+```python
+from mloda.testing.feature_groups.data_operations.mixins.duckdb import DuckdbTestMixin
+from mloda.testing.feature_groups.data_operations.row_preserving.binning.binning import (
+    BinningTestBase,
+)
+from mloda.community.feature_groups.data_operations.row_preserving.binning.duckdb_binning import (
+    DuckdbBinning,
+)
+
+
+class TestDuckdbBinning(DuckdbTestMixin, BinningTestBase):
+    @classmethod
+    def implementation_class(cls):
+        return DuckdbBinning
+```
+
+If your framework reorders, you will see row-count assertions pass but value comparisons fail with "row 0: 3 != reference 0". That means order is wrong, not math. Add the row-number workaround and try again.
+
+---
+
+## Aggregation is different
+
+Aggregations under `data_operations/aggregation/` are **not** row-preserving. They reduce to one row per partition key. The [reference implementation](03-reference-implementation.md) still applies (PyArrow defines the expected result), but row count is expected to shrink.
+
+---
+
+## Related
+
+- [Reference implementation pattern](03-reference-implementation.md) - Why PyArrow is the source of truth.
+- [Binning](05-binning.md) - Concrete walkthrough of the DuckDB workaround.
+- [Adding a new data operation](10-adding-new-operation.md) - How to wire up the tests that enforce this contract.

--- a/docs/guides/data-operation-patterns/03-reference-implementation.md
+++ b/docs/guides/data-operation-patterns/03-reference-implementation.md
@@ -1,0 +1,76 @@
+# Reference Implementation Pattern
+
+Every data operation has one framework designated as the reference. Other frameworks are correct if and only if they match the reference on the shared test suite. PyArrow is the reference for the operations that ship today.
+
+**What**: One framework implementation is the source of truth. Cross-framework tests run the same feature through both the target framework and the reference, then assert the two results match.
+**When**: Every time you add a new operation or add a new framework implementation for an existing operation.
+**Why**: Without a fixed reference, frameworks drift into mutually incompatible results (e.g. different NULL handling, different tie-breaking in ranks). Making PyArrow authoritative keeps semantics aligned without requiring everyone to agree on an abstract spec.
+**Where**: `mloda/testing/feature_groups/data_operations/base.py::DataOpsTestBase._compare_with_reference`.
+**How**: Each framework mixin provides `create_test_data` (converts the canonical PyArrow table to the framework's native format) and `extract_column` (materializes the result back to a Python list for comparison).
+
+---
+
+## Why PyArrow
+
+PyArrow implementations are:
+
+- **Columnar and index-based**, so row order is trivially preserved.
+- **Explicit about NULL** via `pa.array` masks, so NULL handling is unambiguous.
+- **Deterministic**: `pc.sort_indices`, `pc.rank`, `pc.round` give the same result every run.
+
+These properties make PyArrow a reasonable ground truth. It is not faster than the others; it is the cleanest semantic reference.
+
+---
+
+## How the comparison works
+
+`_compare_with_reference` runs both implementations on equivalent data:
+
+```python
+# self.test_data is the framework-native test fixture
+# self._arrow_table is the same data as a PyArrow table
+fs = make_feature_set(feature_name, partition_by=partition_by, order_by=order_by)
+result = self.implementation_class().calculate_feature(self.test_data, fs)
+ref    = self.reference_implementation_class().calculate_feature(self._arrow_table, fs)
+
+result_col = self.extract_column(result, feature_name)
+ref_col    = _extract_column(ref, feature_name)
+assert result_col == ref_col  # or pytest.approx for floats
+```
+
+`self.test_data` is produced by the framework mixin's `create_test_data(pa.Table)`. The canonical input is always PyArrow; the mixin converts it once per test. This keeps the fixtures aligned: both sides compute from the *same* starting values, just in different native representations.
+
+---
+
+## What "matching" means
+
+For integer operations, matching means exact element-wise equality including NULLs. For floating-point operations, the test harness accepts `pytest.approx` with `rel=1e-6` when `use_approx=True`. That tolerance exists because frameworks differ in accumulation order (running sums through SQL engines vs. columnar reductions), not because results are allowed to drift.
+
+If your framework produces NaN where PyArrow produces NULL, the comparison fails. NaN and NULL are not interchangeable; frame-level tests treat them as distinct.
+
+---
+
+## Canonical test data
+
+Row-preserving and aggregation tests share a canonical input: 12 rows with columns `region`, `category`, `value_int`, `value_float`, `ts`, `name`. Each operation's test base asserts specific expected values against this fixture. When you subclass the test base for a new framework, you do not redefine the data or the expected values. You only implement the adapter methods that convert between PyArrow and your framework's native type.
+
+---
+
+## When the reference itself is wrong
+
+Bugs happen. If the PyArrow implementation is wrong:
+
+1. Fix the PyArrow implementation.
+2. Update the operation's test base (`BinningTestBase`, `AggregationTestBase`, etc.) so the expected values reflect the correct result.
+3. Run every framework's test class. Every non-PyArrow implementation that was "matching" the bug will now fail.
+4. Fix each framework implementation so it matches the corrected reference.
+
+Do not "fix" a non-PyArrow framework to agree with the PyArrow bug. The reference is where correctness lives, so fixing the reference is what realigns the ecosystem.
+
+---
+
+## Related
+
+- [Row-preserving contract](02-row-preserving-contract.md) - The row-count-and-order invariant that the reference comparison enforces.
+- [Supported ops per framework](04-supported-ops.md) - How a framework skips comparisons for ops it cannot express.
+- [Adding a new data operation](10-adding-new-operation.md) - Where to put the PyArrow reference when adding an op.

--- a/docs/guides/data-operation-patterns/04-supported-ops.md
+++ b/docs/guides/data-operation-patterns/04-supported-ops.md
@@ -1,0 +1,102 @@
+# Supported Ops Per Framework
+
+Not every framework can express every operation. SQLite has no native REVERSE; some frameworks lack a native NTILE. The `supported_ops()` pattern lets a framework test class declare what it can handle so the shared tests skip the rest cleanly.
+
+**What**: A class method on the test class that returns the set of op names the framework implements.
+**When**: Your framework implementation does not cover every op listed in the operation's base class.
+**Why**: Without it, inherited tests for unsupported ops would fail with "operation not matched" errors. With it, they skip with a clear message.
+**Where**: Defined on the operation's test base (e.g. `BinningTestBase.supported_ops`) and overridden on the concrete framework test class.
+**How**: Override `supported_ops()` to return the subset. `_skip_if_unsupported(op)` in `DataOpsTestBase` handles the skip logic.
+
+---
+
+## How `_skip_if_unsupported` finds the set
+
+`DataOpsTestBase._skip_if_unsupported` probes four class methods in order and uses whichever is defined:
+
+```python
+for attr in ("supported_agg_types", "supported_ops", "supported_offset_types", "supported_rank_types"):
+    method = getattr(self, attr, None)
+    if method is not None:
+        if op not in method():
+            pytest.skip(f"{op} not supported by this framework")
+        return
+```
+
+The multiple method names exist because different operation categories use different vocabulary: aggregation has "agg_types", binning has "ops", offset has "offset_types", rank has "rank_types". The semantics are the same.
+
+---
+
+## Example: SQLite excludes `reverse`
+
+The string operation `reverse` has no native SQLite equivalent. The framework implementation refuses to match at selection time:
+
+```python
+# mloda/community/feature_groups/data_operations/string/sqlite_string.py
+_SQLITE_STRING_EXPRS: dict[str, str] = {
+    "upper":  "UPPER({col})",
+    "lower":  "LOWER({col})",
+    "trim":   "TRIM({col})",
+    "length": "LENGTH({col})",
+}
+
+@classmethod
+def _validate_string_match(cls, feature_name, operation_config, source_feature) -> bool:
+    return operation_config in _SQLITE_STRING_EXPRS
+```
+
+The test class mirrors that decision:
+
+```python
+# mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py
+class TestSqliteStringOps(SqliteTestMixin, StringTestBase):
+    @classmethod
+    def supported_ops(cls) -> set[str]:
+        return {"upper", "lower", "trim", "length"}
+```
+
+With this override, the inherited `test_reverse_*` methods skip with "reverse not supported by this framework" instead of failing.
+
+---
+
+## Two places, two responsibilities
+
+The test-side `supported_ops()` is only for test skipping. It does **not** by itself change what feature names the framework accepts at runtime. The two declarations are independent:
+
+| Declaration | Lives in | Purpose |
+|---|---|---|
+| `_validate_string_match` / `match_feature_group_criteria` override | `framework_{op}.py` | Refuses the feature name at resolution time so the mloda engine routes elsewhere (or errors). |
+| `supported_ops()` (or `supported_agg_types`, etc.) | `tests/test_{framework}.py` | Makes the inherited test suite skip the ones the framework does not claim. |
+
+Keep them consistent. If your implementation silently drops an op at runtime but the test class still claims to support it, the suite will fail. If the test class over-restricts, you lose coverage for something you actually implemented.
+
+---
+
+## Adding a new framework for an existing op
+
+When you add, say, a Polars-lazy implementation for an operation, copy the test template:
+
+```python
+from mloda.testing.feature_groups.data_operations.mixins.polars_lazy import PolarsLazyTestMixin
+from mloda.testing.feature_groups.data_operations.row_preserving.rank.rank import RankTestBase
+
+class TestPolarsLazyRank(PolarsLazyTestMixin, RankTestBase):
+    @classmethod
+    def implementation_class(cls):
+        return PolarsLazyRank
+
+    @classmethod
+    def supported_rank_types(cls) -> set[str]:
+        return {"row_number", "rank", "dense_rank", "percent_rank"}
+        # ntile_N omitted if Polars version lacks a clean NTILE equivalent
+```
+
+Start by returning the full set the operation supports. Shrink it only as concrete limitations appear.
+
+---
+
+## Related
+
+- [Reference implementation pattern](03-reference-implementation.md) - How framework implementations are compared against PyArrow.
+- [String operations](09-string-operations.md) - The most common place `supported_ops()` comes up.
+- [Adding a new data operation](10-adding-new-operation.md) - How to define the method on a new operation's test base.

--- a/docs/guides/data-operation-patterns/05-binning.md
+++ b/docs/guides/data-operation-patterns/05-binning.md
@@ -1,0 +1,110 @@
+# Binning
+
+Binning maps a numeric column onto integer bucket indices `0..n-1`. Two variants ship: equal-width (`bin`) and quantile-based (`qbin`).
+
+**What**: `BinningFeatureGroup` accepts feature names of the form `{col}__bin_{N}` or `{col}__qbin_{N}`.
+**When**: You need discretization for downstream grouping, charting, or model features.
+**Why**: Both operations are standard, but implementing them identically across frameworks is non-trivial because of NTILE reordering and NULL propagation.
+**Where**: `mloda/community/feature_groups/data_operations/row_preserving/binning/`.
+**How**: Feature name encodes the op and bin count; the framework implementation computes the bin index per row and preserves input order.
+
+---
+
+## Two binning modes
+
+```python
+# mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+BINNING_OPS = {
+    "bin":  "Equal-width binning (value range divided into n equal intervals)",
+    "qbin": "Quantile-based binning (rows divided into n roughly equal groups by rank)",
+}
+```
+
+| Mode | Semantics | Result shape |
+|---|---|---|
+| `bin` (equal-width) | Divide `[min, max]` into N intervals of equal width. Bin index = `floor((value - min) / width)`, clamped to `N-1`. | Bins may be unbalanced if the distribution is skewed. |
+| `qbin` (quantile) | Sort rows by value, assign rank `r` to bin `r * N // n` where `n` is the count of non-null values. | Bins are always roughly equal in row count. |
+
+`qbin` uses rank-based assignment rather than sample quantiles. That is a deliberate choice to sidestep interpolation disagreements across frameworks: ranks are integers and leave no room for numerical drift.
+
+---
+
+## NTILE vs rank-based equivalence
+
+SQL engines offer `NTILE(N)` to partition rows into N buckets. Its semantics are "assign bucket `ceil(rank * N / n)`", which is equivalent to the rank-based formula `r * N // n` up to a 1-based-vs-0-based offset. The mloda convention is 0-based, so SQL implementations subtract 1 and clamp at `N-1`.
+
+Pseudocode equivalence:
+
+| Expression | Produces |
+|---|---|
+| PyArrow `rank * n_bins // n` | 0..N-1 |
+| DuckDB `NTILE(N) OVER (ORDER BY col) - 1` | 0..N-1 |
+| Pandas `(rank * N // n).astype("Int64")` | 0..N-1 |
+
+All three resolve to the same labels for the same row order, but only after accounting for how each framework handles ties and NULLs.
+
+---
+
+## NULL and NaN handling
+
+- Input NULLs are skipped when computing `min`, `max`, and the non-null count `n`.
+- Rows with NULL in the source column receive NULL in the bin column, not a real bin index.
+- NaN in floating columns is treated like NULL. DuckDB explicitly guards with `isnan(col)`:
+
+```sql
+CASE WHEN col IS NULL OR isnan(col) THEN NULL
+     ELSE LEAST(NTILE(N) OVER (
+         PARTITION BY CASE WHEN col IS NOT NULL AND NOT isnan(col) THEN 1 END
+         ORDER BY col) - 1, N - 1) END
+```
+
+The `PARTITION BY CASE WHEN ...` clause is what ensures NULL/NaN rows do not participate in the rank at all; they stay unpartitioned and the CASE returns NULL for them.
+
+---
+
+## The DuckDB row-order workaround
+
+`NTILE` requires `ORDER BY col`, which produces rows sorted by `col`, not by original input order. The row-preserving contract requires input order. The fix:
+
+```python
+# Paraphrased from duckdb_binning.py
+qrn = quote_ident("__mloda_rn__")
+with_rn    = data.select(_raw_sql=f"*, ROW_NUMBER() OVER () AS {qrn}")
+with_qbin  = with_rn.select(_raw_sql=f"*, {ntile_expression} AS {quoted_feature}")
+sorted_rel = with_qbin.order(qrn)
+# project out __mloda_rn__ in the final select
+```
+
+1. Tag each input row with `ROW_NUMBER() OVER ()` before the window runs.
+2. Apply the NTILE-based expression.
+3. Re-sort by the tagged row number to restore input order.
+4. Drop the temporary column from the projection.
+
+Any framework whose native operation reorders will need an analogous workaround. Pandas and PyArrow do not, because both assign by index directly. See [the row-preserving contract](02-row-preserving-contract.md) for the general rule.
+
+---
+
+## Usage
+
+```python
+from mloda.user import Feature, PluginLoader, mloda
+
+PluginLoader.all()
+
+features = [
+    Feature("value_int__bin_5"),    # equal-width, 5 bins
+    Feature("value_int__qbin_4"),   # quartiles
+]
+
+result = mloda.run_all(features, compute_frameworks={"PandasDataFrame"})
+```
+
+Row count matches the input; each new column contains integers in `[0, N-1]` (or NULL for unbinnable rows).
+
+---
+
+## Related
+
+- [Row-preserving contract](02-row-preserving-contract.md) - Why the DuckDB `ROW_NUMBER()` tag-and-restore pattern exists.
+- [Reference implementation pattern](03-reference-implementation.md) - PyArrow's rank-based `qbin` is the source of truth.
+- [Adding a new data operation](10-adding-new-operation.md) - Template for extending binning to a new framework.

--- a/docs/guides/data-operation-patterns/06-window-aggregation.md
+++ b/docs/guides/data-operation-patterns/06-window-aggregation.md
@@ -28,8 +28,8 @@ median, mode, nunique, first, last
 
 | Key | Type | Required | Purpose |
 |---|---|---|---|
-| `partition_by` | `list[str]` | Optional | Columns defining the window. Omit for a global window. |
-| `order_by` | `str` | Optional | Column that orders rows within each partition. Some agg types (`first`, `last`) rely on it. |
+| `partition_by` | `list[str]` (or tuple) | Required | Columns defining the window. Must be present and non-empty; the matcher rejects the feature otherwise. For a single global window, use [scalar aggregate](08-scalar-and-frame-aggregate.md) instead. |
+| `order_by` | `str` | Required for ordered aggs (`first`, `last`) | Column that orders rows within each partition. |
 | `mask` | tuple or list of tuples | Optional | Conditional aggregation. See [Masking](../feature-group-patterns/25-masking.md). |
 
 ---

--- a/docs/guides/data-operation-patterns/06-window-aggregation.md
+++ b/docs/guides/data-operation-patterns/06-window-aggregation.md
@@ -1,0 +1,99 @@
+# Window Aggregation
+
+Window aggregation computes a group aggregate (sum, avg, etc.) and broadcasts it back onto every row. Row count is preserved; every row receives the aggregate value for its partition.
+
+**What**: `WindowAggregationFeatureGroup` handles feature names of the form `{col}__{agg}_window`.
+**When**: You want a group aggregate alongside the original rows (e.g. "total sales per region on every order row").
+**Why**: Unlike `aggregation`, which reduces rows, window aggregation keeps them. You get per-row context plus a per-partition aggregate without a join.
+**Where**: `mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/`.
+**How**: Encode the aggregation in the feature name. Pass `partition_by` (and optionally `order_by` for ordered aggregates) via `Options(context=...)`.
+
+---
+
+## Supported aggregation types
+
+The matcher accepts any token that falls inside the name regex `r".*__([\w]+)_window$"` and is also present in the supported set:
+
+```
+sum, avg, mean, count, min, max,
+std, var, std_pop, std_samp, var_pop, var_samp,
+median, mode, nunique, first, last
+```
+
+`avg` and `mean` are aliases. `std`/`std_pop` and `var`/`var_pop` are aliases (ddof=0). `std_samp` and `var_samp` use ddof=1.
+
+---
+
+## Parameters via `Options(context=...)`
+
+| Key | Type | Required | Purpose |
+|---|---|---|---|
+| `partition_by` | `list[str]` | Optional | Columns defining the window. Omit for a global window. |
+| `order_by` | `str` | Optional | Column that orders rows within each partition. Some agg types (`first`, `last`) rely on it. |
+| `mask` | tuple or list of tuples | Optional | Conditional aggregation. See [Masking](../feature-group-patterns/25-masking.md). |
+
+---
+
+## Usage
+
+```python
+from mloda.user import Feature, Options, PluginLoader, mloda
+
+PluginLoader.all()
+
+features = [
+    Feature(
+        "value_int__sum_window",
+        Options(context={"partition_by": ["region"]}),
+    ),
+    Feature(
+        "value_int__first_window",
+        Options(context={"partition_by": ["region"], "order_by": "ts"}),
+    ),
+]
+
+result = mloda.run_all(features, compute_frameworks={"DuckdbRelation"})
+```
+
+Every row in `result` has the same number of columns plus the two new ones. Within each `region`, `value_int__sum_window` holds the same value on every row.
+
+---
+
+## Row-preserving behavior
+
+Because window aggregation must preserve input order (see [row-preserving contract](02-row-preserving-contract.md)), framework implementations rely on native windowed expressions that do not reorder:
+
+| Framework | Native construct |
+|---|---|
+| PyArrow | `groupby_aggregate` + broadcast back via index mapping |
+| Pandas | `groupby(partition_by)[col].transform(agg)` |
+| Polars lazy | `col.{agg}().over(partition_by)` |
+| DuckDB / SQLite | `{AGG}(col) OVER (PARTITION BY ...)` (no `ORDER BY` when not needed) |
+
+The DuckDB/SQLite form omits `ORDER BY` for non-ordered aggregates (`sum`, `avg`, etc.). Adding one would reorder rows and break the contract for engines that otherwise would not reorder.
+
+---
+
+## Mask support
+
+Every window-aggregation feature accepts the `mask` option. Masked rows have their source value replaced with NULL before the aggregate runs, so the aggregate skips them. Row count is still preserved; the masked rows remain in the output, just carrying a non-contributing NULL.
+
+```python
+Feature(
+    "value_int__sum_window",
+    Options(context={
+        "partition_by": ["region"],
+        "mask": ("category", "equal", "X"),
+    }),
+)
+```
+
+See [Masking](../feature-group-patterns/25-masking.md) for the full mask spec.
+
+---
+
+## Related
+
+- [Row-preserving contract](02-row-preserving-contract.md) - Why ordered window functions need careful handling.
+- [Scalar and frame aggregate](08-scalar-and-frame-aggregate.md) - Global broadcast and rolling variants.
+- [Aggregation naming](../feature-group-patterns/13-feature-naming.md) - How the engine matches `__{agg}_window` suffixes.

--- a/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
+++ b/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
@@ -1,0 +1,109 @@
+# Percentile, Rank, Offset
+
+Three related row-preserving families for analytic windows: percentile (value-at-rank), rank (rank-of-value), and offset (shift-relative-to-row). They share naming and parameter conventions.
+
+**What**: Three feature groups that each compute a per-row analytic value within an optional partition.
+**When**: You need percentiles, ranks, lags, or cumulative positions alongside the original rows.
+**Why**: These are the core analytic-window primitives that power feature engineering for time series and grouped analytics.
+**Where**: `mloda/community/feature_groups/data_operations/row_preserving/{percentile,rank,offset}/`.
+**How**: Encode the op and its parameter N into the feature name. Pass `partition_by` (and `order_by` where relevant) via `Options(context=...)`.
+
+---
+
+## Percentile
+
+`PercentileFeatureGroup` computes the value at percentile N within each partition and broadcasts it to every row.
+
+| Pattern | Example |
+|---|---|
+| `{col}__p{N}_percentile` where N is 0..100 | `latency__p95_percentile` |
+
+```python
+from mloda.user import Feature, Options, PluginLoader, mloda
+
+PluginLoader.all()
+
+feature = Feature(
+    "latency__p95_percentile",
+    Options(context={"partition_by": ["service"]}),
+)
+```
+
+All rows of the same `service` share the same P95 value. Percentiles use the framework's native method (linear interpolation by default in Pandas and PyArrow). Cross-framework tests allow `pytest.approx` tolerance for floating-point comparisons.
+
+---
+
+## Rank
+
+`RankFeatureGroup` assigns each row a rank within its partition.
+
+| Pattern | Example |
+|---|---|
+| `{col}__{rank_type}_ranked` | `score__dense_rank_ranked` |
+
+Rank types:
+
+| Type | Semantics |
+|---|---|
+| `row_number` | Unique 1-based position, ties broken by `order_by` |
+| `rank` | Standard rank with gaps (1, 2, 2, 4) |
+| `dense_rank` | Standard rank without gaps (1, 2, 2, 3) |
+| `percent_rank` | `(rank - 1) / (n - 1)` in `[0, 1]` |
+| `ntile_N` | Split into N buckets, return 1..N |
+| `top_N` | Boolean: row is in top N by `order_by` |
+| `bottom_N` | Boolean: row is in bottom N by `order_by` |
+
+```python
+Feature(
+    "score__dense_rank_ranked",
+    Options(context={"partition_by": ["region"], "order_by": "score"}),
+)
+```
+
+Rank types that need an ordering (`row_number`, `rank`, `dense_rank`, `percent_rank`, `top_N`, `bottom_N`) require `order_by`. Framework test classes may restrict `supported_rank_types` when their engine does not implement one variant; see [Supported ops](04-supported-ops.md).
+
+---
+
+## Offset
+
+`OffsetFeatureGroup` shifts a column by a fixed number of rows inside each partition.
+
+| Pattern | Example |
+|---|---|
+| `{col}__{offset_type}_offset` | `value__lag_1_offset` |
+
+Offset types:
+
+| Type | Semantics |
+|---|---|
+| `lag_N` | Value from N rows earlier (NULL for first N rows per partition) |
+| `lead_N` | Value from N rows later |
+| `diff_N` | `value - lag_N(value)` |
+| `pct_change_N` | `(value - lag_N(value)) / lag_N(value)` |
+| `first_value` | First value in the partition by `order_by` |
+| `last_value` | Last value in the partition by `order_by` |
+
+```python
+Feature(
+    "revenue__lag_1_offset",
+    Options(context={"partition_by": ["customer_id"], "order_by": "month"}),
+)
+```
+
+All offset types require `order_by`; partition ordering is what "previous row" means.
+
+---
+
+## Shared semantics
+
+- **NULL propagation**: If the source value for a row is NULL, the result is NULL for value-returning types (`lag`, `lead`, `first_value`, `last_value`). Rank types ignore NULLs when computing positions and return NULL for NULL rows.
+- **Partition boundaries**: Operations never cross partitions. `lag_1` at the first row of a partition yields NULL, not a value from the previous partition.
+- **Empty partitions**: Impossible by construction (a partition exists only if a row has its key).
+
+---
+
+## Related
+
+- [Row-preserving contract](02-row-preserving-contract.md) - Analytic windows must preserve input order.
+- [Window aggregation](06-window-aggregation.md) - Aggregates broadcast per partition; the same `partition_by` semantics apply.
+- [Scalar and frame aggregate](08-scalar-and-frame-aggregate.md) - Aggregates over the whole frame, rolling, or expanding windows.

--- a/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
+++ b/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
@@ -60,7 +60,7 @@ Feature(
 )
 ```
 
-Rank types that need an ordering (`row_number`, `rank`, `dense_rank`, `percent_rank`, `top_N`, `bottom_N`) require `order_by`. Framework test classes may restrict `supported_rank_types` when their engine does not implement one variant; see [Supported ops](04-supported-ops.md).
+`order_by` is required for every rank type; the matcher rejects the feature if it is missing. That includes `ntile_N` as well as the standard numeric and boolean variants. Framework test classes may restrict `supported_rank_types` when their engine does not implement one variant; see [Supported ops](04-supported-ops.md).
 
 ---
 
@@ -96,7 +96,8 @@ All offset types require `order_by`; partition ordering is what "previous row" m
 
 ## Shared semantics
 
-- **NULL propagation**: If the source value for a row is NULL, the result is NULL for value-returning types (`lag`, `lead`, `first_value`, `last_value`). Rank types ignore NULLs when computing positions and return NULL for NULL rows.
+- **NULL in offsets**: Offsets reference *other* rows, so the current row being NULL does not force a NULL result. `lag_N` on a NULL row returns whatever sits N rows earlier (possibly non-NULL). `first_value` and `last_value` skip NULL source values and return the first or last non-NULL in the partition; the result is NULL only when every value in the partition is NULL. A NULL result from `lag_N`/`lead_N` happens when the referenced position falls outside the partition (first or last N rows).
+- **NULL in ranks**: NULL values in the order column sort *last* in both ascending and descending directions; they still receive a rank. For `top_N`/`bottom_N` those NULL-ordered rows get `False` whenever N is smaller than the partition size.
 - **Partition boundaries**: Operations never cross partitions. `lag_1` at the first row of a partition yields NULL, not a value from the previous partition.
 - **Empty partitions**: Impossible by construction (a partition exists only if a row has its key).
 

--- a/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
+++ b/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
@@ -1,0 +1,101 @@
+# Scalar and Frame Aggregate
+
+Two row-preserving aggregate families. Scalar aggregate broadcasts one value across the whole table. Frame aggregate broadcasts a value computed over a bounded window (rolling, time-window, cumulative, or expanding).
+
+**What**: `ScalarAggregateFeatureGroup` and `FrameAggregateFeatureGroup` compute aggregates without reducing rows.
+**When**: You need a reference value on every row (scalar) or a moving aggregate (frame).
+**Why**: Both preserve row count, which lets them chain with other row-preserving ops. The group-reducing variant lives in `aggregation/` and is covered separately.
+**Where**: `mloda/community/feature_groups/data_operations/row_preserving/{scalar_aggregate,frame_aggregate}/`.
+**How**: Encode the agg type in the feature name. Frame variants also encode the window kind and size.
+
+---
+
+## Scalar aggregate
+
+Pattern: `{col}__{agg}_scalar` (regex `r".*__([\w]+)_scalar$"`).
+
+Every row receives the same aggregate value. No partitioning, no windowing.
+
+```python
+from mloda.user import Feature, PluginLoader, mloda
+
+PluginLoader.all()
+
+# Every row gets the global max
+feature = Feature("value_int__max_scalar")
+```
+
+Supported aggregations match [window aggregation](06-window-aggregation.md): `sum`, `avg`/`mean`, `count`, `min`, `max`, `std`/`std_pop`/`std_samp`, `var`/`var_pop`/`var_samp`, `median`, `mode`, `nunique`, `first`, `last`.
+
+Scalar aggregate accepts the `mask` option. Masked rows have their source value replaced with NULL before the aggregate computes; the output still has the same row count.
+
+---
+
+## Frame aggregate
+
+Frame aggregate supports four window kinds. The feature name encodes which kind and its size.
+
+| Kind | Pattern | Example |
+|---|---|---|
+| Rolling (row-count window) | `{col}__{agg}_rolling_{N}` | `value__sum_rolling_3` |
+| Time-based window | `{col}__{agg}_{size}_{unit}_window` | `value__avg_7_day_window` |
+| Cumulative | `{col}__cum{agg}` | `value__cumsum`, `value__cummax` |
+| Expanding | `{col}__expanding_{agg}` | `value__expanding_avg` |
+
+### Rolling
+
+`value__sum_rolling_3` computes the sum of the current row plus the two preceding, giving a 3-row rolling sum. The first `N-1` rows per partition return NULL (incomplete window).
+
+```python
+Feature(
+    "value__sum_rolling_3",
+    Options(context={"partition_by": ["customer_id"], "order_by": "ts"}),
+)
+```
+
+### Time window
+
+`value__avg_7_day_window` computes an average over all rows whose `order_by` timestamp falls within the last 7 days of the current row's timestamp. Supported units include `day`, `hour`, `minute`, `second`. The `order_by` column must be a timestamp.
+
+### Cumulative
+
+`value__cumsum` is the running sum from the start of the partition to the current row. Cumulative variants: `cumsum`, `cummin`, `cummax`, `cumcount`.
+
+### Expanding
+
+`value__expanding_avg` is the aggregate of all rows from the start of the partition up to and including the current row. Any supported aggregation works.
+
+---
+
+## Shared options
+
+All frame-aggregate variants accept:
+
+| Key | Type | Purpose |
+|---|---|---|
+| `partition_by` | `list[str]` | Resets the window at each partition boundary |
+| `order_by` | `str` | Required for rolling, time-window, cumulative, and expanding |
+| `mask` | tuple or list of tuples | Conditional aggregation; see [Masking](../feature-group-patterns/25-masking.md) |
+
+---
+
+## Scalar vs frame vs window vs aggregation
+
+Four nearby concepts; easy to mix up.
+
+| Feature group | Pattern suffix | Row behavior | Scope |
+|---|---|---|---|
+| Scalar aggregate | `_scalar` | Preserves (broadcasts one value globally) | Whole table |
+| Window aggregation | `_window` | Preserves (broadcasts per partition) | Partition |
+| Frame aggregate | `_rolling_N`, `_{size}_{unit}_window`, `cum*`, `expanding_*` | Preserves (broadcasts per bounded window) | Row-relative window |
+| Aggregation | `_agg` | Reduces to one row per group | Partition |
+
+Pick by what your downstream step needs: same row count and a reference value (scalar), same row count and per-partition context (window), same row count with a moving window (frame), or a collapsed group-by table (aggregation).
+
+---
+
+## Related
+
+- [Window aggregation](06-window-aggregation.md) - Per-partition aggregates without the rolling/expanding dimension.
+- [Row-preserving contract](02-row-preserving-contract.md) - Why the output row count matches the input for all frame kinds.
+- [Masking](../feature-group-patterns/25-masking.md) - Conditional aggregation for all of these variants.

--- a/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
+++ b/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
@@ -25,7 +25,7 @@ PluginLoader.all()
 feature = Feature("value_int__max_scalar")
 ```
 
-Supported aggregations match [window aggregation](06-window-aggregation.md): `sum`, `avg`/`mean`, `count`, `min`, `max`, `std`/`std_pop`/`std_samp`, `var`/`var_pop`/`var_samp`, `median`, `mode`, `nunique`, `first`, `last`.
+Supported aggregations are `sum`, `min`, `max`, `avg`/`mean`, `count`, `std`/`std_pop`/`std_samp`, `var`/`var_pop`/`var_samp`, and `median`. `mode`, `nunique`, `first`, and `last` are not supported on scalar aggregate, only on [window aggregation](06-window-aggregation.md); they need ordering or group structure that a single global scalar does not provide.
 
 Scalar aggregate accepts the `mask` option. Masked rows have their source value replaced with NULL before the aggregate computes; the output still has the same row count.
 

--- a/docs/guides/data-operation-patterns/09-string-operations.md
+++ b/docs/guides/data-operation-patterns/09-string-operations.md
@@ -4,7 +4,7 @@ Element-wise string transforms: uppercase, lowercase, trim, length, reverse. Row
 
 **What**: `StringFeatureGroup` handles feature names of the form `{col}__{op}` where `op` is one of `upper`, `lower`, `trim`, `length`, `reverse`.
 **When**: You need cleaned or derived text alongside the original column.
-**Why**: These cover the overwhelmingly common cases. Each maps directly to a native function in every target framework, so there is no interpretation layer.
+**Why**: These cover the overwhelmingly common cases. Four of the five (`upper`, `lower`, `trim`, `length`) map directly to a native function in every target framework. `reverse` is the one exception: SQLite has no native REVERSE, so the SQLite implementation refuses to match it at resolution time.
 **Where**: `mloda/community/feature_groups/data_operations/string/`.
 **How**: Name the feature; no context options are required.
 

--- a/docs/guides/data-operation-patterns/09-string-operations.md
+++ b/docs/guides/data-operation-patterns/09-string-operations.md
@@ -1,0 +1,107 @@
+# String Operations
+
+Element-wise string transforms: uppercase, lowercase, trim, length, reverse. Row-preserving by construction.
+
+**What**: `StringFeatureGroup` handles feature names of the form `{col}__{op}` where `op` is one of `upper`, `lower`, `trim`, `length`, `reverse`.
+**When**: You need cleaned or derived text alongside the original column.
+**Why**: These cover the overwhelmingly common cases. Each maps directly to a native function in every target framework, so there is no interpretation layer.
+**Where**: `mloda/community/feature_groups/data_operations/string/`.
+**How**: Name the feature; no context options are required.
+
+---
+
+## Operations
+
+```python
+# mloda/community/feature_groups/data_operations/string/base.py
+STRING_OPS = {
+    "upper":   "Convert string to uppercase",
+    "lower":   "Convert string to lowercase",
+    "trim":    "Strip leading and trailing whitespace",
+    "length":  "Return the length of the string (integer)",
+    "reverse": "Reverse the string",
+}
+
+PREFIX_PATTERN = r".+__(upper|lower|trim|length|reverse)$"
+```
+
+`length` returns an integer; the other four return strings.
+
+---
+
+## Usage
+
+```python
+from mloda.user import Feature, PluginLoader, mloda
+
+PluginLoader.all()
+
+features = [
+    Feature("name__upper"),
+    Feature("description__trim"),
+    Feature("name__length"),
+]
+
+result = mloda.run_all(features, compute_frameworks={"PandasDataFrame"})
+```
+
+No `Options` needed. The feature name alone is enough.
+
+---
+
+## NULL handling
+
+All five operations propagate NULL. A NULL input produces a NULL output; they never raise and never substitute an empty string.
+
+---
+
+## Framework differences
+
+| Framework | Native mapping |
+|---|---|
+| PyArrow | `pc.utf8_upper`, `pc.utf8_lower`, `pc.utf8_trim_whitespace`, `pc.utf8_length`, `pc.utf8_reverse` |
+| Pandas | `.str.upper()`, `.str.lower()`, `.str.strip()`, `.str.len()`, `.str[::-1]` (NULL-safe) |
+| Polars lazy | `col.str.to_uppercase()`, `.to_lowercase()`, `.strip_chars()`, `.len_chars()`, `.reverse()` |
+| DuckDB | `UPPER`, `LOWER`, `TRIM`, `LENGTH`, `REVERSE` |
+| SQLite | `UPPER`, `LOWER`, `TRIM`, `LENGTH` only |
+
+SQLite has no native `REVERSE`. The implementation refuses to match `__reverse` at resolution time rather than emulating it in SQL:
+
+```python
+# mloda/community/feature_groups/data_operations/string/sqlite_string.py
+_SQLITE_STRING_EXPRS: dict[str, str] = {
+    "upper":  "UPPER({col})",
+    "lower":  "LOWER({col})",
+    "trim":   "TRIM({col})",
+    "length": "LENGTH({col})",
+}
+
+@classmethod
+def _validate_string_match(cls, feature_name, operation_config, source_feature) -> bool:
+    return operation_config in _SQLITE_STRING_EXPRS
+```
+
+The SQLite test class mirrors the restriction:
+
+```python
+class TestSqliteStringOps(SqliteTestMixin, StringTestBase):
+    @classmethod
+    def supported_ops(cls) -> set[str]:
+        return {"upper", "lower", "trim", "length"}
+```
+
+If you request `name__reverse` with `compute_frameworks={"SqliteRelation"}`, the SQLite feature group will not match and the engine falls back to resolving the feature elsewhere (or errors). See [Supported ops](04-supported-ops.md) for how this pattern generalizes.
+
+---
+
+## Adding new string operations
+
+String operations are intentionally narrow. If you need `regex_replace`, `split`, `concat`, etc., build them as a new feature group rather than extending `StringFeatureGroup`. A new feature group gives you room for the extra parameters (regex patterns, split delimiters, concat lists) that a bare suffix in the feature name cannot encode cleanly.
+
+---
+
+## Related
+
+- [Supported ops per framework](04-supported-ops.md) - The mechanism SQLite uses to exclude `reverse`.
+- [Adding a new data operation](10-adding-new-operation.md) - Build a separate feature group for richer string ops.
+- [Feature naming](../feature-group-patterns/13-feature-naming.md) - General rules for the `{col}__{op}` convention.

--- a/docs/guides/data-operation-patterns/10-adding-new-operation.md
+++ b/docs/guides/data-operation-patterns/10-adding-new-operation.md
@@ -1,0 +1,226 @@
+# Adding a New Data Operation
+
+End-to-end recipe for introducing a new data operation: base class, framework implementations, test base, test mixins, and how to wire everything so the cross-framework comparison works.
+
+**What**: The concrete steps to add a new operation category (or a new op inside an existing category) and have it tested across every supported framework.
+**When**: You want a declarative transform that behaves identically on PyArrow, Pandas, Polars, DuckDB, and SQLite.
+**Why**: The existing pattern enforces the row-preserving contract, reference-implementation comparison, and supported-ops skipping for free. Following it gets you coverage without reinventing test harnesses.
+**Where**: Code in `mloda/community/feature_groups/data_operations/{your_category}/`, test bases in `mloda/testing/feature_groups/data_operations/{your_category}/`.
+**How**: Follow the seven steps below in order. Every existing category (binning, window_aggregation, rank, offset, percentile, scalar_aggregate, frame_aggregate, string, aggregation) was built the same way.
+
+---
+
+## Step 1: Decide the category
+
+- **Row-preserving**? Place it under `row_preserving/{your_op}/`. Read [the row-preserving contract](02-row-preserving-contract.md) first.
+- **Row-reducing** (group aggregate)? Place it under `aggregation/` if it fits the `__{agg}_agg` naming; otherwise it probably wants its own folder at the top level of `data_operations/`.
+- **Element-wise on strings**? Extend `string/` only if the new op has no parameters. Otherwise build a separate feature group.
+
+The category decides your naming pattern. See [overview](01-overview.md) for the conventions.
+
+---
+
+## Step 2: Write the base class
+
+File: `mloda/community/feature_groups/data_operations/{category}/{your_op}/base.py`.
+
+```python
+from typing import Any
+from mloda.provider import FeatureGroup, FeatureSet
+
+
+YOUR_OPS = {
+    "op_a": "What op_a does",
+    "op_b": "What op_b does",
+}
+
+
+class YourOpFeatureGroup(FeatureGroup):
+    PREFIX_PATTERN = r".+__(op_a|op_b)$"
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        table = data
+        for feature in features.features:
+            source_col = cls._extract_source_features(feature)[0]
+            op = cls._extract_op(feature)
+            table = cls._compute(table, feature.name, source_col, op)
+        return table
+
+    @classmethod
+    def _compute(cls, data: Any, feature_name: str, source_col: str, op: str) -> Any:
+        raise NotImplementedError
+```
+
+The base class owns:
+
+- The feature-name regex.
+- The loop over `features.features`.
+- Extraction of source column, operation, and any options from `Options(context=...)`.
+- Delegation to a per-framework `_compute` hook.
+
+Existing bases to crib from: `row_preserving/binning/base.py` (simple), `row_preserving/window_aggregation/base.py` (with `partition_by`/`order_by`/masks). They compose `FeatureChainParserMixin` to parse the suffix of the feature name; copy that detail verbatim from the closest existing base.
+
+---
+
+## Step 3: Write the PyArrow implementation first
+
+PyArrow is the reference. Write it first; it defines correctness for everything else.
+
+File: `{category}/{your_op}/pyarrow_{your_op}.py`.
+
+```python
+import pyarrow as pa
+import pyarrow.compute as pc
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from .base import YourOpFeatureGroup
+
+
+class PyArrowYourOp(YourOpFeatureGroup):
+    @classmethod
+    def compute_framework_rule(cls) -> set[type]:
+        return {PyArrowTable}
+
+    @classmethod
+    def _compute(cls, data: pa.Table, feature_name: str, source_col: str, op: str) -> pa.Table:
+        col = data.column(source_col)
+        # ...op-specific columnar work...
+        return data.append_column(feature_name, result_array)
+```
+
+Preserve row order. Preserve NULL. Handle the empty-table case.
+
+---
+
+## Step 4: Write the operation's test base
+
+File: `mloda/testing/feature_groups/data_operations/{category}/{your_op}/{your_op}.py`.
+
+```python
+from typing import Any
+from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
+from mloda.community.feature_groups.data_operations.{category}.{your_op}.pyarrow_{your_op} import (
+    PyArrowYourOp,
+)
+
+
+class YourOpTestBase(DataOpsTestBase):
+    @classmethod
+    def reference_implementation_class(cls) -> Any:
+        return PyArrowYourOp
+
+    @classmethod
+    def supported_ops(cls) -> set[str]:
+        return {"op_a", "op_b"}
+
+    def test_op_a_basic(self) -> None:
+        self._skip_if_unsupported("op_a")
+        self._compare_with_reference("value_int__op_a")
+
+    def test_op_b_partitioned(self) -> None:
+        self._skip_if_unsupported("op_b")
+        self._compare_with_reference("value_int__op_b", partition_by=["region"])
+```
+
+The test methods call `_compare_with_reference`, which runs both the implementation under test and PyArrow and asserts they match. Every framework's concrete test class will inherit these methods.
+
+---
+
+## Step 5: Add the other framework implementations
+
+One file per framework, all subclassing `YourOpFeatureGroup`:
+
+```
+{category}/{your_op}/
+  base.py
+  pyarrow_{your_op}.py
+  pandas_{your_op}.py
+  polars_lazy_{your_op}.py
+  duckdb_{your_op}.py
+  sqlite_{your_op}.py
+```
+
+Each class implements `_compute` using its native primitives. For row-preserving ops, respect the row-order invariant. If the native operation reorders (DuckDB `NTILE`), use the `ROW_NUMBER()` tag-and-restore pattern from [the row-preserving contract](02-row-preserving-contract.md).
+
+---
+
+## Step 6: Wire up the framework test classes
+
+One file per framework, all inheriting from your test base and the framework's mixin:
+
+```python
+# tests/test_pandas.py
+from typing import Any
+import pytest
+
+pytest.importorskip("pandas")
+
+from mloda.community.feature_groups.data_operations.{category}.{your_op}.pandas_{your_op} import (
+    PandasYourOp,
+)
+from mloda.testing.feature_groups.data_operations.mixins.pandas import PandasTestMixin
+from mloda.testing.feature_groups.data_operations.{category}.{your_op}.{your_op} import (
+    YourOpTestBase,
+)
+
+
+class TestPandasYourOp(PandasTestMixin, YourOpTestBase):
+    @classmethod
+    def implementation_class(cls) -> Any:
+        return PandasYourOp
+```
+
+No test method bodies. Everything is inherited. If the framework cannot do one op, override `supported_ops` to return the subset; `_skip_if_unsupported` handles the skip.
+
+---
+
+## Step 7: Decide if it needs mask support
+
+If the new op is an aggregate (or anything that consumes source values that a user might want to conditionally include), wire it up to `MaskTestMixin`:
+
+```python
+from mloda.testing.feature_groups.data_operations.mixins.mask import MaskTestMixin
+
+class YourOpTestBase(MaskTestMixin, DataOpsTestBase):
+    @classmethod
+    def mask_feature_name(cls) -> str:
+        return "value_int__op_a"
+
+    @classmethod
+    def mask_partition_by(cls) -> list[str] | None:
+        return ["region"]
+
+    @classmethod
+    def mask_is_reducing(cls) -> bool:
+        return False  # row-preserving
+
+    @classmethod
+    def mask_expected_row_count(cls) -> int:
+        return 12
+
+    # Plus mask_equal_expected, mask_multiple_conditions_expected,
+    # mask_is_in_expected, mask_greater_than_expected, mask_no_mask_expected
+```
+
+`MaskTestMixin` adds six inherited test methods covering equal, AND-combined, `is_in`, greater-than, fully-masked, and no-mask-baseline scenarios. See [Masking](../feature-group-patterns/25-masking.md) for the full user-facing spec.
+
+---
+
+## Checklist
+
+- [ ] Base class with `PREFIX_PATTERN`, `calculate_feature`, and an abstract `_compute` hook.
+- [ ] PyArrow implementation first; it is the reference.
+- [ ] Test base in `mloda/testing/.../{your_op}.py` with inherited test methods.
+- [ ] One framework implementation per target framework, each respecting row-preserving if applicable.
+- [ ] One `tests/test_{framework}.py` per framework, importing the framework mixin.
+- [ ] `supported_ops()` overrides only where the framework genuinely cannot do the op.
+- [ ] Mask tests wired if the op consumes values that benefit from conditional inclusion.
+
+---
+
+## Related
+
+- [Overview](01-overview.md) - Where this op fits in the category taxonomy.
+- [Row-preserving contract](02-row-preserving-contract.md) - The invariant row-preserving ops must honor.
+- [Reference implementation pattern](03-reference-implementation.md) - Why PyArrow goes first.
+- [Supported ops per framework](04-supported-ops.md) - Mechanics of the `supported_ops` override.

--- a/docs/guides/data-operation-patterns/index.md
+++ b/docs/guides/data-operation-patterns/index.md
@@ -1,0 +1,20 @@
+# Data Operation Patterns
+
+Data operations are built-in feature groups that transform existing columns: row-preserving analytics (binning, ranks, windows, offsets, percentiles), group-reducing aggregations, and element-wise string transforms.
+
+These guides describe the contracts each category must honor, the cross-framework reference-implementation pattern, and the end-to-end recipe for adding a new operation.
+
+Read them after you are comfortable with the [feature-group patterns](../feature-group-patterns/01-root-features.md). They extend that model with the additional invariants that make a single feature name produce identical results on PyArrow, Pandas, Polars, DuckDB, and SQLite.
+
+## Guides
+
+1. [Overview](01-overview.md) - Categories, naming patterns, and where the code lives
+2. [Row-preserving contract](02-row-preserving-contract.md) - Output row count and order must match input
+3. [Reference implementation pattern](03-reference-implementation.md) - PyArrow is the source of truth
+4. [Supported ops per framework](04-supported-ops.md) - Excluding ops a framework cannot express
+5. [Binning](05-binning.md) - `bin` vs `qbin`, NTILE vs rank, NULL handling
+6. [Window aggregation](06-window-aggregation.md) - Partitioned aggregates broadcast per row
+7. [Percentile, rank, offset](07-percentile-rank-offset.md) - The analytic window family
+8. [Scalar and frame aggregate](08-scalar-and-frame-aggregate.md) - Global broadcast and rolling/expanding windows
+9. [String operations](09-string-operations.md) - Element-wise string transforms
+10. [Adding a new data operation](10-adding-new-operation.md) - End-to-end recipe

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -40,3 +40,11 @@ Extend mloda's capabilities with custom plugins.
 - [Create a feature group](09-create-feature-group.md) - Detailed feature group creation
 - [Create a compute framework plugin](10-create-compute-framework.md) - Add support for new data libraries
 - [Create an extender plugin](11-create-extender.md) - Add logging, tracing, and metrics
+
+---
+
+## 5. Data Operation Patterns
+
+Contracts, cross-framework semantics, and extension path for the built-in data operations (row-preserving, aggregation, string).
+
+- [Data operation patterns index](data-operation-patterns/index.md) - Start here for row-preserving, aggregation, and string operations


### PR DESCRIPTION
## Summary

Adds a new `docs/guides/data-operation-patterns/` section covering the built-in data operations (row-preserving, aggregation, string) that previously had no dedicated guides.

- 10 numbered guides plus an `index.md`, following the existing `feature-group-patterns/` style and numbering convention.
- Covers the row-preserving contract, PyArrow-as-reference pattern, `supported_ops()` mechanism, binning semantics (including the DuckDB `ROW_NUMBER()` workaround for NTILE), window / scalar / frame aggregates, percentile/rank/offset, string ops and the SQLite `reverse` exclusion, plus an end-to-end recipe for adding a new operation.
- Wires the section into `docs/guides/index.md`.

Closes #121.

## Test plan

- [x] `python scripts/lint_docs.py` passes (no broken relative links, no internal-import snippets).
- [x] `PYTEST_WORKERS=1 tox -e python310` passes (2459 tests pass, 109 skipped, ruff + mypy strict + bandit all clean).
- [ ] CI green on the PR.