### PR TITLE
chore(release): add 11 community data-operations packages to release set

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,9 +105,18 @@ jobs:
 
       - name: Build packages
         run: |
-          # Build bundle packages + example packages for regression testing
-          # Using --wheel --no-build-isolation because the monorepo layout
-          # requires access to parent directories during build
+          # Released set: 4 bundles + 11 community data-operations packages +
+          # 2 examples kept for end-to-end PyPI dependency-resolution coverage
+          # (mloda-community-example, mloda-community-example-a).
+          #
+          # Other example/demo packages declared in config/packages.toml are
+          # intentionally NOT published standalone; their code ships inside
+          # the mloda-community / mloda-enterprise bundle wheels. See the
+          # header comment in config/packages.toml for the full policy and
+          # the checklist for adding a new released package.
+          #
+          # `--wheel --no-build-isolation` is required by the monorepo layout
+          # (build needs access to parent directories).
           packages=(
             "mloda-registry"
             "mloda-testing"
@@ -115,6 +124,17 @@ jobs:
             "mloda-enterprise"
             "mloda-community-example"
             "mloda-community-example-a"
+            "mloda-community-data-operations"
+            "mloda-community-aggregation"
+            "mloda-community-rank"
+            "mloda-community-offset"
+            "mloda-community-window-aggregation"
+            "mloda-community-frame-aggregate"
+            "mloda-community-scalar-aggregate"
+            "mloda-community-datetime"
+            "mloda-community-string"
+            "mloda-community-binning"
+            "mloda-community-percentile"
           )
 
           mkdir -p dist

--- a/config/packages.toml
+++ b/config/packages.toml
@@ -1,5 +1,69 @@
-# Package-specific configuration for mloda-registry packages
-# Edit this file and run: python scripts/generate_pyproject.py
+# Package-specific configuration for mloda-registry packages.
+#
+# This file is the canonical declaration of every package that exists in this
+# repository. `scripts/generate_pyproject.py` reads it to (re)generate per-
+# package `pyproject.toml` files and the `[tool.uv.workspace]` member list in
+# the root `pyproject.toml`.
+#
+# Edit this file, then run: python scripts/generate_pyproject.py
+#
+# -----------------------------------------------------------------------------
+# Released vs bundle-only packages
+# -----------------------------------------------------------------------------
+# Not every package declared here is published as a standalone PyPI artifact.
+# The release pipeline (`.github/workflows/release.yaml`) carries a hardcoded
+# subset, and so do the post-release verify recipes in `tox.ini` and the local
+# build-sanity check in `scripts/verify_builds.py`. Until the single-source-of-
+# truth refactor lands, you must hand-edit each of those when adding a new
+# *production* (released) package. See the checklist below.
+#
+# Released as standalone PyPI artifacts (17 packages):
+#   - 4 bundles: mloda-registry, mloda-testing, mloda-community, mloda-enterprise
+#   - 11 community data-operations: mloda-community-data-operations and the 10
+#     leaves (aggregation, rank, offset, window-aggregation, frame-aggregate,
+#     scalar-aggregate, datetime, string, binning, percentile)
+#   - 2 examples kept released to exercise the cross-package dependency
+#     mechanism on real PyPI installs: mloda-community-example and
+#     mloda-community-example-a
+#
+# Bundle-only, NOT released standalone (6 packages):
+#   - mloda-community-example-b
+#   - mloda-enterprise-example
+#   - mloda-community-compute-frameworks-example
+#   - mloda-community-extenders-example
+#   - mloda-enterprise-compute-frameworks-example
+#   - mloda-enterprise-extenders-example
+# These are demo / test-scaffold packages. Their code reaches users only as
+# part of the `mloda-community` and `mloda-enterprise` bundle wheels, never as
+# standalone `pip install <name>` artifacts. Do not add them to release.yaml.
+#
+# -----------------------------------------------------------------------------
+# Checklist when adding a new *production* (released) package
+# -----------------------------------------------------------------------------
+# 1. Add a `[packages.<name>]` section in this file.
+# 2. Run `python scripts/generate_pyproject.py`.
+# 3. Add the package name to:
+#      - `.github/workflows/release.yaml` (build/upload bash array, ~line 111)
+#      - `tox.ini` `[testenv:verify-published]` install line (~line 91) and
+#        add a corresponding `python -c "import ..."` smoke-test line.
+#      - `tox.ini` `[testenv:security]` uninstall + install lines (~164-165)
+#      - `scripts/verify_builds.py` `PACKAGES` list (~line 18)
+# Example-only packages (listed above) skip step 3.
+#
+# -----------------------------------------------------------------------------
+# Pending cleanup (tracked, not addressed here)
+# -----------------------------------------------------------------------------
+# - `tox.ini [testenv:verify-published-independent]` only isolates the 4
+#   bundles; the 11 data-ops leaves should also be tested standalone.
+# - `tox.ini [testenv:verify-extras]` only smoke-tests
+#   `mloda-community-example[all]`; data-ops packages declare `[pyarrow]`,
+#   `[polars]`, `[pandas]`, `[duckdb]`, `[all]` extras (and
+#   `mloda-community-data-operations[all]` is structurally analogous) but none
+#   are exercised post-release.
+# - `memory-bank/release-pypi.md` still describes the legacy 6-package release.
+# - The duplicated package lists above should ultimately derive from this file
+#   via a `scripts/list_packages.py` helper so adding a package here cascades
+#   automatically and this drift class is eliminated.
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"

--- a/config/packages.toml
+++ b/config/packages.toml
@@ -1,69 +1,12 @@
-# Package-specific configuration for mloda-registry packages.
+# Package-specific configuration for mloda-registry packages
+# Edit this file and run: python scripts/generate_pyproject.py
 #
-# This file is the canonical declaration of every package that exists in this
-# repository. `scripts/generate_pyproject.py` reads it to (re)generate per-
-# package `pyproject.toml` files and the `[tool.uv.workspace]` member list in
-# the root `pyproject.toml`.
-#
-# Edit this file, then run: python scripts/generate_pyproject.py
-#
-# -----------------------------------------------------------------------------
-# Released vs bundle-only packages
-# -----------------------------------------------------------------------------
-# Not every package declared here is published as a standalone PyPI artifact.
-# The release pipeline (`.github/workflows/release.yaml`) carries a hardcoded
-# subset, and so do the post-release verify recipes in `tox.ini` and the local
-# build-sanity check in `scripts/verify_builds.py`. Until the single-source-of-
-# truth refactor lands, you must hand-edit each of those when adding a new
-# *production* (released) package. See the checklist below.
-#
-# Released as standalone PyPI artifacts (17 packages):
-#   - 4 bundles: mloda-registry, mloda-testing, mloda-community, mloda-enterprise
-#   - 11 community data-operations: mloda-community-data-operations and the 10
-#     leaves (aggregation, rank, offset, window-aggregation, frame-aggregate,
-#     scalar-aggregate, datetime, string, binning, percentile)
-#   - 2 examples kept released to exercise the cross-package dependency
-#     mechanism on real PyPI installs: mloda-community-example and
-#     mloda-community-example-a
-#
-# Bundle-only, NOT released standalone (6 packages):
-#   - mloda-community-example-b
-#   - mloda-enterprise-example
-#   - mloda-community-compute-frameworks-example
-#   - mloda-community-extenders-example
-#   - mloda-enterprise-compute-frameworks-example
-#   - mloda-enterprise-extenders-example
-# These are demo / test-scaffold packages. Their code reaches users only as
-# part of the `mloda-community` and `mloda-enterprise` bundle wheels, never as
-# standalone `pip install <name>` artifacts. Do not add them to release.yaml.
-#
-# -----------------------------------------------------------------------------
-# Checklist when adding a new *production* (released) package
-# -----------------------------------------------------------------------------
-# 1. Add a `[packages.<name>]` section in this file.
-# 2. Run `python scripts/generate_pyproject.py`.
-# 3. Add the package name to:
-#      - `.github/workflows/release.yaml` (build/upload bash array, ~line 111)
-#      - `tox.ini` `[testenv:verify-published]` install line (~line 91) and
-#        add a corresponding `python -c "import ..."` smoke-test line.
-#      - `tox.ini` `[testenv:security]` uninstall + install lines (~164-165)
-#      - `scripts/verify_builds.py` `PACKAGES` list (~line 18)
-# Example-only packages (listed above) skip step 3.
-#
-# -----------------------------------------------------------------------------
-# Pending cleanup (tracked, not addressed here)
-# -----------------------------------------------------------------------------
-# - `tox.ini [testenv:verify-published-independent]` only isolates the 4
-#   bundles; the 11 data-ops leaves should also be tested standalone.
-# - `tox.ini [testenv:verify-extras]` only smoke-tests
-#   `mloda-community-example[all]`; data-ops packages declare `[pyarrow]`,
-#   `[polars]`, `[pandas]`, `[duckdb]`, `[all]` extras (and
-#   `mloda-community-data-operations[all]` is structurally analogous) but none
-#   are exercised post-release.
-# - `memory-bank/release-pypi.md` still describes the legacy 6-package release.
-# - The duplicated package lists above should ultimately derive from this file
-#   via a `scripts/list_packages.py` helper so adding a package here cascades
-#   automatically and this drift class is eliminated.
+# Some packages declared here are example/demo only and intentionally NOT
+# released as standalone PyPI artifacts; they reach users via the
+# mloda-community / mloda-enterprise bundle wheels. Do not add them to the
+# build/upload list in .github/workflows/release.yaml:
+#   mloda-community-example-b, mloda-enterprise-example,
+#   mloda-{community,enterprise}-{compute-frameworks,extenders}-example
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"

--- a/scripts/verify_builds.py
+++ b/scripts/verify_builds.py
@@ -28,13 +28,28 @@ PACKAGES = [
     ("mloda-community-aggregation", "mloda/community/feature_groups/data_operations/aggregation/pyproject.toml"),
     ("mloda-community-rank", "mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml"),
     ("mloda-community-offset", "mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml"),
-    ("mloda-community-window-aggregation", "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml"),
-    ("mloda-community-frame-aggregate", "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml"),
-    ("mloda-community-scalar-aggregate", "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml"),
-    ("mloda-community-datetime", "mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml"),
+    (
+        "mloda-community-window-aggregation",
+        "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml",
+    ),
+    (
+        "mloda-community-frame-aggregate",
+        "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml",
+    ),
+    (
+        "mloda-community-scalar-aggregate",
+        "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml",
+    ),
+    (
+        "mloda-community-datetime",
+        "mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml",
+    ),
     ("mloda-community-string", "mloda/community/feature_groups/data_operations/string/pyproject.toml"),
     ("mloda-community-binning", "mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml"),
-    ("mloda-community-percentile", "mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml"),
+    (
+        "mloda-community-percentile",
+        "mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml",
+    ),
 ]
 
 

--- a/scripts/verify_builds.py
+++ b/scripts/verify_builds.py
@@ -24,6 +24,17 @@ PACKAGES = [
     ("mloda-enterprise-example", "mloda/enterprise/feature_groups/example/pyproject.toml"),
     ("mloda-community-example-a", "mloda/community/feature_groups/example/example_a/pyproject.toml"),
     ("mloda-community-example-b", "mloda/community/feature_groups/example/example_b/pyproject.toml"),
+    ("mloda-community-data-operations", "mloda/community/feature_groups/data_operations/pyproject.toml"),
+    ("mloda-community-aggregation", "mloda/community/feature_groups/data_operations/aggregation/pyproject.toml"),
+    ("mloda-community-rank", "mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml"),
+    ("mloda-community-offset", "mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml"),
+    ("mloda-community-window-aggregation", "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml"),
+    ("mloda-community-frame-aggregate", "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml"),
+    ("mloda-community-scalar-aggregate", "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml"),
+    ("mloda-community-datetime", "mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml"),
+    ("mloda-community-string", "mloda/community/feature_groups/data_operations/string/pyproject.toml"),
+    ("mloda-community-binning", "mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml"),
+    ("mloda-community-percentile", "mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml"),
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ allowlist_externals = sh, uv, rm
 commands =
     sh -c 'uv cache clean'
     sh -c 'rm -rf /tmp/mloda-verify && uv venv /tmp/mloda-verify'
-    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify uv pip install mloda-registry=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-testing=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-enterprise=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-example=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-example-a=={env:MLODA_REGISTRY_VERSION:0.3.0}'
+    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify uv pip install mloda-registry=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-testing=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-enterprise=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-example=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-example-a=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-data-operations=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-aggregation=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-rank=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-offset=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-window-aggregation=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-frame-aggregate=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-scalar-aggregate=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-datetime=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-string=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-binning=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-percentile=={env:MLODA_REGISTRY_VERSION:0.3.0}'
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.registry import discover, search; print(\"mloda.registry OK\")"'
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.testing import FeatureGroupTestBase; print(\"mloda.testing OK\")"'
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.community.feature_groups.example import CommunityExampleFeatureGroup; print(\"mloda.community.example OK\")"'
@@ -98,6 +98,17 @@ commands =
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.community.extenders.example import CommunityExampleExtender; print(\"mloda.community.extenders.example OK\")"'
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.enterprise.compute_frameworks.example import EnterpriseExampleComputeFramework; print(\"mloda.enterprise.compute_frameworks.example OK\")"'
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.enterprise.extenders.example import EnterpriseExampleExtender; print(\"mloda.enterprise.extenders.example OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations; print(\"mloda.community.data_operations OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.aggregation; print(\"mloda.community.aggregation OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.rank; print(\"mloda.community.rank OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.offset; print(\"mloda.community.offset OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.window_aggregation; print(\"mloda.community.window_aggregation OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate; print(\"mloda.community.frame_aggregate OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate; print(\"mloda.community.scalar_aggregate OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.datetime; print(\"mloda.community.datetime OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.string; print(\"mloda.community.string OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.binning; print(\"mloda.community.binning OK\")"'
+    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.percentile; print(\"mloda.community.percentile OK\")"'
     sh -c 'echo "=== All packages verified ==="'
 
 [testenv:verify-extras]
@@ -150,8 +161,8 @@ deps =
 allowlist_externals = sh, mkdir, uv
 commands =
     mkdir -p security-reports
-    sh -c "uv pip uninstall mloda-registry mloda-testing mloda-community mloda-enterprise mloda-community-example mloda-community-example-a 2>/dev/null || true"
-    uv pip install mloda-registry=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-testing=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-enterprise=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-example=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-example-a=={env:MLODA_REGISTRY_VERSION:0.3.0}
+    sh -c "uv pip uninstall mloda-registry mloda-testing mloda-community mloda-enterprise mloda-community-example mloda-community-example-a mloda-community-data-operations mloda-community-aggregation mloda-community-rank mloda-community-offset mloda-community-window-aggregation mloda-community-frame-aggregate mloda-community-scalar-aggregate mloda-community-datetime mloda-community-string mloda-community-binning mloda-community-percentile 2>/dev/null || true"
+    uv pip install mloda-registry=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-testing=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-enterprise=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-example=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-example-a=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-data-operations=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-aggregation=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-rank=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-offset=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-window-aggregation=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-frame-aggregate=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-scalar-aggregate=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-datetime=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-string=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-binning=={env:MLODA_REGISTRY_VERSION:0.3.0} mloda-community-percentile=={env:MLODA_REGISTRY_VERSION:0.3.0}
     sh -c "pip-audit --desc --format=json --output=security-reports/pip-audit.json || pip-audit --desc"
     sh -c "echo '=== CVE Scan Complete ==='"
     sh -c "echo 'Report: security-reports/pip-audit.json'"


### PR DESCRIPTION
## Summary

- The 0.3.0 release silently shipped 6 of 23 declared packages because the publish list is hardcoded in `release.yaml` instead of being derived from `config/packages.toml`. Users cannot `pip install mloda-community-aggregation` (etc.) from PyPI today.
- This PR adds the 11 community data-operations packages (`mloda-community-data-operations` + the 10 leaves: aggregation, rank, offset, window-aggregation, frame-aggregate, scalar-aggregate, datetime, string, binning, percentile) to the release pipeline and to every place `tox.ini` / `verify_builds.py` mirrors the same list. 0.3.1 will publish 17 packages.
- Documents the released-vs-bundle-only policy as a header comment in `config/packages.toml` so the omission cannot recur silently. The 6 example/demo packages (`mloda-community-example-b`, `mloda-enterprise-example`, and the four compute-frameworks/extenders examples) remain intentionally unpublished standalone; their code ships inside the `mloda-community` / `mloda-enterprise` bundle wheels.

## Files changed

- `.github/workflows/release.yaml` — bash array extended 6 → 17; build-step comment rewritten to name the policy and point at `config/packages.toml`.
- `tox.ini` — `[testenv:verify-published]` install line + 11 import smoke-tests; `[testenv:security]` uninstall + pip-audit install.
- `scripts/verify_builds.py` — `PACKAGES` extended 8 → 19 (also covers `mloda-community-example-b` and `mloda-enterprise-example` for build sanity).
- `config/packages.toml` — header comment block: which 17 are released, which 6 are bundle-only, the manual-edit checklist for adding a new released package, and pending cleanup notes.

## Out of scope (documented in the new header)

Tracked but not addressed here:

- `tox.ini [testenv:verify-published-independent]` still isolates only the 4 bundles; data-ops leaves not exercised standalone.
- `tox.ini [testenv:verify-extras]` only covers `mloda-community-example[all]`; data-ops `[pyarrow]`/`[polars]`/`[pandas]`/`[duckdb]`/`[all]` extras (and `mloda-community-data-operations[all]`) untested.
- `memory-bank/release-pypi.md` describes the legacy 6-package release.
- The single-source-of-truth refactor (derive every list from `config/packages.toml` via a helper) is the durable fix; deferred.

## Test plan

- [ ] CI green (`ci.yaml`, `package-integrity.yaml`).
- [ ] `tox -e verify-builds` passes locally with all 19 PACKAGES building.
- [ ] After merge, trigger the Release workflow on `main`; publish job log shows 17 wheels uploaded (was 6 in 0.3.0).
- [ ] PyPI shows 0.3.1 as latest for spot-checks: `mloda-community-aggregation`, `mloda-community-data-operations`, `mloda-community-percentile`.
- [ ] `MLODA_REGISTRY_VERSION=0.3.1 tox -e verify-published` installs and imports all 17.
- [ ] `MLODA_REGISTRY_VERSION=0.3.1 tox -e security` (pip-audit) completes.
- [ ] Fresh venv: `pip install mloda-community-aggregation==0.3.1` then `python -c "import mloda.community.feature_groups.data_operations.aggregation"` succeeds.