### PR TITLE
docs: known-divergences guide for cross-framework data operations (refs #146)

### DIFF
--- a/docs/guides/data-operation-patterns/01-overview.md
+++ b/docs/guides/data-operation-patterns/01-overview.md
@@ -75,4 +75,5 @@ Each feature name resolves to one of the built-in data-operation feature groups.
 
 - [Row-preserving contract](02-row-preserving-contract.md) explains the central invariant that shapes most of this section.
 - [Reference implementation pattern](03-reference-implementation.md) explains why PyArrow is the source of truth.
+- [Known divergences](known-divergences.md) lists every audited case where a framework would otherwise produce a different result, and the mitigation for each.
 - [Adding a new data operation](10-adding-new-operation.md) is the end-to-end recipe if you want to extend this system.

--- a/docs/guides/data-operation-patterns/03-reference-implementation.md
+++ b/docs/guides/data-operation-patterns/03-reference-implementation.md
@@ -73,4 +73,5 @@ Do not "fix" a non-PyArrow framework to agree with the PyArrow bug. The referenc
 
 - [Row-preserving contract](02-row-preserving-contract.md) - The row-count-and-order invariant that the reference comparison enforces.
 - [Supported ops per framework](04-supported-ops.md) - How a framework skips comparisons for ops it cannot express.
+- [Known divergences](known-divergences.md) - Audited cases where a framework's native operator would diverge from PyArrow, and the fix or exclusion used.
 - [Adding a new data operation](10-adding-new-operation.md) - Where to put the PyArrow reference when adding an op.

--- a/docs/guides/data-operation-patterns/index.md
+++ b/docs/guides/data-operation-patterns/index.md
@@ -18,3 +18,4 @@ Read them after you are comfortable with the [feature-group patterns](../feature
 8. [Scalar and frame aggregate](08-scalar-and-frame-aggregate.md) - Global broadcast and rolling/expanding windows
 9. [String operations](09-string-operations.md) - Element-wise string transforms
 10. [Adding a new data operation](10-adding-new-operation.md) - End-to-end recipe
+11. [Known divergences](known-divergences.md) - Audited cases where a framework would diverge from the PyArrow reference, with the mitigation for each

--- a/docs/guides/data-operation-patterns/known-divergences.md
+++ b/docs/guides/data-operation-patterns/known-divergences.md
@@ -1,0 +1,135 @@
+# Known Divergences
+
+Authoritative list of cases where a non-PyArrow framework would, without intervention, produce a different result from the PyArrow reference on realistic inputs. For each one, this page records the mitigation and how to detect a regression.
+
+**What**: Every audited case where a framework's native operator diverges from PyArrow semantics.
+**When**: Read this before adding a new data-operation implementation, a new framework, or changing null or tie-breaking behavior in an existing one.
+**Why**: Divergences of this kind are the most dangerous class of bug: the feature resolves, the pipeline succeeds, the output is silently wrong. Keeping a single list prevents that category from growing unnoticed.
+**Where**: Audit of the 10 data operations under `mloda/community/feature_groups/data_operations/`.
+**How**: Each entry records the divergence, the mitigation, and the test (or `supported_ops()` exclusion) that keeps it from silently regressing.
+
+---
+
+## Categories of divergence
+
+Divergences fall into three kinds, handled in three different places.
+
+| Kind | Example | Mitigation |
+|---|---|---|
+| Implementation fix | Polars `sum()` returns `0` for an all-null group; PyArrow returns `null`. | The framework implementation detects the edge case and returns the PyArrow-equivalent result. |
+| Excluded op | SQLite `UPPER`/`LOWER` are ASCII-only; `REVERSE` has no native function. | `_validate_string_match` refuses to resolve the feature; `supported_ops()` skips the corresponding tests. See [Supported ops](04-supported-ops.md). |
+| Accepted tolerance | Float accumulation order differs between columnar reductions and SQL window functions. | Cross-framework comparison uses `pytest.approx(rel=1e-6)` when the test flips `use_approx=True`. |
+
+An entry is added here only after a cross-framework test or an explicit audit has confirmed the divergence.
+
+---
+
+## Entries
+
+### Polars `sum()` on an all-null group returns `0`
+
+- **Operations**: `aggregation`, `scalar_aggregate`, `window_aggregation`.
+- **Where it lives**: `mloda/community/feature_groups/data_operations/aggregation/polars_lazy_aggregation.py`, `.../row_preserving/scalar_aggregate/polars_lazy_scalar_aggregate.py`, `.../row_preserving/window_aggregation/polars_lazy_window_aggregation.py`.
+- **Reference behavior**: PyArrow's `pc.sum` returns `null` when every input value in the group is null.
+- **Native Polars behavior**: `pl.col(...).sum()` returns `0` for the same input.
+- **Mitigation kind**: Implementation fix.
+- **How**: The Polars implementation wraps the `sum` expression with `pl.when(count > 0).then(sum).otherwise(None)`, so an all-null group maps back to `null`.
+- **Regression signal**: The canonical 12-row fixture has a `score` column that is all-null. `test_null_policy_skip_all_null_column` in `mloda/testing/feature_groups/data_operations/aggregation/aggregation.py` asserts `score__sum_agg` is all-null per region, and fails if this correction is removed.
+
+### Polars `rank()` returns null for null inputs
+
+- **Operations**: `rank` (all rank types: `row_number`, `rank`, `dense_rank`, `percent_rank`, `ntile_N`, `top_N`, `bottom_N`).
+- **Where it lives**: `mloda/community/feature_groups/data_operations/row_preserving/rank/polars_lazy_rank.py`.
+- **Reference behavior**: PyArrow and every SQL engine assign null rows a real integer rank at the end of the ordering (nulls-last).
+- **Native Polars behavior**: `pl.col(x).rank(...)` propagates nulls: null rows get `null` rank.
+- **Mitigation kind**: Implementation fix.
+- **How**: An internal `_NULL_FLAG_COL` helper counts nulls per partition; null rows are assigned `non_null_count + k` where `k` depends on the rank method. See `_row_number_nulls_last` and the `rank_type` branches in `polars_lazy_rank.py`.
+- **Regression signal**: Group B in the canonical fixture has `value_int = [None, 50, 30, 60]`. Tests like `test_row_number_ranked`, `test_rank_ranked`, `test_dense_rank_ranked`, `test_percent_rank_ranked` in `mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py` assert the null row receives the last rank integer, not a null.
+
+### Mode tie-breaking by first occurrence
+
+- **Operations**: `aggregation` (`mode` agg type), `window_aggregation` (`mode` agg type).
+- **Where it lives**: `mloda/community/feature_groups/data_operations/aggregation/polars_lazy_aggregation.py` (`_mode_with_insertion_order`); Pandas uses a `Counter`-based helper in `pandas_helpers.py`.
+- **Reference behavior**: PyArrow's `pc.mode` breaks ties by first occurrence in the input ordering.
+- **Native framework behavior**: Polars' `.mode()` and Pandas' `.mode()` break ties differently (sorted order / multiple returned values / unspecified).
+- **Mitigation kind**: Implementation fix.
+- **How**: Both frameworks explicitly rank candidate values by `(count desc, first_occurrence_index asc)` and take the head.
+- **Regression signal**: The canonical fixture has values that tie; mode tests compare against the PyArrow reference via `_compare_with_reference`.
+
+### SQLite `UPPER`/`LOWER` are ASCII-only; no native `REVERSE`
+
+- **Operations**: `string` (`upper`, `lower`, `reverse`).
+- **Where it lives**: `mloda/community/feature_groups/data_operations/string/sqlite_string.py`.
+- **Reference behavior**: PyArrow's `pc.utf8_upper("héllo")` is `"HÉLLO"`.
+- **Native SQLite behavior**: `UPPER('héllo')` returns `'HéLLO'`. `REVERSE` is not implemented.
+- **Mitigation kind**: Excluded op.
+- **How**: `SqliteStringOps._validate_string_match` returns `True` only for `trim` and `length`. Requesting `name__upper`, `name__lower`, or `name__reverse` with `compute_frameworks={"SqliteRelation"}` refuses to match at resolution time. The test class mirrors the decision through `supported_ops()`.
+- **Regression signal**: `test_sqlite.py` inherits the unicode expected values (row 10 = `"héllo"` / `"HÉLLO"` / `"oll\u00e9h"`) and `supported_ops()` restricts the test suite to `{"trim", "length"}`. Adding an op without also enabling a Unicode-safe expression is caught immediately by cross-framework comparison.
+- **Related**: Resolved from #146 via #147.
+
+### Float accumulation order across SQL engines vs. columnar reductions
+
+- **Operations**: `aggregation`, `scalar_aggregate`, `window_aggregation`, `percentile` (`avg`, `mean`, `std`, `var`, percentile interpolation).
+- **Where it lives**: Integration tests that flip `use_approx=True` on the cross-framework comparison (e.g. `aggregation/tests/test_integration.py:96`, `scalar_aggregate/tests/test_integration.py:82`, `window_aggregation/tests/test_integration.py:81`, `percentile/tests/test_integration.py:78`).
+- **Reference behavior**: PyArrow computes a columnar mean in a deterministic reduction tree.
+- **Native SQL behavior**: DuckDB and SQLite accumulate with a running sum in query execution order, producing tiny relative-precision differences (~`1e-12` to `1e-8`).
+- **Mitigation kind**: Accepted tolerance.
+- **How**: The cross-framework assertion uses `pytest.approx(ref_value, rel=1e-6)` when the test's `use_approx` class attribute is `True`. Integer ops and null-equality still require exact match.
+- **Regression signal**: If a change makes the relative error exceed `1e-6`, the approx check fails with a loud message pointing at the specific row.
+
+### PyArrow lacks native `frame_aggregate`, `offset`, `percentile`, `rank`
+
+- **Operations**: `row_preserving/frame_aggregate`, `.../offset`, `.../percentile`, `.../rank`.
+- **Reference behavior**: PyArrow is the reference *for correctness semantics*, but it does not provide native rolling/expanding, LAG/LEAD, percentile, or rank. The reference implementations for these ops live in pure Python over PyArrow arrays.
+- **Mitigation kind**: Excluded op (from the test suite, not from routing).
+- **How**: The `supported_ops()` / `supported_agg_types()` on each operation's PyArrow test class returns an empty or reduced set so the suite does not try to compare against an implementation that does not exist. See `aggregation/tests/test_pyarrow.py` and `row_preserving/window_aggregation/tests/test_pyarrow.py`.
+- **Regression signal**: Restoring the op on PyArrow requires both providing a native implementation and re-expanding the supported set; no silent skip is possible.
+- **Related**: This is the "Category 1" case described in issue #146; listed here for completeness.
+
+### SQLite lacks `percentile` and `reverse` (and the string ops above)
+
+- **Operations**: `row_preserving/percentile` and `string`.
+- **Mitigation kind**: Excluded op.
+- **How**: `supported_ops()` / `supported_agg_types()` on each SQLite test class restricts the covered set. See `row_preserving/percentile/tests/test_sqlite.py` and `string/tests/test_sqlite.py`.
+- **Related**: Category 1 of issue #146.
+
+---
+
+## Audit coverage (2026-04-13)
+
+The full audit covered all ten data operations: `binning`, `datetime`, `frame_aggregate`, `offset`, `percentile`, `rank`, `scalar_aggregate`, `window_aggregation`, `aggregation`, `string`. Every implementation file and every `*TestBase` was read.
+
+| Operation | Frameworks audited | New divergence found? |
+|---|---|---|
+| aggregation | PyArrow, Pandas, Polars lazy, DuckDB, SQLite | No (all mitigated above) |
+| binning | PyArrow, Pandas, Polars lazy, DuckDB, SQLite | No |
+| datetime | PyArrow, Pandas, Polars lazy, DuckDB, SQLite | No |
+| frame_aggregate | Pandas, Polars lazy, DuckDB, SQLite | No |
+| offset | Pandas, Polars lazy, DuckDB, SQLite | No |
+| percentile | Pandas, Polars lazy, DuckDB | No (float tolerance already accepted) |
+| rank | Pandas, Polars lazy, DuckDB, SQLite | No (all mitigated above) |
+| scalar_aggregate | PyArrow, Pandas, Polars lazy, DuckDB, SQLite | No |
+| string | PyArrow, Pandas, Polars lazy, DuckDB, SQLite | No (SQLite ASCII mitigated) |
+| window_aggregation | Pandas, Polars lazy, DuckDB, SQLite | No (all mitigated above) |
+
+No unmitigated divergences were found. The `expected_*()` hooks defined on `StringTestBase` (`expected_upper`, `expected_lower`, `expected_trim`, `expected_length`, `expected_reverse`) are present for future use but are not currently overridden by any framework: after #147, SQLite no longer matches the unicode-unsafe ops instead of returning a divergent result.
+
+---
+
+## When to add to this page
+
+Add a new entry here if and only if all three hold:
+
+1. A framework operator produces a measurably different result from PyArrow on a realistic input.
+2. That difference cannot be hidden by the cross-framework comparison (i.e. it would require an `expected_*()` override, a `use_approx=True` bump, a `pytest.skip`, or a `supported_ops()` exclusion).
+3. The decision (fix vs. document vs. exclude) has been made and landed in code.
+
+Do not add speculative entries. If an audit only uncovered a hypothetical divergence, add a failing regression test first so the entry corresponds to something the test suite measures.
+
+---
+
+## Related
+
+- [Reference implementation pattern](03-reference-implementation.md) - Why PyArrow is authoritative.
+- [Supported ops per framework](04-supported-ops.md) - The exclusion mechanism used when a framework cannot match PyArrow.
+- [Row-preserving contract](02-row-preserving-contract.md) - The invariant every row-preserving op must honor.


### PR DESCRIPTION
## Summary
- Adds \`docs/guides/data-operation-patterns/known-divergences.md\`, an authoritative list of every audited case where a non-PyArrow framework would diverge from the PyArrow reference, with the mitigation used for each.
- Audits all 10 data operations (\`aggregation\`, \`binning\`, \`datetime\`, \`frame_aggregate\`, \`offset\`, \`percentile\`, \`rank\`, \`scalar_aggregate\`, \`string\`, \`window_aggregation\`) across PyArrow, Pandas, Polars lazy, DuckDB, and SQLite. No new unmitigated divergences were found.
- Cross-links the new guide from \`index.md\`, \`01-overview.md\`, and \`03-reference-implementation.md\`.

Addresses the \"What this issue asks for\" section of #146: the single authoritative list of known divergences, organized so this category of silent cross-framework bug cannot grow unnoticed.

### Documented cases
- Polars \`sum()\` on an all-null group returns 0 (implementation fix)
- Polars \`rank()\` returns null for null inputs (implementation fix)
- Mode tie-breaking by first occurrence in Polars and Pandas (implementation fix)
- SQLite \`UPPER\`/\`LOWER\` ASCII-only and no native \`REVERSE\` (excluded op; resolved from #146 via #147)
- Float accumulation order tolerated with \`pytest.approx(rel=1e-6)\` via \`use_approx=True\` (accepted tolerance)
- PyArrow lacks native \`frame_aggregate\`, \`offset\`, \`percentile\`, \`rank\` (Category 1 of #146; excluded via \`supported_*\`)
- SQLite lacks \`percentile\` and \`reverse\` (Category 1 of #146; excluded via \`supported_*\`)

### Non-goals
- No behavior changes, no new tests. Every documented divergence already has a regression signal in the existing cross-framework \`_compare_with_reference\` test suite; the guide names the specific test or fixture for each entry.

## Test plan
- [x] \`PYTEST_WORKERS=1 tox\` green locally (2455 passed, 115 skipped; ruff, mypy --strict, bandit all clean)
- [x] \`python scripts/lint_docs.py\` passes (no broken relative links)
- [ ] CI green on GitHub