### PR TITLE
refactor(duckdb): remove data._relation private attribute access (refs #74)

### DIFF
--- a/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
@@ -12,6 +12,7 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import q
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
+from mloda.community.feature_groups.data_operations.duckdb_helpers import group_aggregate
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 
@@ -72,6 +73,5 @@ class DuckdbAggregation(AggregationFeatureGroup):
 
         # Use lazy relation methods (aggregate + order) instead of eager query()
         # so DuckDB defers execution until the result is consumed.
-        rel = data._relation.aggregate(f"{partition_cols}, {agg_expr} AS {quoted_feature}", partition_cols)
-        rel = rel.order(partition_cols)
-        return DuckdbRelation(data.connection, rel)
+        rel = group_aggregate(data, f"{partition_cols}, {agg_expr} AS {quoted_feature}", partition_cols)
+        return rel.order(partition_cols)

--- a/mloda/community/feature_groups/data_operations/duckdb_helpers.py
+++ b/mloda/community/feature_groups/data_operations/duckdb_helpers.py
@@ -1,0 +1,42 @@
+"""DuckDB relation helpers that avoid touching ``DuckdbRelation._relation``.
+
+``DuckdbRelation`` (in ``mloda``) currently exposes only a subset of the
+underlying ``DuckDBPyRelation`` operations as public API. The data
+operation feature groups occasionally need ``aggregate()`` (GROUP BY on a
+lazy relation) and ``query()`` (run SQL against the relation bound to a
+table alias), neither of which has a public wrapper yet.
+
+Rather than reach into the private ``_relation`` attribute from every
+feature group, this module centralises that coupling in one place. When
+``mloda`` adds public equivalents these thin helpers can be replaced by
+direct calls without touching the feature group implementations.
+
+Security note: callers must ensure that *agg_expr*, *group_expr* and
+*sql* contain only trusted fragments (e.g. identifiers produced by
+``quote_ident`` and hardcoded SQL functions). No user input is inlined.
+"""
+
+from __future__ import annotations
+
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
+
+
+def group_aggregate(data: DuckdbRelation, agg_expr: str, group_expr: str) -> DuckdbRelation:
+    """Return a lazy relation computed as ``SELECT <agg_expr> GROUP BY <group_expr>``.
+
+    Thin wrapper around ``DuckDBPyRelation.aggregate`` that preserves
+    laziness (no temp views or eager SQL execution).
+    """
+    new_rel = data._relation.aggregate(agg_expr, group_expr)
+    return DuckdbRelation(data.connection, new_rel)
+
+
+def query_with_alias(data: DuckdbRelation, alias: str, sql: str) -> DuckdbRelation:
+    """Run *sql* against *data* exposed under *alias*, returning a new relation.
+
+    Thin wrapper around ``DuckDBPyRelation.query``. Used when a feature
+    group needs full SELECT syntax (e.g. window functions combined with
+    row-order tagging) that cannot be expressed via ``project`` alone.
+    """
+    new_rel = data._relation.query(alias, sql)
+    return DuckdbRelation(data.connection, new_rel)

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
@@ -92,7 +92,7 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
         # ORDER BY in the window frame reorders rows; tag with ROW_NUMBER(),
         # compute, then .order(qrn) to restore original order.
         # Step 1: tag rows with original position
-        rel = data._relation.project(f"*, ROW_NUMBER() OVER () AS {qrn}")  # nosec
+        rel = data.select(_raw_sql=f"*, ROW_NUMBER() OVER () AS {qrn}")  # nosec
 
         # Step 2: compute window function with frame
         raw_sql = (  # nosec
@@ -100,11 +100,9 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
             f"(PARTITION BY {partition_clause} ORDER BY {order_clause} {frame_clause}) "
             f"AS {quoted_feature}"
         )
-        rel = rel.project(raw_sql)
+        rel = rel.select(_raw_sql=raw_sql)
 
         # Step 3: restore original order, drop helper
         rel = rel.order(qrn)
         keep = ", ".join(quote_ident(c) for c in rel.columns if c != _RN_COL)
-        rel = rel.project(keep)
-
-        return DuckdbRelation(data.connection, rel)
+        return rel.select(_raw_sql=keep)

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/duckdb_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/duckdb_offset.py
@@ -7,6 +7,7 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framewor
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import query_with_alias
 from mloda.community.feature_groups.data_operations.row_preserving.offset.base import (
     OffsetFeatureGroup,
 )
@@ -60,11 +61,9 @@ class DuckdbOffset(OffsetFeatureGroup):
                 f"ROW_NUMBER() OVER () AS {qrn} "
                 f"FROM __t ORDER BY {qrn}"
             )
-            new_rel = data._relation.query("__t", sql)
-            result_rel = new_rel.project(
-                ", ".join(quote_ident(c) for c in [col for col in new_rel.columns if col != _RN_COL])
-            )
-            return DuckdbRelation(data.connection, result_rel)
+            new_rel = query_with_alias(data, "__t", sql)
+            keep = ", ".join(quote_ident(c) for c in new_rel.columns if c != _RN_COL)
+            return new_rel.select(_raw_sql=keep)
         elif offset_type == "first_value":
             offset_expr = f"FIRST_VALUE({quoted_source} IGNORE NULLS)"
             # PyArrow parity: the reference scans the entire partition for
@@ -89,8 +88,6 @@ class DuckdbOffset(OffsetFeatureGroup):
             f"ROW_NUMBER() OVER () AS {qrn} "
             f"FROM __t ORDER BY {qrn}"
         )
-        new_rel = data._relation.query("__t", sql)
-        result_rel = new_rel.project(
-            ", ".join(quote_ident(c) for c in [col for col in new_rel.columns if col != _RN_COL])
-        )
-        return DuckdbRelation(data.connection, result_rel)
+        new_rel = query_with_alias(data, "__t", sql)
+        keep = ", ".join(quote_ident(c) for c in new_rel.columns if c != _RN_COL)
+        return new_rel.select(_raw_sql=keep)

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
@@ -9,6 +9,7 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framewor
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import query_with_alias
 from mloda.community.feature_groups.data_operations.row_preserving.rank.base import (
     RankFeatureGroup,
 )
@@ -82,9 +83,7 @@ class DuckdbRank(RankFeatureGroup):
                 f"ROW_NUMBER() OVER () AS {qrn} "
                 f"FROM __t ORDER BY {qrn}"
             )
-        new_rel = data._relation.query("__t", sql)
+        new_rel = query_with_alias(data, "__t", sql)
         # Drop the helper column
-        result_rel = new_rel.project(
-            ", ".join(quote_ident(c) for c in [col for col in new_rel.columns if col != _RN_COL])
-        )
-        return DuckdbRelation(data.connection, result_rel)
+        keep = ", ".join(quote_ident(c) for c in new_rel.columns if c != _RN_COL)
+        return new_rel.select(_raw_sql=keep)

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
@@ -115,18 +115,18 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
         order_clause = f"ORDER BY {quote_ident(order_by)}" if order_by else ""
 
         # Step 1: tag rows with their original position
-        rel = data._relation.project(f"*, ROW_NUMBER() OVER () AS {qrn}")
+        rel = data.select(_raw_sql=f"*, ROW_NUMBER() OVER () AS {qrn}")
 
         # Step 2: compute with full frame and ORDER BY for deterministic results
-        rel = rel.project(
-            f"*, {agg_func}({source_sql} IGNORE NULLS) "
-            f"OVER (PARTITION BY {partition_clause} {order_clause} "
-            f"ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS {quoted_feature}"
+        rel = rel.select(
+            _raw_sql=(
+                f"*, {agg_func}({source_sql} IGNORE NULLS) "
+                f"OVER (PARTITION BY {partition_clause} {order_clause} "
+                f"ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS {quoted_feature}"
+            )
         )
 
         # Step 3: restore original row order, drop helper column
         rel = rel.order(qrn)
         keep = ", ".join(quote_ident(c) for c in rel.columns if c != _RN_COL)
-        rel = rel.project(keep)
-
-        return DuckdbRelation(data.connection, rel)
+        return rel.select(_raw_sql=keep)

--- a/mloda/community/feature_groups/data_operations/tests/test_duckdb_helpers.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_duckdb_helpers.py
@@ -1,0 +1,80 @@
+"""Tests for the DuckDB relation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb")
+pytest.importorskip("pyarrow")
+
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
+
+from mloda.community.feature_groups.data_operations.duckdb_helpers import (
+    group_aggregate,
+    query_with_alias,
+)
+
+
+@pytest.fixture()
+def sample_relation() -> DuckdbRelation:
+    """Small relation with a repeating key column for group-by tests."""
+    conn = duckdb.connect(":memory:")
+    rel = DuckdbRelation.from_dict(
+        conn,
+        {
+            "key": ["a", "a", "b", "b", "b"],
+            "value": [1, 2, 3, 4, 5],
+        },
+    )
+    return rel
+
+
+class TestGroupAggregate:
+    def test_returns_duckdb_relation(self, sample_relation: DuckdbRelation) -> None:
+        """group_aggregate must return a DuckdbRelation, not a raw DuckDBPyRelation."""
+        result = group_aggregate(sample_relation, '"key", SUM("value") AS total', '"key"')
+        assert isinstance(result, DuckdbRelation)
+
+    def test_reuses_same_connection(self, sample_relation: DuckdbRelation) -> None:
+        """The helper must not open a new connection."""
+        result = group_aggregate(sample_relation, '"key", SUM("value") AS total', '"key"')
+        assert result.connection is sample_relation.connection
+
+    def test_group_by_sums_values(self, sample_relation: DuckdbRelation) -> None:
+        """A SUM group-by returns one row per key with the correct total."""
+        result = group_aggregate(sample_relation, '"key", SUM("value") AS total', '"key"')
+        arrow = result.order('"key"').to_arrow_table()
+        data = arrow.to_pydict()
+        assert data["key"] == ["a", "b"]
+        assert data["total"] == [3, 12]
+
+    def test_does_not_mutate_source(self, sample_relation: DuckdbRelation) -> None:
+        """Aggregating must not change the columns of the source relation."""
+        group_aggregate(sample_relation, '"key", COUNT(*) AS n', '"key"')
+        assert sample_relation.columns == ["key", "value"]
+
+
+class TestQueryWithAlias:
+    def test_returns_duckdb_relation(self, sample_relation: DuckdbRelation) -> None:
+        """query_with_alias must return a DuckdbRelation."""
+        result = query_with_alias(sample_relation, "__t", 'SELECT * FROM __t WHERE "value" > 2')
+        assert isinstance(result, DuckdbRelation)
+
+    def test_reuses_same_connection(self, sample_relation: DuckdbRelation) -> None:
+        result = query_with_alias(sample_relation, "__t", "SELECT * FROM __t")
+        assert result.connection is sample_relation.connection
+
+    def test_select_filters_rows(self, sample_relation: DuckdbRelation) -> None:
+        """Arbitrary SELECT against the alias works end to end."""
+        result = query_with_alias(sample_relation, "__t", 'SELECT * FROM __t WHERE "value" > 2')
+        arrow = result.order('"value"').to_arrow_table()
+        data = arrow.to_pydict()
+        assert data["value"] == [3, 4, 5]
+
+    def test_window_function(self, sample_relation: DuckdbRelation) -> None:
+        """The helper is specifically useful for window queries that project() cannot express directly."""
+        sql = 'SELECT *, ROW_NUMBER() OVER (PARTITION BY "key" ORDER BY "value") AS rn FROM __t'
+        result = query_with_alias(sample_relation, "__t", sql)
+        arrow = result.order('"key"', '"value"').to_arrow_table()
+        data = arrow.to_pydict()
+        assert data["rn"] == [1, 2, 1, 2, 3]


### PR DESCRIPTION
## Summary

Addresses task **#11** in the data_operations audit (issue #74): the five DuckDB feature group implementations (`aggregation`, `frame_aggregate`, `offset`, `rank`, `window_aggregation`) were reaching into the private `DuckdbRelation._relation` attribute to call `.aggregate()`, `.query()`, and `.project()` on the underlying `DuckDBPyRelation`.

- `.project(raw_sql)` is replaced by the existing public `data.select(_raw_sql=...)` (already used by `duckdb_scalar_aggregate`).
- `.aggregate()` and `.query()` have no public equivalent on `DuckdbRelation` yet, so a new tiny helper module `mloda/community/feature_groups/data_operations/duckdb_helpers.py` wraps them behind `group_aggregate()` and `query_with_alias()`. The private-API coupling is now confined to this single module and clearly documented; when upstream mloda exposes public equivalents the helpers can be removed without touching any feature group.
- Added unit tests for both helpers covering return type, connection reuse, correctness, and immutability of the source relation.

## Test plan

- [x] `PYTEST_WORKERS=1 tox` passes locally (pytest, ruff format, ruff check, mypy --strict, bandit) &mdash; 2563 passed, 119 skipped
- [x] New `tests/test_duckdb_helpers.py` covers both helpers
- [x] All existing DuckDB data_operations tests still pass
- [x] `grep _relation` confirms the only remaining references are inside `duckdb_helpers.py`