### PR TITLE
fix(data-operations): list supported types in unsupported-type errors

### DIFF
--- a/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
@@ -12,6 +12,7 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import q
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 
 # All aggregation types natively supported by DuckDB.
@@ -64,7 +65,7 @@ class DuckdbAggregation(AggregationFeatureGroup):
         else:
             agg_func = _DUCKDB_AGG_FUNCS.get(agg_type)
             if agg_func is None:
-                raise ValueError(f"Unsupported aggregation type for DuckDB: {agg_type}")
+                raise unsupported_agg_type_error(agg_type, _DUCKDB_AGG_FUNCS.keys(), framework="DuckDB")
             agg_expr = f"{agg_func}({source_sql})"
             if agg_type in ("first", "last"):
                 agg_expr += f" FILTER (WHERE {source_sql} IS NOT NULL)"

--- a/mloda/community/feature_groups/data_operations/aggregation/pandas_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/pandas_aggregation.py
@@ -13,6 +13,7 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_mask_from_spec
 from mloda.community.feature_groups.data_operations.pandas_helpers import (
     PANDAS_AGG_FUNCS,
@@ -23,6 +24,8 @@ from mloda.community.feature_groups.data_operations.pandas_helpers import (
 from mloda_plugins.compute_framework.base_implementations.pandas.pandas_mask_engine import (
     PandasMaskEngine,
 )
+
+_SUPPORTED_AGG_TYPES = {*PANDAS_AGG_FUNCS.keys(), "mode"}
 
 
 class PandasAggregation(AggregationFeatureGroup):
@@ -51,7 +54,7 @@ class PandasAggregation(AggregationFeatureGroup):
 
         pandas_func = PANDAS_AGG_FUNCS.get(agg_type)
         if pandas_func is None:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Pandas")
 
         grouped = null_safe_groupby(data, partition_by, source_col)
         result = apply_null_safe_agg(grouped, pandas_func, agg_type).reset_index()

--- a/mloda/community/feature_groups/data_operations/aggregation/polars_lazy_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/polars_lazy_aggregation.py
@@ -12,6 +12,7 @@ from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe 
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import _POLARS_MASK_TMP, apply_polars_mask
 
 # Mapping from aggregation type to a Polars expression builder.
@@ -33,6 +34,8 @@ _POLARS_AGG_EXPRS: dict[str, Any] = {
     "first": lambda col: pl.col(col).drop_nulls().first(),
     "last": lambda col: pl.col(col).drop_nulls().last(),
 }
+
+_SUPPORTED_AGG_TYPES = {*_POLARS_AGG_EXPRS.keys(), "mode"}
 
 
 def _mode_with_insertion_order(s: pl.Series) -> Any:
@@ -95,7 +98,7 @@ class PolarsLazyAggregation(AggregationFeatureGroup):
             else:
                 expr = raw_expr
         else:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Polars")
 
         result = data.group_by(partition_by, maintain_order=True).agg(expr)
         if mask_spec is not None:

--- a/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
@@ -17,6 +17,7 @@ from mloda_plugins.compute_framework.base_implementations.pyarrow.table import P
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import apply_pyarrow_mask
 
 # Aggregation types with direct PyArrow group_by support.
@@ -45,6 +46,8 @@ _ORDERED_FUNCS: dict[str, str] = {
     "first": "first",
     "last": "last",
 }
+
+_SUPPORTED_AGG_TYPES = {*_PA_AGG_FUNCS, *_VARIANCE_FUNCS, *_ORDERED_FUNCS}
 
 
 class PyArrowAggregation(AggregationFeatureGroup):
@@ -75,7 +78,7 @@ class PyArrowAggregation(AggregationFeatureGroup):
             pa_func = _ORDERED_FUNCS[agg_type]
             grouped = table.group_by(partition_by, use_threads=False).aggregate([(source_col, pa_func)])
         else:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="PyArrow")
 
         # Rename auto-generated column (e.g. "val_sum") to feature_name.
         auto_col = f"{source_col}_{pa_func}"

--- a/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
@@ -12,6 +12,7 @@ from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 
 # Aggregation types that SQLite supports natively.
@@ -43,7 +44,7 @@ class SqliteAggregation(AggregationFeatureGroup):
         """Execute the aggregation as a SQL GROUP BY query."""
         agg_func = _SQLITE_AGG_FUNCS.get(agg_type)
         if agg_func is None:
-            raise ValueError(f"Unsupported aggregation type for SQLite: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SQLITE_AGG_FUNCS.keys(), framework="SQLite")
 
         quoted_source = quote_ident(source_col)
         quoted_feature = quote_ident(feature_name)

--- a/mloda/community/feature_groups/data_operations/errors.py
+++ b/mloda/community/feature_groups/data_operations/errors.py
@@ -1,0 +1,68 @@
+"""Helpers that build uniform, user-guiding errors for data operations.
+
+Every ``_compute_*`` implementation branches on ``agg_type`` (and for
+frame aggregates on ``frame_type``). When a user passes a value that the
+concrete framework does not support, a bare ``ValueError`` that echoes
+the rejected value is unhelpful: the user has no way to discover which
+values *are* accepted without reading the source.
+
+The helpers in this module produce messages that include the rejected
+value and the sorted list of supported values for the specific framework
+and operation that raised. The messages are deterministic so that tests
+can match them reliably.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def unsupported_agg_type_error(
+    agg_type: str,
+    supported: Iterable[str],
+    *,
+    framework: str | None = None,
+    operation: str | None = None,
+) -> ValueError:
+    """Build a ``ValueError`` describing an unsupported aggregation type.
+
+    Args:
+        agg_type: The value the caller provided.
+        supported: All ``agg_type`` values the caller *could* have used.
+            Deduplicated and sorted alphabetically in the message.
+        framework: Optional framework label (``"DuckDB"``, ``"SQLite"``,
+            ``"Pandas"``, ...). Included in the message when provided so
+            that the user knows which backend rejected the value.
+        operation: Optional operation qualifier (``"frame aggregate"``,
+            ``"cumulative/expanding"``, ...) that disambiguates frameworks
+            that implement more than one operation.
+    """
+    prefix = "Unsupported aggregation type"
+    if framework is not None:
+        prefix += f" for {framework}"
+    if operation is not None:
+        prefix += f" {operation}"
+    supported_list = ", ".join(sorted(set(supported)))
+    return ValueError(f"{prefix}: {agg_type!r}. Supported types: {supported_list}.")
+
+
+def unsupported_frame_type_error(
+    frame_type: str,
+    supported: Iterable[str],
+    *,
+    framework: str | None = None,
+) -> ValueError:
+    """Build a ``ValueError`` describing an unsupported frame type.
+
+    Args:
+        frame_type: The value the caller provided.
+        supported: All ``frame_type`` values the caller *could* have used.
+            Deduplicated and sorted alphabetically in the message.
+        framework: Optional framework label, included in the message when
+            provided.
+    """
+    prefix = "Unsupported frame type"
+    if framework is not None:
+        prefix += f" for {framework}"
+    supported_list = ", ".join(sorted(set(supported)))
+    return ValueError(f"{prefix}: {frame_type!r}. Supported types: {supported_list}.")

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
@@ -9,6 +9,10 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framewor
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 
+from mloda.community.feature_groups.data_operations.errors import (
+    unsupported_agg_type_error,
+    unsupported_frame_type_error,
+)
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.base import (
     FrameAggregateFeatureGroup,
@@ -51,7 +55,12 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
     ) -> DuckdbRelation:
         agg_func = _DUCKDB_AGG_FUNCS.get(agg_type)
         if agg_func is None:
-            raise ValueError(f"Unsupported aggregation type for DuckDB frame aggregate: {agg_type}")
+            raise unsupported_agg_type_error(
+                agg_type,
+                _DUCKDB_AGG_FUNCS.keys(),
+                framework="DuckDB",
+                operation="frame aggregate",
+            )
 
         quoted_source = quote_ident(source_col)
         source_sql = quoted_source
@@ -73,7 +82,11 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
         elif frame_type == "time":
             raise ValueError("DuckDB time-based frame windows require RANGE which needs timestamp columns")
         else:
-            raise ValueError(f"Unsupported frame type for DuckDB: {frame_type}")
+            raise unsupported_frame_type_error(
+                frame_type,
+                cls.SUPPORTED_FRAME_TYPES,
+                framework="DuckDB",
+            )
 
         # PyArrow parity: the reference preserves input row order. DuckDB
         # ORDER BY in the window frame reorders rows; tag with ROW_NUMBER(),

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pandas_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pandas_frame_aggregate.py
@@ -9,6 +9,10 @@ import pandas as pd
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
+from mloda.community.feature_groups.data_operations.errors import (
+    unsupported_agg_type_error,
+    unsupported_frame_type_error,
+)
 from mloda.community.feature_groups.data_operations.mask_utils import build_mask_from_spec
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.base import (
     FrameAggregateFeatureGroup,
@@ -53,7 +57,12 @@ class PandasFrameAggregate(FrameAggregateFeatureGroup):
     ) -> pd.DataFrame:
         pandas_func = _PANDAS_FRAME_AGG_FUNCS.get(agg_type)
         if pandas_func is None:
-            raise ValueError(f"Unsupported aggregation type for Pandas frame aggregate: {agg_type}")
+            raise unsupported_agg_type_error(
+                agg_type,
+                _PANDAS_FRAME_AGG_FUNCS.keys(),
+                framework="Pandas",
+                operation="frame aggregate",
+            )
 
         data = data.copy()
 
@@ -84,7 +93,11 @@ class PandasFrameAggregate(FrameAggregateFeatureGroup):
             window = int(frame_size) if frame_size is not None else 1
             window_obj = grouped.rolling(window=window, min_periods=min_periods)
         else:
-            raise ValueError(f"Unsupported frame type for Pandas: {frame_type}")
+            raise unsupported_frame_type_error(
+                frame_type,
+                cls.SUPPORTED_FRAME_TYPES,
+                framework="Pandas",
+            )
 
         if agg_type in ("std", "var"):
             result = getattr(window_obj, pandas_func)(ddof=0).reset_index(level=reset_levels, drop=True)

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/polars_lazy_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/polars_lazy_frame_aggregate.py
@@ -9,12 +9,19 @@ import polars as pl
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
+from mloda.community.feature_groups.data_operations.errors import (
+    unsupported_agg_type_error,
+    unsupported_frame_type_error,
+)
 from mloda.community.feature_groups.data_operations.mask_utils import _POLARS_MASK_TMP, apply_polars_mask
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.base import (
     FrameAggregateFeatureGroup,
 )
 
 _RN_COL = "__mloda_rn__"
+
+_CUMULATIVE_AGG_TYPES = {"sum", "min", "max", "count", "avg"}
+_ROLLING_AGG_TYPES = {"sum", "avg", "min", "max", "std", "var", "median", "count"}
 
 
 class PolarsLazyFrameAggregate(FrameAggregateFeatureGroup):
@@ -72,7 +79,12 @@ class PolarsLazyFrameAggregate(FrameAggregateFeatureGroup):
                 cum_count = col.cum_count().over(partition_by).cast(pl.Float64)
                 expr = (cum_sum / cum_count).alias(feature_name)
             else:
-                raise ValueError(f"Unsupported cumulative/expanding agg for Polars: {agg_type}")
+                raise unsupported_agg_type_error(
+                    agg_type,
+                    _CUMULATIVE_AGG_TYPES,
+                    framework="Polars",
+                    operation="cumulative/expanding",
+                )
         elif frame_type == "rolling":
             window = int(frame_size) if frame_size is not None else 1
             if agg_type == "sum":
@@ -98,9 +110,18 @@ class PolarsLazyFrameAggregate(FrameAggregateFeatureGroup):
                     .alias(feature_name)
                 )
             else:
-                raise ValueError(f"Unsupported rolling agg for Polars: {agg_type}")
+                raise unsupported_agg_type_error(
+                    agg_type,
+                    _ROLLING_AGG_TYPES,
+                    framework="Polars",
+                    operation="rolling",
+                )
         else:
-            raise ValueError(f"Unsupported frame type for Polars: {frame_type}")
+            raise unsupported_frame_type_error(
+                frame_type,
+                cls.SUPPORTED_FRAME_TYPES,
+                framework="Polars",
+            )
 
         result = sorted_data.with_columns(expr)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/sqlite_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/sqlite_frame_aggregate.py
@@ -9,6 +9,10 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import q
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation
 
+from mloda.community.feature_groups.data_operations.errors import (
+    unsupported_agg_type_error,
+    unsupported_frame_type_error,
+)
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.base import (
     FrameAggregateFeatureGroup,
@@ -46,7 +50,12 @@ class SqliteFrameAggregate(FrameAggregateFeatureGroup):
     ) -> SqliteRelation:
         agg_func = _SQLITE_AGG_FUNCS.get(agg_type)
         if agg_func is None:
-            raise ValueError(f"Unsupported aggregation type for SQLite frame aggregate: {agg_type}")
+            raise unsupported_agg_type_error(
+                agg_type,
+                _SQLITE_AGG_FUNCS.keys(),
+                framework="SQLite",
+                operation="frame aggregate",
+            )
 
         quoted_source = quote_ident(source_col)
         source_sql = quoted_source
@@ -68,7 +77,11 @@ class SqliteFrameAggregate(FrameAggregateFeatureGroup):
         elif frame_type == "time":
             raise ValueError("SQLite does not support RANGE-based time windows natively")
         else:
-            raise ValueError(f"Unsupported frame type for SQLite: {frame_type}")
+            raise unsupported_frame_type_error(
+                frame_type,
+                cls.SUPPORTED_FRAME_TYPES,
+                framework="SQLite",
+            )
 
         # Safety: all identifiers use quote_ident(), agg_func from whitelist
         sql = " ".join(  # nosec

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
@@ -12,7 +12,7 @@ column and fills every row with that scalar result.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
@@ -48,6 +48,8 @@ class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     MAX_IN_FEATURES = 1
 
     AGGREGATION_TYPE = "aggregation_type"
+
+    _SUPPORTED_AGG_TYPES: ClassVar[frozenset[str]] = frozenset(AGGREGATION_TYPES)
 
     PROPERTY_MAPPING = {
         AGGREGATION_TYPE: {

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/duckdb_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/duckdb_scalar_aggregate.py
@@ -9,6 +9,7 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framewor
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
     ScalarAggregateFeatureGroup,
@@ -47,7 +48,7 @@ class DuckdbScalarAggregate(ScalarAggregateFeatureGroup):
     ) -> DuckdbRelation:
         agg_func = _DUCKDB_AGG_FUNCS.get(agg_type)
         if agg_func is None:
-            raise ValueError(f"Unsupported aggregation type for DuckDB: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _DUCKDB_AGG_FUNCS.keys(), framework="DuckDB")
 
         quoted_source = quote_ident(source_col)
         quoted_feature = quote_ident(feature_name)

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pandas_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pandas_scalar_aggregate.py
@@ -18,22 +18,6 @@ from mloda_plugins.compute_framework.base_implementations.pandas.pandas_mask_eng
     PandasMaskEngine,
 )
 
-_SUPPORTED_AGG_TYPES = {
-    "sum",
-    "min",
-    "max",
-    "avg",
-    "mean",
-    "count",
-    "std",
-    "std_pop",
-    "std_samp",
-    "var",
-    "var_pop",
-    "var_samp",
-    "median",
-}
-
 
 class PandasScalarAggregate(ScalarAggregateFeatureGroup):
     @classmethod
@@ -78,7 +62,7 @@ class PandasScalarAggregate(ScalarAggregateFeatureGroup):
         elif agg_type == "median":
             result = col.median()
         else:
-            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Pandas")
+            raise unsupported_agg_type_error(agg_type, cls._SUPPORTED_AGG_TYPES, framework="Pandas")
 
         data[feature_name] = result
         return data

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pandas_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pandas_scalar_aggregate.py
@@ -9,6 +9,7 @@ import pandas as pd
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_mask_from_spec
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
     ScalarAggregateFeatureGroup,
@@ -16,6 +17,22 @@ from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggreg
 from mloda_plugins.compute_framework.base_implementations.pandas.pandas_mask_engine import (
     PandasMaskEngine,
 )
+
+_SUPPORTED_AGG_TYPES = {
+    "sum",
+    "min",
+    "max",
+    "avg",
+    "mean",
+    "count",
+    "std",
+    "std_pop",
+    "std_samp",
+    "var",
+    "var_pop",
+    "var_samp",
+    "median",
+}
 
 
 class PandasScalarAggregate(ScalarAggregateFeatureGroup):
@@ -61,7 +78,7 @@ class PandasScalarAggregate(ScalarAggregateFeatureGroup):
         elif agg_type == "median":
             result = col.median()
         else:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Pandas")
 
         data[feature_name] = result
         return data

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/polars_lazy_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/polars_lazy_scalar_aggregate.py
@@ -15,22 +15,6 @@ from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggreg
     ScalarAggregateFeatureGroup,
 )
 
-_SUPPORTED_AGG_TYPES = {
-    "sum",
-    "min",
-    "max",
-    "avg",
-    "mean",
-    "count",
-    "std",
-    "std_pop",
-    "std_samp",
-    "var",
-    "var_pop",
-    "var_samp",
-    "median",
-}
-
 
 class PolarsLazyScalarAggregate(ScalarAggregateFeatureGroup):
     @classmethod
@@ -76,7 +60,7 @@ class PolarsLazyScalarAggregate(ScalarAggregateFeatureGroup):
         elif agg_type == "median":
             expr = col.median()
         else:
-            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Polars")
+            raise unsupported_agg_type_error(agg_type, cls._SUPPORTED_AGG_TYPES, framework="Polars")
 
         result = data.with_columns(expr.alias(feature_name))
         if mask_spec is not None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/polars_lazy_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/polars_lazy_scalar_aggregate.py
@@ -9,10 +9,27 @@ import polars as pl
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import _POLARS_MASK_TMP, apply_polars_mask
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
     ScalarAggregateFeatureGroup,
 )
+
+_SUPPORTED_AGG_TYPES = {
+    "sum",
+    "min",
+    "max",
+    "avg",
+    "mean",
+    "count",
+    "std",
+    "std_pop",
+    "std_samp",
+    "var",
+    "var_pop",
+    "var_samp",
+    "median",
+}
 
 
 class PolarsLazyScalarAggregate(ScalarAggregateFeatureGroup):
@@ -59,7 +76,7 @@ class PolarsLazyScalarAggregate(ScalarAggregateFeatureGroup):
         elif agg_type == "median":
             expr = col.median()
         else:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Polars")
 
         result = data.with_columns(expr.alias(feature_name))
         if mask_spec is not None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyarrow_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyarrow_scalar_aggregate.py
@@ -10,10 +10,27 @@ import pyarrow.compute as pc
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import apply_pyarrow_mask
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
     ScalarAggregateFeatureGroup,
 )
+
+_SUPPORTED_AGG_TYPES = {
+    "sum",
+    "min",
+    "max",
+    "avg",
+    "mean",
+    "count",
+    "std",
+    "std_pop",
+    "std_samp",
+    "var",
+    "var_pop",
+    "var_samp",
+    "median",
+}
 
 
 class PyArrowScalarAggregate(ScalarAggregateFeatureGroup):
@@ -59,7 +76,7 @@ class PyArrowScalarAggregate(ScalarAggregateFeatureGroup):
                 raise ValueError("pc.quantile returned an empty result for median computation")
             result = q_result[0].as_py()
         else:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="PyArrow")
 
         repeated = pa.array([result] * table.num_rows)
         return table.append_column(feature_name, repeated)

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyarrow_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyarrow_scalar_aggregate.py
@@ -16,22 +16,6 @@ from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggreg
     ScalarAggregateFeatureGroup,
 )
 
-_SUPPORTED_AGG_TYPES = {
-    "sum",
-    "min",
-    "max",
-    "avg",
-    "mean",
-    "count",
-    "std",
-    "std_pop",
-    "std_samp",
-    "var",
-    "var_pop",
-    "var_samp",
-    "median",
-}
-
 
 class PyArrowScalarAggregate(ScalarAggregateFeatureGroup):
     @classmethod
@@ -76,7 +60,7 @@ class PyArrowScalarAggregate(ScalarAggregateFeatureGroup):
                 raise ValueError("pc.quantile returned an empty result for median computation")
             result = q_result[0].as_py()
         else:
-            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="PyArrow")
+            raise unsupported_agg_type_error(agg_type, cls._SUPPORTED_AGG_TYPES, framework="PyArrow")
 
         repeated = pa.array([result] * table.num_rows)
         return table.append_column(feature_name, repeated)

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/sqlite_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/sqlite_scalar_aggregate.py
@@ -9,6 +9,7 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import q
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
     ScalarAggregateFeatureGroup,
@@ -40,7 +41,7 @@ class SqliteScalarAggregate(ScalarAggregateFeatureGroup):
     ) -> SqliteRelation:
         agg_func = _SQLITE_AGG_FUNCS.get(agg_type)
         if agg_func is None:
-            raise ValueError(f"Unsupported aggregation type for SQLite: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SQLITE_AGG_FUNCS.keys(), framework="SQLite")
 
         quoted_source = quote_ident(source_col)
         quoted_feature = quote_ident(feature_name)

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
@@ -9,6 +9,7 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framewor
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
@@ -73,7 +74,9 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
         if agg_type in ("first", "last"):
             return cls._compute_first_last(data, feature_name, source_sql, partition_by, agg_type, order_by)
 
-        agg_func = _DUCKDB_AGG_FUNCS[agg_type]
+        agg_func = _DUCKDB_AGG_FUNCS.get(agg_type)
+        if agg_func is None:
+            raise unsupported_agg_type_error(agg_type, _DUCKDB_AGG_FUNCS.keys(), framework="DuckDB")
         raw_sql = f"*, {agg_func}({source_sql}) OVER (PARTITION BY {partition_clause}) AS {quoted_feature}"
         result = data.select(_raw_sql=raw_sql)
         return result

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pandas_window_aggregation.py
@@ -10,6 +10,7 @@ import pandas as pd
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_mask_from_spec
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
@@ -23,6 +24,8 @@ from mloda.community.feature_groups.data_operations.pandas_helpers import (
 from mloda_plugins.compute_framework.base_implementations.pandas.pandas_mask_engine import (
     PandasMaskEngine,
 )
+
+_SUPPORTED_AGG_TYPES = {*PANDAS_AGG_FUNCS.keys(), "mode"}
 
 
 class PandasWindowAggregation(WindowAggregationFeatureGroup):
@@ -55,7 +58,7 @@ class PandasWindowAggregation(WindowAggregationFeatureGroup):
 
         pandas_func = PANDAS_AGG_FUNCS.get(agg_type)
         if pandas_func is None:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Pandas")
 
         grouped = null_safe_groupby(data, partition_by, source_col)
         result_series = apply_null_safe_agg(grouped, pandas_func, agg_type, method="transform")

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/polars_lazy_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/polars_lazy_window_aggregation.py
@@ -9,6 +9,7 @@ import polars as pl
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import _POLARS_MASK_TMP, apply_polars_mask
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
@@ -32,6 +33,8 @@ _POLARS_AGG_EXPRS: dict[str, Any] = {
     "median": lambda col: pl.col(col).median(),
     "nunique": lambda col: pl.col(col).drop_nulls().n_unique(),
 }
+
+_SUPPORTED_AGG_TYPES = {*_POLARS_AGG_EXPRS.keys(), "mode", "first", "last"}
 
 
 def _mode_with_insertion_order(s: pl.Series) -> Any:
@@ -92,7 +95,7 @@ class PolarsLazyWindowAggregation(WindowAggregationFeatureGroup):
             else:
                 expr = raw_expr.alias(feature_name)
         else:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Polars")
 
         result = data.with_columns(expr)
         if mask_spec is not None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
@@ -16,6 +16,7 @@ import pyarrow.compute as pc
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import apply_pyarrow_mask
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
@@ -46,6 +47,8 @@ _ORDERED_FUNCS: dict[str, str] = {
     "first": "first",
     "last": "last",
 }
+
+_SUPPORTED_AGG_TYPES = {*_PA_AGG_FUNCS, *_VARIANCE_FUNCS, *_ORDERED_FUNCS}
 
 
 class PyArrowWindowAggregation(WindowAggregationFeatureGroup):
@@ -94,7 +97,7 @@ class PyArrowWindowAggregation(WindowAggregationFeatureGroup):
             return cls._compute_ordered(t_with_idx, feature_name, source_col, partition_by, agg_type, order_by)
 
         else:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="PyArrow")
 
         return cls._broadcast(table, grouped, agg_col, feature_name, num_rows)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
@@ -9,6 +9,7 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import q
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
@@ -44,7 +45,7 @@ class SqliteWindowAggregation(WindowAggregationFeatureGroup):
         """Execute the aggregation as a SQL window function."""
         agg_func = _SQLITE_AGG_FUNCS.get(agg_type)
         if agg_func is None:
-            raise ValueError(f"Unsupported aggregation type for SQLite: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SQLITE_AGG_FUNCS.keys(), framework="SQLite")
 
         quoted_source = quote_ident(source_col)
         partition_clause = ", ".join(quote_ident(col) for col in partition_by)

--- a/mloda/community/feature_groups/data_operations/tests/test_errors.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_errors.py
@@ -1,0 +1,100 @@
+"""Tests for shared error-construction helpers used by data operations."""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.community.feature_groups.data_operations.errors import (
+    unsupported_agg_type_error,
+    unsupported_frame_type_error,
+)
+
+
+class TestUnsupportedAggTypeError:
+    def test_returns_value_error(self) -> None:
+        """The helper returns a ValueError instance (not raises it)."""
+        err = unsupported_agg_type_error("foo", ["sum", "avg"])
+        assert isinstance(err, ValueError)
+
+    def test_message_quotes_rejected_value(self) -> None:
+        """Rejected value is quoted via repr() so whitespace/empty is visible."""
+        err = unsupported_agg_type_error("foo", ["sum"])
+        assert "'foo'" in str(err)
+
+    def test_message_lists_supported_sorted(self) -> None:
+        """Supported types appear alphabetically sorted in the message."""
+        err = unsupported_agg_type_error("foo", ["sum", "avg", "count"])
+        assert "Supported types: avg, count, sum." in str(err)
+
+    def test_message_deduplicates_supported(self) -> None:
+        """Duplicate entries in supported are deduplicated."""
+        err = unsupported_agg_type_error("foo", ["sum", "sum", "avg"])
+        assert "Supported types: avg, sum." in str(err)
+
+    def test_message_includes_framework_when_given(self) -> None:
+        err = unsupported_agg_type_error("foo", ["sum"], framework="DuckDB")
+        assert "Unsupported aggregation type for DuckDB:" in str(err)
+
+    def test_message_includes_operation_when_given(self) -> None:
+        err = unsupported_agg_type_error(
+            "foo",
+            ["sum"],
+            framework="SQLite",
+            operation="frame aggregate",
+        )
+        assert "Unsupported aggregation type for SQLite frame aggregate:" in str(err)
+
+    def test_message_without_framework_or_operation(self) -> None:
+        err = unsupported_agg_type_error("foo", ["sum"])
+        assert str(err) == "Unsupported aggregation type: 'foo'. Supported types: sum."
+
+    def test_accepts_dict_keys_view(self) -> None:
+        """Callers pass ``dict.keys()`` directly: ensure it works."""
+        supported = {"sum": "SUM", "avg": "AVG"}
+        err = unsupported_agg_type_error("foo", supported.keys(), framework="DuckDB")
+        assert "Supported types: avg, sum." in str(err)
+
+    def test_accepts_set(self) -> None:
+        """Callers pass pre-built sets: ensure iteration order is normalised."""
+        err = unsupported_agg_type_error("foo", {"sum", "avg", "count"})
+        # Order must be alphabetical regardless of set insertion order.
+        assert "Supported types: avg, count, sum." in str(err)
+
+    def test_empty_string_agg_type_is_visible(self) -> None:
+        """Empty agg_type must show up as '' (not a silent empty substring)."""
+        err = unsupported_agg_type_error("", ["sum"])
+        assert "''" in str(err)
+
+    def test_raisable(self) -> None:
+        """The returned object must be usable as a raise target."""
+        with pytest.raises(ValueError, match="Supported types: avg, sum"):
+            raise unsupported_agg_type_error("foo", ["sum", "avg"])
+
+
+class TestUnsupportedFrameTypeError:
+    def test_returns_value_error(self) -> None:
+        err = unsupported_frame_type_error("sliding", ["rolling"])
+        assert isinstance(err, ValueError)
+
+    def test_message_quotes_rejected_value(self) -> None:
+        err = unsupported_frame_type_error("sliding", ["rolling"])
+        assert "'sliding'" in str(err)
+
+    def test_message_lists_supported_sorted(self) -> None:
+        err = unsupported_frame_type_error(
+            "sliding",
+            {"rolling", "cumulative", "expanding"},
+        )
+        assert "Supported types: cumulative, expanding, rolling." in str(err)
+
+    def test_message_includes_framework_when_given(self) -> None:
+        err = unsupported_frame_type_error("sliding", ["rolling"], framework="DuckDB")
+        assert "Unsupported frame type for DuckDB:" in str(err)
+
+    def test_raisable(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported frame type for Pandas"):
+            raise unsupported_frame_type_error(
+                "sliding",
+                ["rolling"],
+                framework="Pandas",
+            )

--- a/mloda/community/feature_groups/data_operations/tests/test_unsupported_type_messages.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_unsupported_type_messages.py
@@ -231,6 +231,27 @@ class TestWindowAggregationErrors:
         _assert_valid_error(exc.value, "not_a_real_agg", "sum", "first")
         assert "for PyArrow" in str(exc.value)
 
+    def test_duckdb_window_error(self) -> None:
+        duckdb = pytest.importorskip("duckdb")
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.duckdb_window_aggregation import (
+            DuckdbWindowAggregation,
+        )
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import (
+            DuckdbRelation,
+        )
+
+        arrow = pa.table({"region": ["a", "b"], "val": [1, 2]})
+        conn = duckdb.connect(":memory:")
+        try:
+            rel = DuckdbRelation.from_arrow(conn, arrow)
+            with pytest.raises(ValueError) as exc:
+                DuckdbWindowAggregation._compute_window(rel, "f", "val", ["region"], "not_a_real_agg")
+            _assert_valid_error(exc.value, "not_a_real_agg", "sum", "median", "mode")
+            assert "for DuckDB" in str(exc.value)
+        finally:
+            conn.close()
+
     def test_sqlite_window_error(self) -> None:
         pa = pytest.importorskip("pyarrow")
         from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.sqlite_window_aggregation import (

--- a/mloda/community/feature_groups/data_operations/tests/test_unsupported_type_messages.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_unsupported_type_messages.py
@@ -401,6 +401,84 @@ class TestReferenceAggregationHelperError:
         _assert_valid_error(exc.value, "not_a_real_agg", "sum", "median", "mode")
 
 
+class TestScalarAggregateSupportedTypes:
+    """Guard the single-source-of-truth contract for scalar_aggregate supported types.
+
+    The base class must declare ``_SUPPORTED_AGG_TYPES`` as a ``frozenset``
+    derived from ``AGGREGATION_TYPES``. The pandas, pyarrow, and polars
+    scalar_aggregate modules must not redeclare the set at module scope and
+    their concrete classes must inherit the base attribute unchanged.
+    """
+
+    def test_base_class_declares_supported_agg_types_frozenset(self) -> None:
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
+            AGGREGATION_TYPES,
+            ScalarAggregateFeatureGroup,
+        )
+
+        assert hasattr(ScalarAggregateFeatureGroup, "_SUPPORTED_AGG_TYPES")
+        assert isinstance(ScalarAggregateFeatureGroup._SUPPORTED_AGG_TYPES, frozenset)
+        assert ScalarAggregateFeatureGroup._SUPPORTED_AGG_TYPES == frozenset(AGGREGATION_TYPES)
+
+    def test_pandas_pyarrow_polars_modules_do_not_redeclare_supported(self) -> None:
+        import importlib
+
+        module_paths = (
+            (
+                "pandas",
+                "mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pandas_scalar_aggregate",
+            ),
+            (
+                "pyarrow",
+                "mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pyarrow_scalar_aggregate",
+            ),
+            (
+                "polars",
+                "mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.polars_lazy_scalar_aggregate",
+            ),
+        )
+        for dep, path in module_paths:
+            pytest.importorskip(dep)
+            module = importlib.import_module(path)
+            assert not hasattr(module, "_SUPPORTED_AGG_TYPES"), (
+                f"{path} still declares a module-level _SUPPORTED_AGG_TYPES; "
+                "it must be removed in favour of the base class attribute."
+            )
+
+    def test_pandas_scalar_aggregate_uses_base_supported_set(self) -> None:
+        pytest.importorskip("pandas")
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
+            ScalarAggregateFeatureGroup,
+        )
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pandas_scalar_aggregate import (
+            PandasScalarAggregate,
+        )
+
+        assert PandasScalarAggregate._SUPPORTED_AGG_TYPES is ScalarAggregateFeatureGroup._SUPPORTED_AGG_TYPES
+
+    def test_pyarrow_scalar_aggregate_uses_base_supported_set(self) -> None:
+        pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
+            ScalarAggregateFeatureGroup,
+        )
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pyarrow_scalar_aggregate import (
+            PyArrowScalarAggregate,
+        )
+
+        assert PyArrowScalarAggregate._SUPPORTED_AGG_TYPES is ScalarAggregateFeatureGroup._SUPPORTED_AGG_TYPES
+
+    def test_polars_scalar_aggregate_uses_base_supported_set(self) -> None:
+        pytest.importorskip("polars")
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
+            ScalarAggregateFeatureGroup,
+        )
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.polars_lazy_scalar_aggregate import (
+            PolarsLazyScalarAggregate,
+        )
+
+        assert PolarsLazyScalarAggregate._SUPPORTED_AGG_TYPES is ScalarAggregateFeatureGroup._SUPPORTED_AGG_TYPES
+
+
 def test_error_messages_use_single_quoted_repr() -> None:
     """All messages quote the rejected value via !r for robustness.
 

--- a/mloda/community/feature_groups/data_operations/tests/test_unsupported_type_messages.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_unsupported_type_messages.py
@@ -1,0 +1,395 @@
+"""End-to-end checks that every ``_compute_*`` implementation produces an
+unsupported-type error whose message lists the concrete set of valid types.
+
+These tests guard against regressions of the user-guidance contract
+introduced for audit item #14: an unsupported ``agg_type`` (or
+``frame_type``) must raise ``ValueError`` whose message *both* shows the
+rejected value *and* enumerates the types the caller could have used.
+
+The tests import only what the specific framework needs and skip when
+that framework's optional dependency is missing, so running the suite
+in a slim environment still covers everything that is installable.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_valid_error(err: BaseException, agg_type: str, *expected_supported: str) -> None:
+    """Assert the raised error follows the contract shared across frameworks."""
+    msg = str(err)
+    assert repr(agg_type) in msg, f"rejected value {agg_type!r} missing from {msg!r}"
+    assert "Supported types:" in msg, f"missing 'Supported types:' prefix in {msg!r}"
+    for value in expected_supported:
+        assert re.search(rf"\b{re.escape(value)}\b", msg), f"{value!r} missing from {msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# Aggregation (group-by)
+# ---------------------------------------------------------------------------
+
+
+class TestAggregationErrors:
+    def test_pandas_aggregation_error(self) -> None:
+        pd = pytest.importorskip("pandas")
+        from mloda.community.feature_groups.data_operations.aggregation.pandas_aggregation import (
+            PandasAggregation,
+        )
+
+        df = pd.DataFrame({"region": ["a", "b"], "val": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PandasAggregation._compute_group(df, "f", "val", ["region"], "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "count", "mean")
+        assert "for Pandas" in str(exc.value)
+
+    def test_pyarrow_aggregation_error(self) -> None:
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.aggregation.pyarrow_aggregation import (
+            PyArrowAggregation,
+        )
+
+        tbl = pa.table({"region": ["a", "b"], "val": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PyArrowAggregation._compute_group(tbl, "f", "val", ["region"], "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "count", "first")
+        assert "for PyArrow" in str(exc.value)
+
+    def test_duckdb_aggregation_error(self) -> None:
+        duckdb = pytest.importorskip("duckdb")
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.aggregation.duckdb_aggregation import (
+            DuckdbAggregation,
+        )
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import (
+            DuckdbRelation,
+        )
+
+        arrow = pa.table({"region": ["a", "b"], "val": [1, 2]})
+        conn = duckdb.connect(":memory:")
+        try:
+            rel = DuckdbRelation.from_arrow(conn, arrow)
+            with pytest.raises(ValueError) as exc:
+                DuckdbAggregation._compute_group(rel, "f", "val", ["region"], "not_a_real_agg")
+            _assert_valid_error(exc.value, "not_a_real_agg", "sum", "median", "mode")
+            assert "for DuckDB" in str(exc.value)
+        finally:
+            conn.close()
+
+    def test_sqlite_aggregation_error(self) -> None:
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.aggregation.sqlite_aggregation import (
+            SqliteAggregation,
+        )
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import (
+            SqliteRelation,
+        )
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            arrow = pa.table({"region": ["a", "b"], "val": [1, 2]})
+            rel = SqliteRelation.from_arrow(conn, arrow)
+            with pytest.raises(ValueError) as exc:
+                SqliteAggregation._compute_group(rel, "f", "val", ["region"], "median")
+            _assert_valid_error(exc.value, "median", "sum", "avg", "count", "min", "max")
+            assert "for SQLite" in str(exc.value)
+        finally:
+            conn.close()
+
+    def test_polars_lazy_aggregation_error(self) -> None:
+        pl = pytest.importorskip("polars")
+        from mloda.community.feature_groups.data_operations.aggregation.polars_lazy_aggregation import (
+            PolarsLazyAggregation,
+        )
+
+        lf = pl.LazyFrame({"region": ["a", "b"], "val": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PolarsLazyAggregation._compute_group(lf, "f", "val", ["region"], "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "count", "first")
+        assert "for Polars" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Scalar aggregate
+# ---------------------------------------------------------------------------
+
+
+class TestScalarAggregateErrors:
+    def test_pandas_scalar_aggregate_error(self) -> None:
+        pd = pytest.importorskip("pandas")
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pandas_scalar_aggregate import (
+            PandasScalarAggregate,
+        )
+
+        df = pd.DataFrame({"val": [1, 2, 3]})
+        with pytest.raises(ValueError) as exc:
+            PandasScalarAggregate._compute_aggregation(df, "f", "val", "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "median", "std_samp")
+        assert "for Pandas" in str(exc.value)
+
+    def test_pyarrow_scalar_aggregate_error(self) -> None:
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pyarrow_scalar_aggregate import (
+            PyArrowScalarAggregate,
+        )
+
+        tbl = pa.table({"val": [1, 2, 3]})
+        with pytest.raises(ValueError) as exc:
+            PyArrowScalarAggregate._compute_aggregation(tbl, "f", "val", "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "median", "std_samp")
+        assert "for PyArrow" in str(exc.value)
+
+    def test_sqlite_scalar_aggregate_error(self) -> None:
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.sqlite_scalar_aggregate import (
+            SqliteScalarAggregate,
+        )
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import (
+            SqliteRelation,
+        )
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            arrow = pa.table({"val": [1, 2, 3]})
+            rel = SqliteRelation.from_arrow(conn, arrow)
+            with pytest.raises(ValueError) as exc:
+                SqliteScalarAggregate._compute_aggregation(rel, "f", "val", "median")
+            _assert_valid_error(exc.value, "median", "sum", "avg", "count")
+            assert "for SQLite" in str(exc.value)
+        finally:
+            conn.close()
+
+    def test_duckdb_scalar_aggregate_error(self) -> None:
+        duckdb = pytest.importorskip("duckdb")
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.duckdb_scalar_aggregate import (
+            DuckdbScalarAggregate,
+        )
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import (
+            DuckdbRelation,
+        )
+
+        arrow = pa.table({"val": [1, 2, 3]})
+        conn = duckdb.connect(":memory:")
+        try:
+            rel = DuckdbRelation.from_arrow(conn, arrow)
+            with pytest.raises(ValueError) as exc:
+                DuckdbScalarAggregate._compute_aggregation(rel, "f", "val", "not_a_real_agg")
+            _assert_valid_error(exc.value, "not_a_real_agg", "sum", "median")
+            assert "for DuckDB" in str(exc.value)
+        finally:
+            conn.close()
+
+    def test_polars_lazy_scalar_aggregate_error(self) -> None:
+        pl = pytest.importorskip("polars")
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.polars_lazy_scalar_aggregate import (
+            PolarsLazyScalarAggregate,
+        )
+
+        lf = pl.LazyFrame({"val": [1, 2, 3]})
+        with pytest.raises(ValueError) as exc:
+            PolarsLazyScalarAggregate._compute_aggregation(lf, "f", "val", "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "median")
+        assert "for Polars" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Window aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestWindowAggregationErrors:
+    def test_pandas_window_error(self) -> None:
+        pd = pytest.importorskip("pandas")
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.pandas_window_aggregation import (
+            PandasWindowAggregation,
+        )
+
+        df = pd.DataFrame({"region": ["a", "b"], "val": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PandasWindowAggregation._compute_window(df, "f", "val", ["region"], "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "count")
+        assert "for Pandas" in str(exc.value)
+
+    def test_pyarrow_window_error(self) -> None:
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.pyarrow_window_aggregation import (
+            PyArrowWindowAggregation,
+        )
+
+        tbl = pa.table({"region": ["a", "b"], "val": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PyArrowWindowAggregation._compute_window(tbl, "f", "val", ["region"], "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "first")
+        assert "for PyArrow" in str(exc.value)
+
+    def test_sqlite_window_error(self) -> None:
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.sqlite_window_aggregation import (
+            SqliteWindowAggregation,
+        )
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import (
+            SqliteRelation,
+        )
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            arrow = pa.table({"region": ["a", "b"], "val": [1, 2]})
+            rel = SqliteRelation.from_arrow(conn, arrow)
+            with pytest.raises(ValueError) as exc:
+                SqliteWindowAggregation._compute_window(rel, "f", "val", ["region"], "median")
+            _assert_valid_error(exc.value, "median", "sum", "avg", "count")
+            assert "for SQLite" in str(exc.value)
+        finally:
+            conn.close()
+
+    def test_polars_lazy_window_error(self) -> None:
+        pl = pytest.importorskip("polars")
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.polars_lazy_window_aggregation import (
+            PolarsLazyWindowAggregation,
+        )
+
+        lf = pl.LazyFrame({"region": ["a", "b"], "val": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PolarsLazyWindowAggregation._compute_window(lf, "f", "val", ["region"], "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "first")
+        assert "for Polars" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Frame aggregate (agg_type AND frame_type errors)
+# ---------------------------------------------------------------------------
+
+
+class TestFrameAggregateErrors:
+    def test_pandas_frame_agg_type_error(self) -> None:
+        pd = pytest.importorskip("pandas")
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.pandas_frame_aggregate import (
+            PandasFrameAggregate,
+        )
+
+        df = pd.DataFrame({"region": ["a", "b"], "val": [1, 2], "ts": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PandasFrameAggregate._compute_frame(
+                df, "f", "val", ["region"], "ts", "not_a_real_agg", "rolling", frame_size=2
+            )
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "std", "median")
+        assert "for Pandas frame aggregate" in str(exc.value)
+
+    def test_pandas_frame_type_error(self) -> None:
+        pd = pytest.importorskip("pandas")
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.pandas_frame_aggregate import (
+            PandasFrameAggregate,
+        )
+
+        df = pd.DataFrame({"region": ["a", "b"], "val": [1, 2], "ts": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PandasFrameAggregate._compute_frame(df, "f", "val", ["region"], "ts", "sum", "not_a_real_frame")
+        _assert_valid_error(exc.value, "not_a_real_frame", "rolling", "cumulative", "expanding")
+        assert "Unsupported frame type for Pandas" in str(exc.value)
+
+    def test_sqlite_frame_agg_type_error(self) -> None:
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.sqlite_frame_aggregate import (
+            SqliteFrameAggregate,
+        )
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import (
+            SqliteRelation,
+        )
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            arrow = pa.table({"region": ["a", "b"], "val": [1, 2], "ts": [1, 2]})
+            rel = SqliteRelation.from_arrow(conn, arrow)
+            with pytest.raises(ValueError) as exc:
+                SqliteFrameAggregate._compute_frame(
+                    rel, "f", "val", ["region"], "ts", "median", "rolling", frame_size=2
+                )
+            _assert_valid_error(exc.value, "median", "sum", "avg", "count")
+            assert "for SQLite frame aggregate" in str(exc.value)
+        finally:
+            conn.close()
+
+    def test_duckdb_frame_agg_type_error(self) -> None:
+        duckdb = pytest.importorskip("duckdb")
+        pa = pytest.importorskip("pyarrow")
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.duckdb_frame_aggregate import (
+            DuckdbFrameAggregate,
+        )
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import (
+            DuckdbRelation,
+        )
+
+        arrow = pa.table({"region": ["a", "b"], "val": [1, 2], "ts": [1, 2]})
+        conn = duckdb.connect(":memory:")
+        try:
+            rel = DuckdbRelation.from_arrow(conn, arrow)
+            with pytest.raises(ValueError) as exc:
+                DuckdbFrameAggregate._compute_frame(
+                    rel, "f", "val", ["region"], "ts", "not_a_real_agg", "rolling", frame_size=2
+                )
+            _assert_valid_error(exc.value, "not_a_real_agg", "sum", "median", "std")
+            assert "for DuckDB frame aggregate" in str(exc.value)
+        finally:
+            conn.close()
+
+    def test_polars_lazy_frame_cumulative_error(self) -> None:
+        pl = pytest.importorskip("polars")
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.polars_lazy_frame_aggregate import (
+            PolarsLazyFrameAggregate,
+        )
+
+        lf = pl.LazyFrame({"region": ["a", "b"], "val": [1, 2], "ts": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PolarsLazyFrameAggregate._compute_frame(lf, "f", "val", ["region"], "ts", "median", "cumulative")
+        _assert_valid_error(exc.value, "median", "sum", "avg")
+        assert "for Polars cumulative/expanding" in str(exc.value)
+
+    def test_polars_lazy_frame_rolling_error(self) -> None:
+        pl = pytest.importorskip("polars")
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.polars_lazy_frame_aggregate import (
+            PolarsLazyFrameAggregate,
+        )
+
+        lf = pl.LazyFrame({"region": ["a", "b"], "val": [1, 2], "ts": [1, 2]})
+        with pytest.raises(ValueError) as exc:
+            PolarsLazyFrameAggregate._compute_frame(lf, "f", "val", ["region"], "ts", "mode", "rolling", frame_size=2)
+        _assert_valid_error(exc.value, "mode", "sum", "std")
+        assert "for Polars rolling" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Test reference implementations
+# ---------------------------------------------------------------------------
+
+
+class TestReferenceAggregationHelperError:
+    def test_reference_aggregation_helper_error(self) -> None:
+        from mloda.testing.feature_groups.data_operations.aggregation_helpers import aggregate
+
+        with pytest.raises(ValueError) as exc:
+            aggregate([1, 2, 3], "not_a_real_agg")
+        _assert_valid_error(exc.value, "not_a_real_agg", "sum", "median", "mode")
+
+
+def test_error_messages_use_single_quoted_repr() -> None:
+    """All messages quote the rejected value via !r for robustness.
+
+    This regression-guards the contract: if a caller ever refactors the
+    helper to use ``str()`` instead of ``repr()``, empty-string and
+    whitespace values would vanish silently.
+    """
+    from mloda.community.feature_groups.data_operations.errors import (
+        unsupported_agg_type_error,
+    )
+
+    err = unsupported_agg_type_error(" ", {"sum"})
+    assert "' '" in str(err)

--- a/mloda/testing/feature_groups/data_operations/aggregation/reference.py
+++ b/mloda/testing/feature_groups/data_operations/aggregation/reference.py
@@ -21,6 +21,7 @@ from mloda_plugins.compute_framework.base_implementations.pyarrow.table import P
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import apply_pyarrow_mask
 
 # Aggregation types with direct PyArrow group_by support.
@@ -49,6 +50,8 @@ _ORDERED_FUNCS: dict[str, str] = {
     "first": "first",
     "last": "last",
 }
+
+_SUPPORTED_AGG_TYPES = {*_PA_AGG_FUNCS, *_VARIANCE_FUNCS, *_ORDERED_FUNCS, "median", "mode"}
 
 
 class ReferenceAggregation(AggregationFeatureGroup):
@@ -81,7 +84,7 @@ class ReferenceAggregation(AggregationFeatureGroup):
         elif agg_type in ("median", "mode"):
             return cls._compute_via_list(table, feature_name, source_col, partition_by, agg_type)
         else:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Reference")
 
         # Rename auto-generated column (e.g. "val_sum") to feature_name.
         auto_col = f"{source_col}_{pa_func}"

--- a/mloda/testing/feature_groups/data_operations/aggregation_helpers.py
+++ b/mloda/testing/feature_groups/data_operations/aggregation_helpers.py
@@ -10,6 +10,27 @@ from __future__ import annotations
 from collections import Counter
 from typing import Any
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
+
+_SUPPORTED_AGG_TYPES = {
+    "sum",
+    "avg",
+    "count",
+    "min",
+    "max",
+    "std",
+    "std_pop",
+    "std_samp",
+    "var",
+    "var_pop",
+    "var_samp",
+    "median",
+    "mode",
+    "nunique",
+    "first",
+    "last",
+}
+
 
 def aggregate(values: list[Any], agg_type: str) -> Any:
     """Compute a single aggregate over a list of values (may contain None)."""
@@ -49,7 +70,7 @@ def aggregate(values: list[Any], agg_type: str) -> Any:
     if agg_type == "last":
         return non_null[-1]
 
-    raise ValueError(f"Unsupported aggregation type: {agg_type}")
+    raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES)
 
 
 def std(values: list[Any], ddof: int = 0) -> Any:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/reference.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/reference.py
@@ -19,6 +19,7 @@ import pyarrow.compute as pc
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
+from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import apply_pyarrow_mask
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
@@ -49,6 +50,8 @@ _ORDERED_FUNCS: dict[str, str] = {
     "first": "first",
     "last": "last",
 }
+
+_SUPPORTED_AGG_TYPES = {*_PA_AGG_FUNCS, *_VARIANCE_FUNCS, *_ORDERED_FUNCS, "median", "mode"}
 
 
 class ReferenceWindowAggregation(WindowAggregationFeatureGroup):
@@ -100,7 +103,7 @@ class ReferenceWindowAggregation(WindowAggregationFeatureGroup):
             return cls._compute_via_list(t_with_idx, feature_name, source_col, partition_by, agg_type)
 
         else:
-            raise ValueError(f"Unsupported aggregation type: {agg_type}")
+            raise unsupported_agg_type_error(agg_type, _SUPPORTED_AGG_TYPES, framework="Reference")
 
         return cls._broadcast(table, grouped, agg_col, feature_name, num_rows)
 


### PR DESCRIPTION
## Summary

Addresses audit item #14 from #74: _"Error messages don't guide users toward solutions"_.

Every `_compute_*` implementation in `data_operations/` used to raise a bare `ValueError(f"Unsupported aggregation type: {agg_type}")` (21 call sites). A user who passed `median` to SQLite aggregation had no way to discover which types were accepted without reading the source.

- Added `mloda/community/feature_groups/data_operations/errors.py` with `unsupported_agg_type_error()` and `unsupported_frame_type_error()` helpers that produce deterministic messages including framework, operation, rejected value, and the alphabetically sorted supported set.
- Migrated every raise site across aggregation, scalar_aggregate, window_aggregation, and frame_aggregate for pandas, pyarrow, duckdb, sqlite, and polars_lazy — plus the test reference implementations.
- New messages look like: `Unsupported aggregation type for SQLite: 'median'. Supported types: avg, count, max, mean, min, sum.`

## Tests

Added 38 tests (`test_errors.py` + `test_unsupported_type_messages.py`):

- Unit tests for both helpers: sorting, deduplication, framework/operation formatting, `repr()` quoting (so empty-string and whitespace values stay visible), dict-keys and set inputs.
- End-to-end tests that every framework's `_compute_*` path actually raises *through* the helper — the contract is machine-checked per backend, so any future backend that bypasses the helper will be caught.

## Test plan

- [x] `PYTEST_WORKERS=1 tox` — 2493 passed, 115 skipped; ruff format, ruff check, mypy --strict, bandit all clean.
- [x] Verified the new error text on a live SQLite relation (`median` rejected with the sorted supported list).