### PR TITLE
chore(deps): bump pytest to >=9.0.3 (GHSA-6w46-j5rx-g56g)

### DIFF
--- a/config/packages.toml
+++ b/config/packages.toml
@@ -8,9 +8,9 @@ path = "mloda/registry"
 
 [packages.mloda-testing]
 description = "Test utilities for mloda plugin development"
-dependencies = ["mloda>=0.6.1", "pytest"]
+dependencies = ["mloda>=0.6.1", "pytest>=9.0.3"]
 path = "mloda/testing"
-optional_dependencies = { dev = ["pytest"] }
+optional_dependencies = { dev = ["pytest>=9.0.3"] }
 
 [packages.mloda-community]
 description = "All community plugins for mloda"

--- a/config/shared.toml
+++ b/config/shared.toml
@@ -16,4 +16,4 @@ build-backend = "setuptools.build_meta"
 
 [defaults]
 license = "Apache-2.0"
-optional_dependencies = { dev = ["mloda-testing", "pytest"] }
+optional_dependencies = { dev = ["mloda-testing", "pytest>=9.0.3"] }

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda>=0.6.1"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda>=0.6.1"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 pyarrow = ["pyarrow"]
 sqlite = []
 duckdb = ["duckdb"]

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda>=0.6.1"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 all = ["mloda-community-window-aggregation", "mloda-community-aggregation", "mloda-community-rank", "mloda-community-offset", "mloda-community-frame-aggregate", "mloda-community-scalar-aggregate", "mloda-community-datetime", "mloda-community-string", "mloda-community-binning", "mloda-community-percentile"]
 
 [project.urls]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 pyarrow = ["pyarrow"]
 sqlite = []
 duckdb = ["duckdb"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 sqlite = []
 duckdb = ["duckdb"]
 polars = ["polars"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 sqlite = []
 duckdb = ["duckdb"]
 polars = ["polars"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 duckdb = ["duckdb"]
 polars = ["polars"]
 pandas = ["pandas"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 sqlite = []
 duckdb = ["duckdb"]
 polars = ["polars"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 pyarrow = ["pyarrow"]
 sqlite = []
 duckdb = ["duckdb"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 pyarrow = ["pyarrow"]
 sqlite = []
 duckdb = ["duckdb"]

--- a/mloda/community/feature_groups/data_operations/string/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/string/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-data-operations>=0.2.12"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/community/feature_groups/example/example_a/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_a/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-example>=0.2.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/community/feature_groups/example/example_b/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda-community-example>=0.2.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda>=0.6.1"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 all = ["mloda-community-example-a", "mloda-community-example-b"]
 
 [project.urls]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda>=0.6.1"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda>=0.6.1"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda>=0.6.1"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["mloda>=0.6.1"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["mloda-testing", "pytest"]
+dev = ["mloda-testing", "pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/testing/pyproject.toml
+++ b/mloda/testing/pyproject.toml
@@ -11,11 +11,11 @@ version = "0.2.12"
 description = "Test utilities for mloda plugin development"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1", "pytest"]
+dependencies = ["mloda>=0.6.1", "pytest>=9.0.3"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest>=9.0.3"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-04T14:08:35.796301048Z"
+exclude-newer = "2026-04-08T09:45:31.048441485Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -308,7 +308,7 @@ requires-dist = [
     { name = "polars", marker = "extra == 'polars'" },
     { name = "pyarrow", marker = "extra == 'all'" },
     { name = "pyarrow", marker = "extra == 'pyarrow'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "all"]
 
@@ -358,7 +358,7 @@ requires-dist = [
     { name = "polars", marker = "extra == 'polars'" },
     { name = "pyarrow", marker = "extra == 'all'" },
     { name = "pyarrow", marker = "extra == 'pyarrow'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "all"]
 
@@ -380,7 +380,7 @@ dev = [
 requires-dist = [
     { name = "mloda", specifier = ">=0.6.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -424,7 +424,7 @@ requires-dist = [
     { name = "mloda-community-string", marker = "extra == 'all'" },
     { name = "mloda-community-window-aggregation", marker = "extra == 'all'" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "all"]
 
@@ -446,7 +446,7 @@ dev = [
 requires-dist = [
     { name = "mloda-community-data-operations", specifier = ">=0.2.12" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -474,7 +474,7 @@ requires-dist = [
     { name = "mloda-community-example-a", marker = "extra == 'all'" },
     { name = "mloda-community-example-b", marker = "extra == 'all'" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "all"]
 
@@ -496,7 +496,7 @@ dev = [
 requires-dist = [
     { name = "mloda-community-example", specifier = ">=0.2.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -518,7 +518,7 @@ dev = [
 requires-dist = [
     { name = "mloda-community-example", specifier = ">=0.2.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -540,7 +540,7 @@ dev = [
 requires-dist = [
     { name = "mloda", specifier = ">=0.6.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -584,7 +584,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'pandas'" },
     { name = "polars", marker = "extra == 'all'" },
     { name = "polars", marker = "extra == 'polars'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
@@ -628,7 +628,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'pandas'" },
     { name = "polars", marker = "extra == 'all'" },
     { name = "polars", marker = "extra == 'polars'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
@@ -672,7 +672,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'pandas'" },
     { name = "polars", marker = "extra == 'all'" },
     { name = "polars", marker = "extra == 'polars'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "duckdb", "polars", "pandas", "all"]
 
@@ -716,7 +716,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'pandas'" },
     { name = "polars", marker = "extra == 'all'" },
     { name = "polars", marker = "extra == 'polars'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "polars", marker = "extra == 'polars'" },
     { name = "pyarrow", marker = "extra == 'all'" },
     { name = "pyarrow", marker = "extra == 'pyarrow'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "all"]
 
@@ -788,7 +788,7 @@ dev = [
 requires-dist = [
     { name = "mloda-community-data-operations", specifier = ">=0.2.12" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -838,7 +838,7 @@ requires-dist = [
     { name = "polars", marker = "extra == 'polars'" },
     { name = "pyarrow", marker = "extra == 'all'" },
     { name = "pyarrow", marker = "extra == 'pyarrow'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "all"]
 
@@ -871,7 +871,7 @@ dev = [
 requires-dist = [
     { name = "mloda", specifier = ">=0.6.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -893,7 +893,7 @@ dev = [
 requires-dist = [
     { name = "mloda", specifier = ">=0.6.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -915,7 +915,7 @@ dev = [
 requires-dist = [
     { name = "mloda", specifier = ">=0.6.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -937,7 +937,7 @@ dev = [
 requires-dist = [
     { name = "mloda", specifier = ">=0.6.1" },
     { name = "mloda-testing", marker = "extra == 'dev'", editable = "mloda/testing" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -1003,8 +1003,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mloda", specifier = ">=0.6.1" },
-    { name = "pytest" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
 
@@ -1420,7 +1420,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1431,9 +1431,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert [#4](https://github.com/mloda-ai/mloda-registry/security/dependabot/4) / [CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176) / [GHSA-6w46-j5rx-g56g](https://github.com/advisories/GHSA-6w46-j5rx-g56g): pytest <9.0.3 uses predictable `/tmp/pytest-of-{user}` directories on UNIX, allowing local users to cause DoS or possibly gain privileges (CWE-379, CVSS 6.8 medium).
- Pins `pytest>=9.0.3` in `config/shared.toml` and `config/packages.toml` so future `uv lock` runs cannot regress below the patched version.
- Regenerates all 23 `pyproject.toml` files via `scripts/generate_pyproject.py` and refreshes `uv.lock` (pytest 9.0.2 → 9.0.3).

## Test plan
- [x] `PYTEST_WORKERS=1 uv run tox -r` green on freshly rebuilt env: 2602 passed, 119 skipped, pytest-9.0.3 confirmed in the session banner
- [x] `ruff format --check`, `ruff check`, `mypy --strict`, `bandit` all pass
- [ ] Verify GitHub Actions CI is green
- [ ] Confirm Dependabot alert #4 auto-closes after merge