### PR TITLE
perf(pandas): vectorize mode aggregation to remove per-group Python loop

### DIFF
--- a/docs/guides/data-operation-patterns/known-divergences.md
+++ b/docs/guides/data-operation-patterns/known-divergences.md
@@ -49,11 +49,11 @@ An entry is added here only after a cross-framework test or an explicit audit ha
 ### Mode tie-breaking by first occurrence
 
 - **Operations**: `aggregation` (`mode` agg type), `window_aggregation` (`mode` agg type).
-- **Where it lives**: `mloda/community/feature_groups/data_operations/polars_mode_helpers.py` (shared Polars Lazy helpers used by both `polars_lazy_aggregation.py` and `polars_lazy_window_aggregation.py`); Pandas uses a `Counter`-based helper in `pandas_helpers.py`.
+- **Where it lives**: `mloda/community/feature_groups/data_operations/polars_mode_helpers.py` (shared Polars Lazy helpers used by both `polars_lazy_aggregation.py` and `polars_lazy_window_aggregation.py`); Pandas uses the vectorized `compute_mode_winners` helper in `pandas_helpers.py`.
 - **Reference behavior**: PyArrow's `pc.mode` breaks ties by first occurrence in the input ordering.
 - **Native framework behavior**: Polars' `.mode()` and Pandas' `.mode()` break ties differently (sorted order / multiple returned values / unspecified).
 - **Mitigation kind**: Implementation fix.
-- **How**: Both frameworks explicitly rank candidate values by `(count desc, first_occurrence_index asc)` and take the head. The Polars Lazy implementation stays inside the lazy / vectorised path: it adds per-`(partition, value)` count and first-index columns via `.over()`, then uses `sort_by([cnt, first_idx], descending=[True, False], maintain_order=True).first()` (no Python callback).
+- **How**: Both frameworks explicitly rank candidate values by `(count desc, first_occurrence_index asc)` and take the head. The Polars Lazy implementation stays inside the lazy / vectorised path: it adds per-`(partition, value)` count and first-index columns via `.over()`, then uses `sort_by([cnt, first_idx], descending=[True, False], maintain_order=True).first()` (no Python callback). On Pandas this is a single vectorized groupby over `(partition_by, value)` that aggregates count and first-occurrence index, avoiding a per-group Python reducer.
 - **Regression signal**: The canonical fixture has values that tie; mode tests compare against the PyArrow reference via `_compare_with_reference`.
 
 ### SQLite `UPPER`/`LOWER` are ASCII-only; no native `REVERSE`

--- a/mloda/community/feature_groups/data_operations/aggregation/pandas_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/pandas_aggregation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from typing import Any
 
 import pandas as pd
@@ -19,6 +18,7 @@ from mloda.community.feature_groups.data_operations.pandas_helpers import (
     PANDAS_AGG_FUNCS,
     apply_null_safe_agg,
     coerce_count_dtype,
+    compute_mode_winners,
     null_safe_groupby,
 )
 from mloda_plugins.compute_framework.base_implementations.pandas.pandas_mask_engine import (
@@ -73,18 +73,11 @@ class PandasAggregation(AggregationFeatureGroup):
         partition_by: list[str],
     ) -> pd.DataFrame:
         """Compute mode with insertion-order tie-breaking (matching PyArrow)."""
-        grouped = null_safe_groupby(data, partition_by, source_col)
+        winners = compute_mode_winners(data, source_col, partition_by)
+        winners = winners.rename(columns={source_col: feature_name})
 
-        def _insertion_order_mode(x: pd.Series) -> Any:
-            vals = x.dropna()
-            if len(vals) == 0:
-                return None
-            counts = Counter(vals)
-            max_count = max(counts.values())
-            for v in vals:
-                if counts[v] == max_count:
-                    return v
-            return None  # pragma: no cover
+        all_partitions = data[partition_by].drop_duplicates().copy()
+        all_partitions[feature_name] = pd.NA
 
-        result = grouped.agg(_insertion_order_mode).reset_index()
-        return result.rename(columns={source_col: feature_name})
+        combined = pd.concat([winners, all_partitions], ignore_index=True, sort=False)
+        return combined.groupby(partition_by, dropna=False, as_index=False)[feature_name].first().reset_index(drop=True)

--- a/mloda/community/feature_groups/data_operations/aggregation/pandas_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/pandas_aggregation.py
@@ -70,9 +70,15 @@ class PandasAggregation(AggregationFeatureGroup):
         data: pd.DataFrame,
         feature_name: str,
         source_col: str,
-        partition_by: list[str],
+        partition_by: list[str] | tuple[str, ...],
     ) -> pd.DataFrame:
         """Compute mode with insertion-order tie-breaking (matching PyArrow)."""
+        partition_by = list(partition_by)
+        if source_col in partition_by:
+            unique_parts = data[partition_by].drop_duplicates().reset_index(drop=True).copy()
+            unique_parts[feature_name] = unique_parts[source_col].where(unique_parts[source_col].notna(), pd.NA)
+            return unique_parts
+
         winners = compute_mode_winners(data, source_col, partition_by)
         winners = winners.rename(columns={source_col: feature_name})
 

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_pandas.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_pandas.py
@@ -8,6 +8,8 @@ import pytest
 
 pytest.importorskip("pandas")
 
+import pandas as pd
+
 from mloda.community.feature_groups.data_operations.aggregation.pandas_aggregation import (
     PandasAggregation,
 )
@@ -23,3 +25,83 @@ class TestPandasAggregation(PandasTestMixin, AggregationTestBase):
     @classmethod
     def implementation_class(cls) -> Any:
         return PandasAggregation
+
+
+class TestPandasModeVectorized:
+    """Targeted tests for the vectorized ``_compute_mode`` implementation.
+
+    These exercise the tie-breaking and null-handling semantics that were
+    previously delivered by the per-group ``Counter``/Python-loop reducer.
+    """
+
+    def test_mode_single_partition_basic(self) -> None:
+        data = pd.DataFrame({"region": ["A", "A", "A"], "value": [1, 2, 2]})
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["region"])
+        assert result["region"].tolist() == ["A"]
+        assert result["value__mode_agg"].tolist() == [2]
+
+    def test_mode_tie_break_by_first_occurrence(self) -> None:
+        data = pd.DataFrame({"region": ["A", "A", "A", "A"], "value": [3, 1, 1, 3]})
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["region"])
+        assert result["value__mode_agg"].tolist() == [3]
+
+    def test_mode_three_way_tie_picks_earliest(self) -> None:
+        data = pd.DataFrame({"region": ["A"] * 6, "value": [5, 7, 9, 7, 5, 9]})
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["region"])
+        assert result["value__mode_agg"].tolist() == [5]
+
+    def test_mode_all_null_partition_yields_none(self) -> None:
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "B", "B"],
+                "value": [float("nan"), float("nan"), 4.0, 4.0],
+            }
+        )
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["region"])
+        result = result.sort_values("region").reset_index(drop=True)
+        assert result["region"].tolist() == ["A", "B"]
+        assert pd.isna(result.loc[0, "value__mode_agg"])
+        assert result.loc[1, "value__mode_agg"] == 4.0
+
+    def test_mode_nulls_in_source_are_ignored(self) -> None:
+        data = pd.DataFrame({"region": ["A", "A", "A", "A"], "value": [float("nan"), 1.0, 2.0, 2.0]})
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["region"])
+        assert result["value__mode_agg"].tolist() == [2.0]
+
+    def test_mode_null_in_partition_keys_groups_together(self) -> None:
+        data = pd.DataFrame({"region": ["A", None, None, "A"], "value": [1, 9, 9, 1]})
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["region"])
+        result_map: dict[Any, Any] = {}
+        for _, row in result.iterrows():
+            key: Any = None if pd.isna(row["region"]) else row["region"]
+            result_map[key] = row["value__mode_agg"]
+        assert result_map == {"A": 1, None: 9}
+
+    def test_mode_multi_key_partition(self) -> None:
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "A", "B", "B"],
+                "category": ["x", "x", "y", "x", "x"],
+                "value": [1, 1, 5, 7, 9],
+            }
+        )
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["region", "category"])
+        result = result.sort_values(["region", "category"]).reset_index(drop=True)
+        assert result[["region", "category"]].values.tolist() == [
+            ["A", "x"],
+            ["A", "y"],
+            ["B", "x"],
+        ]
+        assert result["value__mode_agg"].tolist() == [1, 5, 7]
+
+    def test_mode_does_not_use_python_counter(self) -> None:
+        """Guard against regressing to the Python ``collections.Counter`` path.
+
+        The vectorized implementation must not import ``Counter`` in the
+        aggregation module; this test pins that invariant.
+        """
+        from mloda.community.feature_groups.data_operations.aggregation import (
+            pandas_aggregation,
+        )
+
+        assert not hasattr(pandas_aggregation, "Counter")

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_pandas.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_pandas.py
@@ -105,3 +105,142 @@ class TestPandasModeVectorized:
         )
 
         assert not hasattr(pandas_aggregation, "Counter")
+
+    def test_mode_source_col_equals_partition_by_single_key(self) -> None:
+        """Bug 1: source_col appearing in partition_by must not raise.
+
+        Mode of X grouped by X is X itself. The current implementation
+        raises ``ValueError: cannot reindex on an axis with duplicate
+        labels`` because ``data[partition_by + [source_col]]`` produces
+        duplicate column labels.
+        """
+        data = pd.DataFrame({"value": [1, 2, 2, 3]})
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["value"])
+        result = result.sort_values("value").reset_index(drop=True)
+        assert result["value"].tolist() == [1, 2, 3]
+        assert result["value__mode_agg"].tolist() == [1, 2, 3]
+
+    def test_mode_source_col_in_multi_key_partition(self) -> None:
+        """Bug 1: source_col appearing among multi-key partition_by must not raise."""
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "B", "B"],
+                "value": [1, 1, 2, 2],
+            }
+        )
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["region", "value"])
+        result = result.sort_values(["region", "value"]).reset_index(drop=True)
+        assert result[["region", "value"]].values.tolist() == [["A", 1], ["B", 2]]
+        assert result["value__mode_agg"].tolist() == [1, 2]
+
+    def test_mode_source_col_equals_partition_by_with_null(self) -> None:
+        """Bug 1: when source_col == partition_by and a value is null, that row's
+        partition is still emitted but the feature value is NaN (matching the
+        all-null-partition convention from ``test_mode_all_null_partition_yields_none``).
+        """
+        data = pd.DataFrame({"value": [1.0, 2.0, float("nan")]})
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ["value"])
+        # three unique partition keys: 1.0, 2.0, NaN
+        assert len(result) == 3
+        non_null = result[result["value"].notna()].sort_values("value").reset_index(drop=True)
+        assert non_null["value"].tolist() == [1.0, 2.0]
+        assert non_null["value__mode_agg"].tolist() == [1.0, 2.0]
+        null_row = result[result["value"].isna()]
+        assert len(null_row) == 1
+        assert pd.isna(null_row["value__mode_agg"]).all()
+
+    def test_mode_accepts_tuple_partition_by_single_key(self) -> None:
+        """Bug 3: partition_by may arrive as a tuple (mloda core hashability fix, #228).
+
+        Other aggregations work because they pass partition_by straight to
+        ``df.groupby``. The new mode path builds ``partition_by + [source_col]``
+        which raises ``TypeError`` when partition_by is a tuple.
+        """
+        data = pd.DataFrame({"region": ["A", "A", "A"], "value": [1, 2, 2]})
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ("region",))
+        assert result["region"].tolist() == ["A"]
+        assert result["value__mode_agg"].tolist() == [2]
+
+    def test_mode_accepts_tuple_partition_by_multi_key(self) -> None:
+        """Bug 3: multi-key tuple partition_by must not crash."""
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "A", "B", "B"],
+                "category": ["x", "x", "y", "x", "x"],
+                "value": [1, 1, 5, 7, 9],
+            }
+        )
+        result = PandasAggregation._compute_mode(data, "value__mode_agg", "value", ("region", "category"))
+        result = result.sort_values(["region", "category"]).reset_index(drop=True)
+        assert result[["region", "category"]].values.tolist() == [
+            ["A", "x"],
+            ["A", "y"],
+            ["B", "x"],
+        ]
+        assert result["value__mode_agg"].tolist() == [1, 5, 7]
+
+
+class TestComputeModeWinnersCollisions:
+    """Bug 2: internal sentinel column names must not collide with user columns.
+
+    ``compute_mode_winners`` uses the hard-coded temp names
+    ``__mloda_mode_row_idx__``, ``__mloda_mode_count__`` and
+    ``__mloda_mode_first_idx__``. If a user column shares any of these
+    names the helper overwrites it silently and produces wrong results.
+    """
+
+    def test_compute_mode_winners_partition_collides_with_row_idx(self) -> None:
+        from mloda.community.feature_groups.data_operations.pandas_helpers import (
+            compute_mode_winners,
+        )
+
+        data = pd.DataFrame(
+            {
+                "__mloda_mode_row_idx__": ["A", "A", "B", "B", "B"],
+                "v": [1, 1, 2, 3, 3],
+            }
+        )
+        result = compute_mode_winners(data, "v", ["__mloda_mode_row_idx__"])
+        result = result.sort_values("__mloda_mode_row_idx__").reset_index(drop=True)
+        assert result["__mloda_mode_row_idx__"].tolist() == ["A", "B"]
+        assert result["v"].tolist() == [1, 3]
+
+    def test_compute_mode_winners_source_col_is_count_sentinel(self) -> None:
+        from mloda.community.feature_groups.data_operations.pandas_helpers import (
+            compute_mode_winners,
+        )
+
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "A", "B", "B"],
+                "__mloda_mode_count__": [10, 10, 20, 30, 30],
+            }
+        )
+        result = compute_mode_winners(data, "__mloda_mode_count__", ["region"])
+        result = result.sort_values("region").reset_index(drop=True)
+        assert result["region"].tolist() == ["A", "B"]
+        assert result["__mloda_mode_count__"].tolist() == [10, 30]
+
+    def test_aggregation_mode_partition_collides_with_row_idx(self) -> None:
+        data = pd.DataFrame(
+            {
+                "__mloda_mode_row_idx__": ["A", "A", "B", "B", "B"],
+                "v": [1, 1, 2, 3, 3],
+            }
+        )
+        result = PandasAggregation._compute_mode(data, "v__mode_agg", "v", ["__mloda_mode_row_idx__"])
+        result = result.sort_values("__mloda_mode_row_idx__").reset_index(drop=True)
+        assert result["__mloda_mode_row_idx__"].tolist() == ["A", "B"]
+        assert result["v__mode_agg"].tolist() == [1, 3]
+
+    def test_aggregation_mode_source_col_is_count_sentinel(self) -> None:
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "A", "B", "B"],
+                "__mloda_mode_count__": [10, 10, 20, 30, 30],
+            }
+        )
+        result = PandasAggregation._compute_mode(data, "out", "__mloda_mode_count__", ["region"])
+        result = result.sort_values("region").reset_index(drop=True)
+        assert result["region"].tolist() == ["A", "B"]
+        assert result["out"].tolist() == [10, 30]

--- a/mloda/community/feature_groups/data_operations/pandas_helpers.py
+++ b/mloda/community/feature_groups/data_operations/pandas_helpers.py
@@ -97,10 +97,19 @@ _MODE_COUNT_COL = "__mloda_mode_count__"
 _MODE_FIRST_IDX_COL = "__mloda_mode_first_idx__"
 
 
+def _unique_temp_name(base: str, existing: Any) -> str:
+    if base not in existing:
+        return base
+    i = 1
+    while f"{base}_{i}" in existing:
+        i += 1
+    return f"{base}_{i}"
+
+
 def compute_mode_winners(
     data: pd.DataFrame,
     source_col: str,
-    partition_by: list[str],
+    partition_by: list[str] | tuple[str, ...],
 ) -> pd.DataFrame:
     """Return one row per partition with the mode value of *source_col*.
 
@@ -112,20 +121,24 @@ def compute_mode_winners(
     The returned frame has columns ``partition_by + [source_col]`` and
     contains at most one row per unique partition-key combination.
     """
+    partition_by = list(partition_by)
     work = data[partition_by + [source_col]].copy()
-    work[_MODE_IDX_COL] = range(len(work))
+    idx_col = _unique_temp_name(_MODE_IDX_COL, work.columns)
+    count_col = _unique_temp_name(_MODE_COUNT_COL, work.columns)
+    first_idx_col = _unique_temp_name(_MODE_FIRST_IDX_COL, work.columns)
+    work[idx_col] = range(len(work))
     work = work[work[source_col].notna()]
     if work.empty:
         return data.iloc[0:0][partition_by + [source_col]].copy()
 
     counts = work.groupby(partition_by + [source_col], dropna=False, as_index=False).agg(
         **{
-            _MODE_COUNT_COL: (_MODE_IDX_COL, "size"),
-            _MODE_FIRST_IDX_COL: (_MODE_IDX_COL, "min"),
+            count_col: (idx_col, "size"),
+            first_idx_col: (idx_col, "min"),
         }
     )
     counts = counts.sort_values(
-        partition_by + [_MODE_COUNT_COL, _MODE_FIRST_IDX_COL],
+        partition_by + [count_col, first_idx_col],
         ascending=[True] * len(partition_by) + [False, True],
         kind="mergesort",
     )

--- a/mloda/community/feature_groups/data_operations/pandas_helpers.py
+++ b/mloda/community/feature_groups/data_operations/pandas_helpers.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pandas as pd
+
 PANDAS_AGG_FUNCS: dict[str, str] = {
     "sum": "sum",
     "avg": "mean",
@@ -88,3 +90,44 @@ def coerce_count_dtype(data: Any, feature_name: str, agg_type: str) -> None:
     """Cast *feature_name* column to int64 in-place when *agg_type* is ``"count"``."""
     if agg_type == "count":
         data[feature_name] = data[feature_name].astype("int64")
+
+
+_MODE_IDX_COL = "__mloda_mode_row_idx__"
+_MODE_COUNT_COL = "__mloda_mode_count__"
+_MODE_FIRST_IDX_COL = "__mloda_mode_first_idx__"
+
+
+def compute_mode_winners(
+    data: pd.DataFrame,
+    source_col: str,
+    partition_by: list[str],
+) -> pd.DataFrame:
+    """Return one row per partition with the mode value of *source_col*.
+
+    Ties are broken by first occurrence in *data* (matching PyArrow
+    ``mode_only``). Null values are ignored when counting (matching
+    pandas ``Series.mode`` semantics); partitions whose source values
+    are all-null are omitted from the result.
+
+    The returned frame has columns ``partition_by + [source_col]`` and
+    contains at most one row per unique partition-key combination.
+    """
+    work = data[partition_by + [source_col]].copy()
+    work[_MODE_IDX_COL] = range(len(work))
+    work = work[work[source_col].notna()]
+    if work.empty:
+        return data.iloc[0:0][partition_by + [source_col]].copy()
+
+    counts = work.groupby(partition_by + [source_col], dropna=False, as_index=False).agg(
+        **{
+            _MODE_COUNT_COL: (_MODE_IDX_COL, "size"),
+            _MODE_FIRST_IDX_COL: (_MODE_IDX_COL, "min"),
+        }
+    )
+    counts = counts.sort_values(
+        partition_by + [_MODE_COUNT_COL, _MODE_FIRST_IDX_COL],
+        ascending=[True] * len(partition_by) + [False, True],
+        kind="mergesort",
+    )
+    winners = counts.groupby(partition_by, dropna=False, as_index=False).head(1)
+    return winners[partition_by + [source_col]].reset_index(drop=True)

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from typing import Any
 
 import pandas as pd
@@ -19,6 +18,7 @@ from mloda.community.feature_groups.data_operations.pandas_helpers import (
     PANDAS_AGG_FUNCS,
     apply_null_safe_agg,
     coerce_count_dtype,
+    compute_mode_winners,
     null_safe_groupby,
 )
 from mloda_plugins.compute_framework.base_implementations.pandas.pandas_mask_engine import (
@@ -78,24 +78,24 @@ class PandasWindowAggregation(WindowAggregationFeatureGroup):
         source_col: str,
         partition_by: list[str],
     ) -> pd.DataFrame:
-        """Compute mode via Counter with insertion-order tie-breaking (matching PyArrow)."""
-        grouped = null_safe_groupby(data, partition_by, source_col)
+        """Compute mode with insertion-order tie-breaking (matching PyArrow)."""
+        winners = compute_mode_winners(data, source_col, partition_by)
+        winners = winners.rename(columns={source_col: feature_name})
 
-        def _insertion_order_mode(x: pd.Series) -> Any:
-            vals = x.dropna()
-            if len(vals) == 0:
-                return None
-            counts = Counter(vals)
-            max_count = max(counts.values())
-            for v in vals:
-                if counts[v] == max_count:
-                    return v
-            return None  # pragma: no cover
+        carrier = data[partition_by].copy()
+        carrier[feature_name] = pd.NA
+        carrier["__mloda_mode_is_data__"] = True
 
-        result_series = grouped.transform(_insertion_order_mode)
+        winners_for_merge = winners.copy()
+        winners_for_merge["__mloda_mode_is_data__"] = False
+
+        combined = pd.concat([winners_for_merge, carrier], ignore_index=True, sort=False)
+        combined[feature_name] = combined.groupby(partition_by, dropna=False)[feature_name].transform("first")
+
+        broadcast = combined.loc[combined["__mloda_mode_is_data__"], feature_name]
 
         data = data.copy()
-        data[feature_name] = result_series
+        data[feature_name] = broadcast.to_numpy()
         return data
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
@@ -16,6 +16,7 @@ from mloda.community.feature_groups.data_operations.row_preserving.window_aggreg
 )
 from mloda.community.feature_groups.data_operations.pandas_helpers import (
     PANDAS_AGG_FUNCS,
+    _unique_temp_name,
     apply_null_safe_agg,
     coerce_count_dtype,
     compute_mode_winners,
@@ -76,23 +77,31 @@ class PandasWindowAggregation(WindowAggregationFeatureGroup):
         data: pd.DataFrame,
         feature_name: str,
         source_col: str,
-        partition_by: list[str],
+        partition_by: list[str] | tuple[str, ...],
     ) -> pd.DataFrame:
         """Compute mode with insertion-order tie-breaking (matching PyArrow)."""
+        partition_by = list(partition_by)
+        if source_col in partition_by:
+            data = data.copy()
+            data[feature_name] = data[source_col]
+            return data
+
+        is_data_col = _unique_temp_name("__mloda_mode_is_data__", data.columns)
+
         winners = compute_mode_winners(data, source_col, partition_by)
         winners = winners.rename(columns={source_col: feature_name})
 
         carrier = data[partition_by].copy()
         carrier[feature_name] = pd.NA
-        carrier["__mloda_mode_is_data__"] = True
+        carrier[is_data_col] = True
 
         winners_for_merge = winners.copy()
-        winners_for_merge["__mloda_mode_is_data__"] = False
+        winners_for_merge[is_data_col] = False
 
         combined = pd.concat([winners_for_merge, carrier], ignore_index=True, sort=False)
         combined[feature_name] = combined.groupby(partition_by, dropna=False)[feature_name].transform("first")
 
-        broadcast = combined.loc[combined["__mloda_mode_is_data__"], feature_name]
+        broadcast = combined.loc[combined[is_data_col], feature_name]
 
         data = data.copy()
         data[feature_name] = broadcast.to_numpy()

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_pandas.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_pandas.py
@@ -8,6 +8,8 @@ import pytest
 
 pytest.importorskip("pandas")
 
+import pandas as pd
+
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.pandas_window_aggregation import (
     PandasWindowAggregation,
 )
@@ -23,3 +25,70 @@ class TestPandasWindowAggregation(PandasTestMixin, WindowAggregationTestBase):
     @classmethod
     def implementation_class(cls) -> Any:
         return PandasWindowAggregation
+
+
+class TestPandasWindowModeVectorized:
+    """Targeted tests for the vectorized window ``_compute_mode``.
+
+    Verifies that the per-row broadcast produced by the vectorized
+    implementation matches the insertion-order tie-breaking semantics of
+    the old ``Counter``-based reducer and preserves the original row order.
+    """
+
+    def test_mode_broadcasts_to_every_row(self) -> None:
+        data = pd.DataFrame({"region": ["A", "A", "A"], "value": [1, 2, 2]})
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ["region"])
+        assert result["mode_val"].tolist() == [2, 2, 2]
+        assert result["value"].tolist() == [1, 2, 2]
+
+    def test_mode_tie_break_by_first_occurrence(self) -> None:
+        data = pd.DataFrame({"region": ["A", "A", "A", "A"], "value": [3, 1, 1, 3]})
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ["region"])
+        assert result["mode_val"].tolist() == [3, 3, 3, 3]
+
+    def test_mode_preserves_original_row_order(self) -> None:
+        data = pd.DataFrame(
+            {
+                "region": ["B", "A", "B", "A", "B"],
+                "value": [9, 1, 9, 2, 7],
+            }
+        )
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ["region"])
+        assert result["region"].tolist() == ["B", "A", "B", "A", "B"]
+        assert result["value"].tolist() == [9, 1, 9, 2, 7]
+        assert result["mode_val"].tolist() == [9, 1, 9, 1, 9]
+
+    def test_mode_all_null_partition_broadcasts_none(self) -> None:
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "B", "B"],
+                "value": [float("nan"), float("nan"), 4.0, 4.0],
+            }
+        )
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ["region"])
+        assert pd.isna(result.loc[result["region"] == "A", "mode_val"]).all()
+        assert (result.loc[result["region"] == "B", "mode_val"] == 4.0).all()
+
+    def test_mode_null_in_partition_keys_groups_together(self) -> None:
+        data = pd.DataFrame({"region": ["A", None, None, "A"], "value": [1, 9, 9, 1]})
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ["region"])
+        assert result["mode_val"].tolist() == [1, 9, 9, 1]
+
+    def test_mode_multi_key_partition_broadcasts(self) -> None:
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "A", "B", "B"],
+                "category": ["x", "x", "y", "x", "x"],
+                "value": [1, 1, 5, 7, 9],
+            }
+        )
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ["region", "category"])
+        assert result["mode_val"].tolist() == [1, 1, 5, 7, 7]
+
+    def test_mode_does_not_use_python_counter(self) -> None:
+        """Guard against regressing to the Python ``collections.Counter`` path."""
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation import (
+            pandas_window_aggregation,
+        )
+
+        assert not hasattr(pandas_window_aggregation, "Counter")

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_pandas.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_pandas.py
@@ -92,3 +92,100 @@ class TestPandasWindowModeVectorized:
         )
 
         assert not hasattr(pandas_window_aggregation, "Counter")
+
+    def test_mode_source_col_equals_partition_by_single_key(self) -> None:
+        """Bug 1: source_col in partition_by must broadcast trivially.
+
+        Within every partition defined by value, the value column is
+        constant, so the mode equals the key.
+        """
+        data = pd.DataFrame({"value": [1, 2, 2, 3]})
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ["value"])
+        assert result["value"].tolist() == [1, 2, 2, 3]
+        assert result["mode_val"].tolist() == [1, 2, 2, 3]
+
+    def test_mode_source_col_in_multi_key_partition(self) -> None:
+        """Bug 1: source_col appearing among multi-key partition_by must broadcast correctly."""
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "B", "B"],
+                "value": [1, 1, 2, 2],
+            }
+        )
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ["region", "value"])
+        assert result["region"].tolist() == ["A", "A", "B", "B"]
+        assert result["value"].tolist() == [1, 1, 2, 2]
+        assert result["mode_val"].tolist() == [1, 1, 2, 2]
+
+    def test_mode_source_col_equals_partition_by_with_null(self) -> None:
+        """Bug 1: null source values broadcast as NaN when source_col == partition_by."""
+        data = pd.DataFrame({"value": [1.0, 2.0, float("nan"), 2.0]})
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ["value"])
+        assert result["value"].tolist()[:2] == [1.0, 2.0]
+        assert result.loc[0, "mode_val"] == 1.0
+        assert result.loc[1, "mode_val"] == 2.0
+        assert pd.isna(result.loc[2, "mode_val"])
+        assert result.loc[3, "mode_val"] == 2.0
+
+    def test_mode_partition_collides_with_is_data_sentinel(self) -> None:
+        """Bug 2: a user partition column named ``__mloda_mode_is_data__`` must
+        still produce a correct mode broadcast. The current implementation uses
+        that name as an internal sentinel and overwrites the column, yielding
+        all-None output.
+        """
+        data = pd.DataFrame(
+            {
+                "__mloda_mode_is_data__": ["A", "A", "B", "B", "B"],
+                "v": [1, 1, 2, 3, 3],
+            }
+        )
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "v", ["__mloda_mode_is_data__"])
+        assert result["__mloda_mode_is_data__"].tolist() == ["A", "A", "B", "B", "B"]
+        assert result["v"].tolist() == [1, 1, 2, 3, 3]
+        assert result["mode_val"].tolist() == [1, 1, 3, 3, 3]
+
+    def test_mode_partition_collides_with_row_idx_sentinel(self) -> None:
+        """Bug 2: a user partition column matching the helper's row-idx sentinel."""
+        data = pd.DataFrame(
+            {
+                "__mloda_mode_row_idx__": ["A", "A", "B", "B", "B"],
+                "v": [1, 1, 2, 3, 3],
+            }
+        )
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "v", ["__mloda_mode_row_idx__"])
+        assert result["mode_val"].tolist() == [1, 1, 3, 3, 3]
+
+    def test_mode_source_col_is_count_sentinel(self) -> None:
+        """Bug 2: a user source column matching the helper's count sentinel."""
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "A", "B", "B"],
+                "__mloda_mode_count__": [10, 10, 20, 30, 30],
+            }
+        )
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "__mloda_mode_count__", ["region"])
+        assert result["mode_val"].tolist() == [10, 10, 10, 30, 30]
+
+    def test_mode_accepts_tuple_partition_by_single_key(self) -> None:
+        """Bug 3: tuple partition_by must not crash the window mode path.
+
+        mloda core converts list options to tuples for hashability (#228).
+        The shared helper builds ``partition_by + [source_col]`` which raises
+        ``TypeError`` when partition_by is a tuple.
+        """
+        data = pd.DataFrame({"region": ["A", "A", "A"], "value": [1, 2, 2]})
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ("region",))
+        assert result["mode_val"].tolist() == [2, 2, 2]
+        assert result["value"].tolist() == [1, 2, 2]
+
+    def test_mode_accepts_tuple_partition_by_multi_key(self) -> None:
+        """Bug 3: multi-key tuple partition_by must broadcast correctly."""
+        data = pd.DataFrame(
+            {
+                "region": ["A", "A", "A", "B", "B"],
+                "category": ["x", "x", "y", "x", "x"],
+                "value": [1, 1, 5, 7, 9],
+            }
+        )
+        result = PandasWindowAggregation._compute_mode(data, "mode_val", "value", ("region", "category"))
+        assert result["mode_val"].tolist() == [1, 1, 5, 7, 7]


### PR DESCRIPTION
## Summary

- Replace the `collections.Counter` + Python `for`-loop reducer in both `PandasAggregation._compute_mode` and `PandasWindowAggregation._compute_mode` with a single vectorized pandas pipeline.
- Add a shared `compute_mode_winners` helper in `pandas_helpers.py` that counts occurrences and first-occurrence indices per `(partition_by, value)` in one grouped aggregation, then ranks by `(count desc, first_idx asc)` and picks the winner per partition.
- Preserve PyArrow-compatible first-occurrence tie-breaking; all-null partitions still surface `None`; null partition keys are handled via `dropna=False` groupbys.
- Update `docs/guides/data-operation-patterns/known-divergences.md` to reflect the new vectorized helper instead of the `Counter`-based one.

Closes #150.

## Test plan

- [x] `PYTEST_WORKERS=1 uv run tox` passes (pytest + ruff format + ruff check + mypy strict + bandit): 2470 passed, 115 skipped.
- [x] New targeted Pandas unit tests added for both sites covering:
  - basic mode + three-way tie break by first occurrence
  - all-null source yields `None`
  - nulls in source ignored
  - NaN in partition keys group together
  - multi-key partitions
  - (window) row order preservation across the broadcast
  - regression guard: `Counter` is no longer imported in either module
- [x] Cross-framework mode tests in `AggregationTestBase` / `WindowAggregationTestBase` still pass unchanged.