### PR TITLE
fix(sqlite): exclude upper/lower since native SQL is ASCII-only

### DIFF
--- a/docs/guides/data-operation-patterns/04-supported-ops.md
+++ b/docs/guides/data-operation-patterns/04-supported-ops.md
@@ -27,15 +27,13 @@ The multiple method names exist because different operation categories use diffe
 
 ---
 
-## Example: SQLite excludes `reverse`
+## Example: SQLite excludes `upper`, `lower`, and `reverse`
 
-The string operation `reverse` has no native SQLite equivalent. The framework implementation refuses to match at selection time:
+SQLite has no native `REVERSE`, and its native `UPPER`/`LOWER` are ASCII-only and would diverge from the PyArrow reference on non-ASCII input (e.g. `UPPER('héllo')` returns `'HéLLO'` instead of `'HÉLLO'`). Rather than silently produce divergent results or emulate in SQL, the framework implementation refuses to match all three at selection time:
 
 ```python
 # mloda/community/feature_groups/data_operations/string/sqlite_string.py
 _SQLITE_STRING_EXPRS: dict[str, str] = {
-    "upper":  "UPPER({col})",
-    "lower":  "LOWER({col})",
     "trim":   "TRIM({col})",
     "length": "LENGTH({col})",
 }
@@ -52,10 +50,10 @@ The test class mirrors that decision:
 class TestSqliteStringOps(SqliteTestMixin, StringTestBase):
     @classmethod
     def supported_ops(cls) -> set[str]:
-        return {"upper", "lower", "trim", "length"}
+        return {"trim", "length"}
 ```
 
-With this override, the inherited `test_reverse_*` methods skip with "reverse not supported by this framework" instead of failing.
+With this override, the inherited `test_upper_*`, `test_lower_*`, and `test_reverse_*` methods skip with "not supported by this framework" instead of failing.
 
 ---
 

--- a/docs/guides/data-operation-patterns/09-string-operations.md
+++ b/docs/guides/data-operation-patterns/09-string-operations.md
@@ -4,7 +4,7 @@ Element-wise string transforms: uppercase, lowercase, trim, length, reverse. Row
 
 **What**: `StringFeatureGroup` handles feature names of the form `{col}__{op}` where `op` is one of `upper`, `lower`, `trim`, `length`, `reverse`.
 **When**: You need cleaned or derived text alongside the original column.
-**Why**: These cover the overwhelmingly common cases. Four of the five (`upper`, `lower`, `trim`, `length`) map directly to a native function in every target framework. `reverse` is the one exception: SQLite has no native REVERSE, so the SQLite implementation refuses to match it at resolution time.
+**Why**: These cover the overwhelmingly common cases. `trim` and `length` map directly to a native function in every target framework. `upper`, `lower`, and `reverse` are not available on every framework: SQLite has no native `REVERSE`, and its native `UPPER`/`LOWER` are ASCII-only and diverge from the PyArrow reference on non-ASCII input. SQLite refuses to match all three at resolution time rather than silently producing divergent results.
 **Where**: `mloda/community/feature_groups/data_operations/string/`.
 **How**: Name the feature; no context options are required.
 
@@ -63,9 +63,9 @@ All five operations propagate NULL. A NULL input produces a NULL output; they ne
 | Pandas | `.str.upper()`, `.str.lower()`, `.str.strip()`, `.str.len()`, `.str[::-1]` (NULL-safe) |
 | Polars lazy | `col.str.to_uppercase()`, `.to_lowercase()`, `.strip_chars()`, `.len_chars()`, `.reverse()` |
 | DuckDB | `UPPER`, `LOWER`, `TRIM`, `LENGTH`, `REVERSE` |
-| SQLite | `TRIM`, `LENGTH` native; `upper` / `lower` applied in Python because SQLite's native `UPPER`/`LOWER` are ASCII-only |
+| SQLite | `TRIM`, `LENGTH` only |
 
-SQLite has no native `REVERSE`. The implementation refuses to match `__reverse` at resolution time rather than emulating it in SQL:
+SQLite refuses to match `upper`, `lower`, and `reverse` at resolution time. `UPPER`/`LOWER` are ASCII-only in SQLite and would diverge from the PyArrow reference on non-ASCII input; `REVERSE` has no native function. Rather than silently producing divergent results or emulating in SQL, the SQLite feature group excludes all three:
 
 ```python
 # mloda/community/feature_groups/data_operations/string/sqlite_string.py
@@ -74,16 +74,9 @@ _SQLITE_STRING_EXPRS: dict[str, str] = {
     "length": "LENGTH({col})",
 }
 
-_PYTHON_STRING_FUNCS: dict[str, Callable[[str], Any]] = {
-    "upper": str.upper,  # Python is unicode-aware; SQLite UPPER is ASCII-only
-    "lower": str.lower,
-}
-
-_SUPPORTED_OPS: frozenset[str] = frozenset(_SQLITE_STRING_EXPRS) | frozenset(_PYTHON_STRING_FUNCS)
-
 @classmethod
 def _validate_string_match(cls, feature_name, operation_config, source_feature) -> bool:
-    return operation_config in _SUPPORTED_OPS
+    return operation_config in _SQLITE_STRING_EXPRS
 ```
 
 The SQLite test class mirrors the restriction:
@@ -92,10 +85,10 @@ The SQLite test class mirrors the restriction:
 class TestSqliteStringOps(SqliteTestMixin, StringTestBase):
     @classmethod
     def supported_ops(cls) -> set[str]:
-        return {"upper", "lower", "trim", "length"}
+        return {"trim", "length"}
 ```
 
-If you request `name__reverse` with `compute_frameworks={"SqliteRelation"}`, the SQLite feature group will not match and the engine falls back to resolving the feature elsewhere (or errors). See [Supported ops](04-supported-ops.md) for how this pattern generalizes.
+If you request `name__upper`, `name__lower`, or `name__reverse` with `compute_frameworks={"SqliteRelation"}`, the SQLite feature group will not match and the engine falls back to resolving the feature elsewhere (or errors). See [Supported ops](04-supported-ops.md) for how this pattern generalizes.
 
 ---
 
@@ -107,6 +100,6 @@ String operations are intentionally narrow. If you need `regex_replace`, `split`
 
 ## Related
 
-- [Supported ops per framework](04-supported-ops.md) - The mechanism SQLite uses to exclude `reverse`.
+- [Supported ops per framework](04-supported-ops.md) - The mechanism SQLite uses to exclude `upper`, `lower`, and `reverse`.
 - [Adding a new data operation](10-adding-new-operation.md) - Build a separate feature group for richer string ops.
 - [Feature naming](../feature-group-patterns/13-feature-naming.md) - General rules for the `{col}__{op}` convention.

--- a/docs/guides/data-operation-patterns/09-string-operations.md
+++ b/docs/guides/data-operation-patterns/09-string-operations.md
@@ -63,22 +63,27 @@ All five operations propagate NULL. A NULL input produces a NULL output; they ne
 | Pandas | `.str.upper()`, `.str.lower()`, `.str.strip()`, `.str.len()`, `.str[::-1]` (NULL-safe) |
 | Polars lazy | `col.str.to_uppercase()`, `.to_lowercase()`, `.strip_chars()`, `.len_chars()`, `.reverse()` |
 | DuckDB | `UPPER`, `LOWER`, `TRIM`, `LENGTH`, `REVERSE` |
-| SQLite | `UPPER`, `LOWER`, `TRIM`, `LENGTH` only |
+| SQLite | `TRIM`, `LENGTH` native; `upper` / `lower` applied in Python because SQLite's native `UPPER`/`LOWER` are ASCII-only |
 
 SQLite has no native `REVERSE`. The implementation refuses to match `__reverse` at resolution time rather than emulating it in SQL:
 
 ```python
 # mloda/community/feature_groups/data_operations/string/sqlite_string.py
 _SQLITE_STRING_EXPRS: dict[str, str] = {
-    "upper":  "UPPER({col})",
-    "lower":  "LOWER({col})",
     "trim":   "TRIM({col})",
     "length": "LENGTH({col})",
 }
 
+_PYTHON_STRING_FUNCS: dict[str, Callable[[str], Any]] = {
+    "upper": str.upper,  # Python is unicode-aware; SQLite UPPER is ASCII-only
+    "lower": str.lower,
+}
+
+_SUPPORTED_OPS: frozenset[str] = frozenset(_SQLITE_STRING_EXPRS) | frozenset(_PYTHON_STRING_FUNCS)
+
 @classmethod
 def _validate_string_match(cls, feature_name, operation_config, source_feature) -> bool:
-    return operation_config in _SQLITE_STRING_EXPRS
+    return operation_config in _SUPPORTED_OPS
 ```
 
 The SQLite test class mirrors the restriction:

--- a/mloda/community/feature_groups/data_operations/string/sqlite_string.py
+++ b/mloda/community/feature_groups/data_operations/string/sqlite_string.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, Callable
+
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
@@ -11,14 +13,23 @@ from mloda.community.feature_groups.data_operations.string.base import (
     StringFeatureGroup,
 )
 
-# SQLite native string functions.
-# reverse is not supported natively in SQLite.
+# SQLite native string functions whose behavior matches the PyArrow reference
+# for the canonical test data (TRIM strips ASCII whitespace; LENGTH on TEXT
+# returns codepoints, same as Python len()).
 _SQLITE_STRING_EXPRS: dict[str, str] = {
-    "upper": "UPPER({col})",
-    "lower": "LOWER({col})",
     "trim": "TRIM({col})",
     "length": "LENGTH({col})",
 }
+
+# Ops that SQLite CAN handle in SQL but ASCII-only, so we apply Python's
+# Unicode-aware equivalents post-fetch instead. Matches PyArrow reference.
+_PYTHON_STRING_FUNCS: dict[str, Callable[[str], Any]] = {
+    "upper": str.upper,
+    "lower": str.lower,
+}
+
+# reverse is not supported natively in SQLite.
+_SUPPORTED_OPS: frozenset[str] = frozenset(_SQLITE_STRING_EXPRS) | frozenset(_PYTHON_STRING_FUNCS)
 
 
 class SqliteStringOps(StringFeatureGroup):
@@ -29,7 +40,7 @@ class SqliteStringOps(StringFeatureGroup):
     @classmethod
     def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
         """Reject 'reverse' at match time since SQLite has no native reverse function."""
-        return operation_config in _SQLITE_STRING_EXPRS
+        return operation_config in _SUPPORTED_OPS
 
     @classmethod
     def _compute_string(
@@ -40,14 +51,33 @@ class SqliteStringOps(StringFeatureGroup):
         op: str,
     ) -> SqliteRelation:
 
+        quoted_source = quote_ident(source_col)
+        quoted_feature = quote_ident(feature_name)
+        qrn = quote_ident("__mloda_rn__")
+
+        if op in _PYTHON_STRING_FUNCS:
+            func = _PYTHON_STRING_FUNCS[op]
+            sql = " ".join(
+                [
+                    "SELECT",
+                    f"{quoted_source} AS {quoted_feature},",
+                    f"ROW_NUMBER() OVER (ORDER BY rowid) AS {qrn}",
+                    "FROM",
+                    f"{quote_ident(data.table_name)}",
+                    "ORDER BY",
+                    qrn,
+                ]
+            )
+            cursor = data.connection.execute(sql)
+            rows = cursor.fetchall()
+            result_values = [None if row[0] is None else func(row[0]) for row in rows]
+            return data.append_column(feature_name, result_values)
+
         expr_template = _SQLITE_STRING_EXPRS.get(op)
         if expr_template is None:
             raise ValueError(f"Unsupported string operation for SQLite: {op}")
 
-        quoted_source = quote_ident(source_col)
         expr = expr_template.format(col=quoted_source)
-        quoted_feature = quote_ident(feature_name)
-        qrn = quote_ident("__mloda_rn__")
 
         sql = " ".join(
             [

--- a/mloda/community/feature_groups/data_operations/string/sqlite_string.py
+++ b/mloda/community/feature_groups/data_operations/string/sqlite_string.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
-
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
@@ -13,23 +11,15 @@ from mloda.community.feature_groups.data_operations.string.base import (
     StringFeatureGroup,
 )
 
-# SQLite native string functions whose behavior matches the PyArrow reference
-# for the canonical test data (TRIM strips ASCII whitespace; LENGTH on TEXT
-# returns codepoints, same as Python len()).
+# SQLite's native UPPER/LOWER are ASCII-only: UPPER('héllo') returns 'HéLLO'
+# instead of 'HÉLLO'. Rather than emulate unicode-aware semantics in Python
+# and risk silent divergence from the PyArrow reference, SQLite refuses to
+# match upper/lower and lets the resolver fall back to another framework.
+# The same pattern is used for 'reverse', which SQLite has no native function for.
 _SQLITE_STRING_EXPRS: dict[str, str] = {
     "trim": "TRIM({col})",
     "length": "LENGTH({col})",
 }
-
-# Ops that SQLite CAN handle in SQL but ASCII-only, so we apply Python's
-# Unicode-aware equivalents post-fetch instead. Matches PyArrow reference.
-_PYTHON_STRING_FUNCS: dict[str, Callable[[str], Any]] = {
-    "upper": str.upper,
-    "lower": str.lower,
-}
-
-# reverse is not supported natively in SQLite.
-_SUPPORTED_OPS: frozenset[str] = frozenset(_SQLITE_STRING_EXPRS) | frozenset(_PYTHON_STRING_FUNCS)
 
 
 class SqliteStringOps(StringFeatureGroup):
@@ -39,8 +29,10 @@ class SqliteStringOps(StringFeatureGroup):
 
     @classmethod
     def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
-        """Reject 'reverse' at match time since SQLite has no native reverse function."""
-        return operation_config in _SUPPORTED_OPS
+        """SQLite only supports trim and length. upper/lower are ASCII-only
+        in SQLite so they diverge from the PyArrow reference; reverse has
+        no native SQLite function. All three are refused at match time."""
+        return operation_config in _SQLITE_STRING_EXPRS
 
     @classmethod
     def _compute_string(
@@ -51,33 +43,14 @@ class SqliteStringOps(StringFeatureGroup):
         op: str,
     ) -> SqliteRelation:
 
-        quoted_source = quote_ident(source_col)
-        quoted_feature = quote_ident(feature_name)
-        qrn = quote_ident("__mloda_rn__")
-
-        if op in _PYTHON_STRING_FUNCS:
-            func = _PYTHON_STRING_FUNCS[op]
-            sql = " ".join(
-                [
-                    "SELECT",
-                    f"{quoted_source} AS {quoted_feature},",
-                    f"ROW_NUMBER() OVER (ORDER BY rowid) AS {qrn}",
-                    "FROM",
-                    f"{quote_ident(data.table_name)}",
-                    "ORDER BY",
-                    qrn,
-                ]
-            )
-            cursor = data.connection.execute(sql)
-            rows = cursor.fetchall()
-            result_values = [None if row[0] is None else func(row[0]) for row in rows]
-            return data.append_column(feature_name, result_values)
-
         expr_template = _SQLITE_STRING_EXPRS.get(op)
         if expr_template is None:
             raise ValueError(f"Unsupported string operation for SQLite: {op}")
 
+        quoted_source = quote_ident(source_col)
         expr = expr_template.format(col=quoted_source)
+        quoted_feature = quote_ident(feature_name)
+        qrn = quote_ident("__mloda_rn__")
 
         sql = " ".join(
             [

--- a/mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import pyarrow as pa
-
 from mloda.community.feature_groups.data_operations.string.sqlite_string import (
     SqliteStringOps,
 )
-from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
 from mloda.testing.feature_groups.data_operations.mixins.sqlite import SqliteTestMixin
 from mloda.testing.feature_groups.data_operations.string.string import (
     StringTestBase,
@@ -19,41 +16,38 @@ from mloda.testing.feature_groups.data_operations.string.string import (
 class TestSqliteStringOps(SqliteTestMixin, StringTestBase):
     """All tests inherited from the base class.
 
-    SQLite does not support the 'reverse' operation natively,
-    so supported_ops excludes it.
+    SQLite supports only 'trim' and 'length' natively in a way that matches
+    the PyArrow reference. 'upper'/'lower' are ASCII-only in SQLite and
+    'reverse' has no native SQLite function, so all three are refused at
+    match time and resolved by another framework.
     """
 
     @classmethod
     def supported_ops(cls) -> set[str]:
-        return {"upper", "lower", "trim", "length"}
+        return {"trim", "length"}
 
     @classmethod
     def implementation_class(cls) -> Any:
         return SqliteStringOps
 
-    def test_unicode_lower_regression(self) -> None:
-        """Regression test: LOWER must lowercase non-ASCII uppercase characters.
 
-        SQLite's native LOWER() is ASCII-only and leaves characters like
-        'É', 'Ö', 'Ω' unchanged. PyArrow / Python str.lower() handle the
-        full unicode range. This test locks in the correct unicode-aware
-        behavior so a regression to ASCII-only LOWER is caught.
-        """
-        table = pa.table(
-            {
-                "name": pa.array(["H\u00c9LLO", "W\u00d6RLD", "\u03a9-OMEGA"], type=pa.string()),
-            }
-        )
-        data = self.create_test_data(table)
-        fs = make_feature_set("name__lower")
-        result = self.implementation_class().calculate_feature(data, fs)
+class TestSqliteUnsupportedOps:
+    """SQLite refuses upper/lower/reverse at match time; the resolver falls
+    back to another framework rather than silently producing ASCII-only output."""
 
-        result_col = self.extract_column(result, "name__lower")
-        assert result_col == ["h\u00e9llo", "w\u00f6rld", "\u03c9-omega"]
+    def test_upper_does_not_match(self) -> None:
+        from mloda.core.abstract_plugins.components.options import Options
 
+        options = Options()
+        result = SqliteStringOps.match_feature_group_criteria("name__upper", options, None)
+        assert result is False
 
-class TestSqliteReverseUnsupported:
-    """SQLite does not support 'reverse', so it should not match at all."""
+    def test_lower_does_not_match(self) -> None:
+        from mloda.core.abstract_plugins.components.options import Options
+
+        options = Options()
+        result = SqliteStringOps.match_feature_group_criteria("name__lower", options, None)
+        assert result is False
 
     def test_reverse_does_not_match(self) -> None:
         from mloda.core.abstract_plugins.components.options import Options
@@ -66,6 +60,6 @@ class TestSqliteReverseUnsupported:
         from mloda.core.abstract_plugins.components.options import Options
 
         options = Options()
-        for op in ("upper", "lower", "trim", "length"):
+        for op in ("trim", "length"):
             result = SqliteStringOps.match_feature_group_criteria(f"name__{op}", options, None)
             assert result is True, f"Expected name__{op} to match SqliteStringOps"

--- a/mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
+import pyarrow as pa
 
 from mloda.community.feature_groups.data_operations.string.sqlite_string import (
     SqliteStringOps,
 )
+from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
 from mloda.testing.feature_groups.data_operations.mixins.sqlite import SqliteTestMixin
 from mloda.testing.feature_groups.data_operations.string.string import (
     StringTestBase,
@@ -19,9 +20,7 @@ class TestSqliteStringOps(SqliteTestMixin, StringTestBase):
     """All tests inherited from the base class.
 
     SQLite does not support the 'reverse' operation natively,
-    so supported_ops excludes it. SQLite's UPPER/LOWER only
-    handle ASCII characters, so unicode accented characters
-    are not transformed.
+    so supported_ops excludes it.
     """
 
     @classmethod
@@ -29,23 +28,28 @@ class TestSqliteStringOps(SqliteTestMixin, StringTestBase):
         return {"upper", "lower", "trim", "length"}
 
     @classmethod
-    def expected_upper(cls) -> list[Any]:
-        # SQLite UPPER only handles ASCII; accent e (\u00e9) stays lowercase
-        return ["ALICE", "BOB", None, "", " EVE ", "FRANK", "GRACE", "ALICE", "  ", "BOB", "H\u00e9LLO", None]
-
-    # Note: expected_lower is NOT overridden because the test data's only
-    # non-ASCII character (accent e in "hello") is already lowercase.
-    # SQLite's ASCII-only LOWER happens to produce the correct result
-    # by coincidence. If test data included uppercase accented characters,
-    # this override would be required.
-
-    @classmethod
     def implementation_class(cls) -> Any:
         return SqliteStringOps
 
-    def test_cross_framework_upper(self) -> None:
-        """Skip: SQLite UPPER differs from PyArrow for non-ASCII characters."""
-        pytest.skip("SQLite UPPER handles only ASCII; unicode results differ from PyArrow")
+    def test_unicode_lower_regression(self) -> None:
+        """Regression test: LOWER must lowercase non-ASCII uppercase characters.
+
+        SQLite's native LOWER() is ASCII-only and leaves characters like
+        'É', 'Ö', 'Ω' unchanged. PyArrow / Python str.lower() handle the
+        full unicode range. This test locks in the correct unicode-aware
+        behavior so a regression to ASCII-only LOWER is caught.
+        """
+        table = pa.table(
+            {
+                "name": pa.array(["H\u00c9LLO", "W\u00d6RLD", "\u03a9-OMEGA"], type=pa.string()),
+            }
+        )
+        data = self.create_test_data(table)
+        fs = make_feature_set("name__lower")
+        result = self.implementation_class().calculate_feature(data, fs)
+
+        result_col = self.extract_column(result, "name__lower")
+        assert result_col == ["h\u00e9llo", "w\u00f6rld", "\u03c9-omega"]
 
 
 class TestSqliteReverseUnsupported:

--- a/mloda/testing/feature_groups/data_operations/string/string.py
+++ b/mloda/testing/feature_groups/data_operations/string/string.py
@@ -134,6 +134,7 @@ class StringTestBase(DataOpsTestBase):
 
     def test_upper(self) -> None:
         """Convert name column to uppercase."""
+        self._skip_if_unsupported("upper")
         fs = make_feature_set("name__upper")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -145,6 +146,7 @@ class StringTestBase(DataOpsTestBase):
 
     def test_lower(self) -> None:
         """Convert name column to lowercase."""
+        self._skip_if_unsupported("lower")
         fs = make_feature_set("name__lower")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -195,6 +197,7 @@ class StringTestBase(DataOpsTestBase):
 
     def test_empty_string_upper(self) -> None:
         """Row 3 has empty string. Upper of empty string is empty string."""
+        self._skip_if_unsupported("upper")
         fs = make_feature_set("name__upper")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
         result_col = self.extract_column(result, "name__upper")
@@ -218,21 +221,25 @@ class StringTestBase(DataOpsTestBase):
     # -- Row-preserving and type checks --------------------------------------
 
     def test_output_rows_equal_input_rows(self) -> None:
-        """Output must have exactly 12 rows, same as input."""
-        fs = make_feature_set("name__upper")
+        """Output must have exactly 12 rows, same as input. Uses 'trim' so
+        the test is independent of which ops a given framework supports."""
+        fs = make_feature_set("name__trim")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
         assert self.get_row_count(result) == 12
 
     def test_new_column_added(self) -> None:
-        """The string result column should be added to the output."""
-        fs = make_feature_set("name__lower")
+        """The string result column should be added to the output. Uses 'trim'
+        so the test is independent of which ops a given framework supports."""
+        fs = make_feature_set("name__trim")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "name__lower")
+        result_col = self.extract_column(result, "name__trim")
         assert len(result_col) == 12
 
     def test_result_has_correct_type(self) -> None:
-        """The result of calculate_feature must be the expected framework type."""
-        fs = make_feature_set("name__upper")
+        """The result of calculate_feature must be the expected framework type.
+        Uses 'trim' so the test is independent of which ops a given framework
+        supports."""
+        fs = make_feature_set("name__trim")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
         assert isinstance(result, self.get_expected_type())
 
@@ -240,10 +247,12 @@ class StringTestBase(DataOpsTestBase):
 
     def test_cross_framework_upper(self) -> None:
         """Upper must match reference."""
+        self._skip_if_unsupported("upper")
         self._compare_with_reference("name__upper")
 
     def test_cross_framework_lower(self) -> None:
         """Lower must match reference."""
+        self._skip_if_unsupported("lower")
         self._compare_with_reference("name__lower")
 
     def test_cross_framework_trim(self) -> None:
@@ -270,6 +279,7 @@ class StringTestBase(DataOpsTestBase):
 
     def test_all_null_column_upper(self) -> None:
         """Upper on an all-null column should produce all None."""
+        self._skip_if_unsupported("upper")
         table = pa.table(
             {
                 "name": pa.array([None, None, None], type=pa.string()),
@@ -300,6 +310,7 @@ class StringTestBase(DataOpsTestBase):
 
     def test_option_based_upper(self) -> None:
         """Option-based configuration (not string pattern) produces the same result."""
+        self._skip_if_unsupported("upper")
         from mloda.core.abstract_plugins.components.feature_set import FeatureSet
         from mloda.core.abstract_plugins.components.options import Options
         from mloda.user import Feature


### PR DESCRIPTION
## Summary

SQLite's native `UPPER`/`LOWER` are ASCII-only: `UPPER('héllo')` returns `'HéLLO'` in SQLite but `'HÉLLO'` in every other framework (PyArrow reference). The divergence was previously hidden behind an `expected_upper()` test override and a `pytest.skip` on the cross-framework comparison.

Align with the existing `reverse` pattern: if SQLite cannot implement the op correctly, don't support it. `SqliteStringOps` refuses to match `name__upper` / `name__lower` at resolution time, so the mloda engine routes the feature to another framework (Pandas, Polars, DuckDB, PyArrow) instead of producing divergent results.

- `_SQLITE_STRING_EXPRS` in `sqlite_string.py` now contains only `trim` and `length`. `_validate_string_match` rejects `upper`, `lower`, and `reverse`.
- Test base (`mloda/testing/.../string/string.py`): gate `test_upper`, `test_lower`, `test_cross_framework_upper`, `test_cross_framework_lower`, `test_empty_string_upper`, `test_all_null_column_upper`, `test_option_based_upper` on `_skip_if_unsupported` so any framework can declare these unsupported. Switch generic row/type/column tests (`test_output_rows_equal_input_rows`, `test_new_column_added`, `test_result_has_correct_type`) from `name__upper`/`name__lower` to `name__trim` so they remain framework-independent.
- SQLite test class (`tests/test_sqlite.py`): `supported_ops()` now returns `{"trim", "length"}`. Add `test_upper_does_not_match` and `test_lower_does_not_match` alongside the existing `test_reverse_does_not_match`. Remove the `expected_upper()` override and the `test_cross_framework_upper` skip.
- Docs (`09-string-operations.md`, `04-supported-ops.md`): describe the three SQLite exclusions together and explain the reasoning (silent divergence is worse than an explicit match failure).

Closes #146.

## Test plan

- [x] `PYTEST_WORKERS=1 .venv/bin/python -m pytest mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py -v` → 16 passed, 9 skipped
- [x] `PYTEST_WORKERS=1 .venv/bin/python -m pytest mloda/community/feature_groups/data_operations/string/` → 143 passed, 9 skipped
- [x] `PYTEST_WORKERS=1 tox` → 2455 passed, 115 skipped; `ruff format --check`, `ruff check`, `mypy --strict`, `bandit` all clean
