### PR TITLE
chore: align contributor onboarding with mloda core

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,48 @@
+name: Issue
+description: Report a bug, request a feature, or propose a small task.
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-sentence description of the bug, request, or task.
+      placeholder: e.g. "PandasGroupByAggregation raises KeyError when aggregating an empty DataFrame."
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Reproduction or motivation
+      description: |
+        For bugs: minimal reproduction steps, then expected vs. actual behavior.
+        For features and tasks: motivation, current workaround if any, and desired behavior.
+      placeholder: |
+        Steps to reproduce:
+        1.
+        2.
+
+        Expected:
+        Actual:
+    validations:
+      required: true
+  - type: textarea
+    id: pointers
+    attributes:
+      label: Code pointers (optional)
+      description: Files and line numbers where the work happens or where the bug originates. Helps newcomers find their starting point quickly.
+      placeholder: e.g. mloda/community/feature_groups/data_operations/aggregation/groupby/pandas_groupby.py:42
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of done (optional)
+      description: What counts as complete. Behavior, tests, docs.
+      placeholder: |
+        - [ ] Function returns X for input Y
+        - [ ] Test added in tests/...
+        - [ ] tox passes
+  - type: input
+    id: environment
+    attributes:
+      label: Environment (optional, bugs only)
+      description: Python version, OS, mloda-registry version.
+      placeholder: Python 3.12, Linux, mloda-registry 0.3.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+See [CLAUDE.md](./CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,29 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - No agent should add `Co-Authored-By` lines or any other commit authorship attribution.
 
+## Project Practices
+
+`tox` is the gate. It runs `pytest -n {env:PYTEST_WORKERS:2}` (default 2 workers, no timeout), then `ruff format --check --line-length 120 .`, `ruff check .`, `mypy --strict --ignore-missing-imports .`, and `bandit -c pyproject.toml -r -q .`. All of these must pass before a PR is mergeable.
+
+- **Python**: supported range is `>=3.10,<3.14`; tox envs cover `python310`, `python311`, `python312`, `python313`.
+- **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007` (extend-selected in `pyproject.toml`).
+- **Formatting**: ruff format with line length 120.
+- **Tests**: parallel-safe (pytest-xdist). Per-package envs are available for isolated runs: `tox -e testing`, `tox -e community-example`, `tox -e registry`, `tox -e enterprise-example`.
+- **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
+- **Auto-generated `pyproject.toml`**: edit `config/shared.toml` (version, authors, urls) or `config/packages.toml` (per-package), then run `python scripts/generate_pyproject.py`. Never edit `pyproject.toml` files directly. See `memory-bank/pyproject-generation.md`.
+- **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`fix:`, `feat:`, `chore:`, `docs:`, `test:`, `refactor:`, `minor:`, `perf:`, `impr:`, `ci:`, `style:`, `build:`). semantic-release computes the next version. This project deviates from the standard: only `minor:` commits bump the minor version; `feat:` is treated as a patch bump along with everything else (see `.releaserc.yaml`).
+
+## Issue Creation
+
+When filing a GitHub issue (via `gh issue create` or otherwise), follow the structure in `.github/ISSUE_TEMPLATE/issue.yml`:
+
+- Summary in one sentence
+- Reproduction (for bugs) or motivation (for features)
+- Code pointers if relevant (`file:line`)
+- Definition of done if scoped (what counts as complete)
+
+Issues that meet this bar are eligible for the `good first issue` label without further sharpening.
+
 ## Virtual Environment Setup
 
 If not in a devcontainer, set up the environment:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+We want mloda to be a project where anyone can contribute, ask questions, or share ideas without worrying about how they will be treated.
+
+## Expected behavior
+
+- Be respectful and constructive in discussions, reviews, and issues.
+- Assume good intent. Ask for clarification before assuming bad intent.
+- Welcome newcomers. Everyone was new once.
+- Give and receive feedback graciously.
+- Focus on what is best for the project and the community.
+
+## Unacceptable behavior
+
+- Harassment, discrimination, or personal attacks of any kind.
+- Trolling, insulting comments, or sustained disruption of discussion.
+- Publishing someone's private information without their explicit permission.
+- Sexualized language or imagery, or unwelcome sexual attention.
+- Any behavior that a reasonable person would consider inappropriate in a professional setting.
+
+## Scope
+
+This applies in all project spaces (GitHub issues, pull requests, discussions, code review) and when representing the project in public.
+
+## Enforcement
+
+If you experience or witness behavior that violates this code, report it to **conduct@mloda.ai**. Reports are reviewed confidentially. Maintainers may warn, temporarily ban, or permanently remove anyone whose behavior is judged to violate this code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+# Contributing to mloda-registry
+
+The `mloda-registry` repo is the home for community and enterprise plugin packages and the [40+ plugin development guides](docs/guides/index.md). Whether you are fixing bugs in registry tooling, improving the guides, or adding a new community plugin, your input is welcome.
+
+By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10 or higher (tested on 3.10, 3.11, 3.12, 3.13)
+- [uv](https://docs.astral.sh/uv/) for dependency management
+- [tox](https://tox.wiki/) as the test runner (installed via uv)
+
+### Local Development Setup
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/mloda-ai/mloda-registry.git
+cd mloda-registry
+```
+
+2. Install uv (if not already installed):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+3. Create a virtual environment and install dependencies:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv sync --all-extras
+```
+
+4. Verify your setup by running the full check suite:
+
+```bash
+uv run tox
+```
+
+## Code Style
+
+All code must pass the automated checks enforced by tox. The toolchain includes:
+
+- **ruff format** for code formatting (line length: 120 characters)
+- **ruff check** for linting (modern type-hint enforcement via `UP006`/`UP007`)
+- **mypy --strict --ignore-missing-imports** for static type checking
+- **bandit** for security scanning
+
+### Conventions
+
+- No code in `__init__.py` files.
+- Avoid `try/except` blocks unless absolutely necessary.
+- Keep documentation to the necessary minimum.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages (`fix:`, `feat:`, `chore:`, `docs:`, etc.). This project deviates from the standard: only `minor:` commits bump the minor version; `feat:` is treated as a patch bump along with everything else (see `.releaserc.yaml`).
+- **Never edit `pyproject.toml` files directly.** They are auto-generated from `config/shared.toml` and `config/packages.toml` via `python scripts/generate_pyproject.py`. Edit the config files and regenerate. See `memory-bank/pyproject-generation.md` for details.
+
+### Running Checks Locally
+
+Run the full suite (linting, formatting, type checking, security, and tests). Always run tox before submitting a pull request:
+
+```bash
+uv run tox
+```
+
+For quick iteration during development, you can run only the tests. Note that this skips linting, type checking, and security checks, so it is not a substitute for tox:
+
+```bash
+pytest -n 2
+```
+
+## Ways to Contribute
+
+### Improve a Community Plugin
+
+The community plugin packages live under `mloda/community/`:
+
+- **Feature groups**: `mloda/community/feature_groups/`
+- **Compute frameworks**: `mloda/community/compute_frameworks/`
+- **Extenders**: `mloda/community/extenders/`
+
+Bug fixes, performance improvements, and new functionality for existing plugins are always welcome.
+
+### Add a New Community Plugin
+
+If you want to add a new plugin to the community registry:
+
+1. Read [`docs/guides/04-create-plugin-package.md`](docs/guides/04-create-plugin-package.md) for packaging conventions.
+2. Read [`docs/guides/06-publish-to-community.md`](docs/guides/06-publish-to-community.md) for the publication path.
+3. For promotion to **official** plugin status, see [`docs/guides/07-contribute-to-official.md`](docs/guides/07-contribute-to-official.md).
+
+### Improve the Plugin Development Guides
+
+The guides under [`docs/guides/`](docs/guides/index.md) are a primary on-ramp for new mloda contributors. Clarifications, missing patterns, and new pattern catalogs are all valuable contributions. Start with the [Plugin Journey overview](docs/guides/index.md) to find the right entry point.
+
+### Fix Registry Tooling
+
+The non-plugin packages support discovery and testing:
+
+- `mloda.registry` — plugin discovery and search
+- `mloda.testing` — test utilities (e.g. `FeatureGroupTestBase`) for plugin development
+
+### Report Issues
+
+Found a bug or have a feature request? [Open an issue](https://github.com/mloda-ai/mloda-registry/issues/). The issue template will prompt you for a summary, reproduction or motivation, optional code pointers, and an optional definition of done.
+
+## Pull Request Workflow
+
+1. Fork the repository and clone your fork:
+
+```bash
+git clone https://github.com/<your-username>/mloda-registry.git
+cd mloda-registry
+```
+
+2. Create a feature branch from `main`:
+
+```bash
+git checkout -b fix/short-description
+```
+
+3. Make your changes and ensure `uv run tox` passes locally.
+4. Commit using [Conventional Commits](https://www.conventionalcommits.org/) format.
+5. Push your branch to your fork and open a pull request targeting `main`.
+6. CI runs the full tox suite. All checks must pass before merge.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache License, Version 2.0](LICENSE), except for contributions to `mloda/enterprise/`, which are covered by the source-available [enterprise license](mloda/enterprise/LICENSE).

--- a/README.md
+++ b/README.md
@@ -64,3 +64,15 @@ uv venv && source .venv/bin/activate && uv sync --all-extras
 # Run all checks via tox
 uv run tox
 ```
+
+## Contributing
+
+We welcome contributions: new plugins, plugin improvements, guide clarifications, and fixes to registry tooling.
+
+**Plugin contributors:** start with the [Plugin Journey overview](docs/guides/index.md) to find the right guide for your level. To scaffold a new standalone plugin package, use the [mloda-plugin-template](https://github.com/mloda-ai/mloda-plugin-template).
+
+**Bug reports and feature requests:** [open an issue](https://github.com/mloda-ai/mloda-registry/issues/new/choose). The issue template prompts for a summary, reproduction or motivation, optional code pointers, and an optional definition of done.
+
+Looking for somewhere to start? Browse [`good first issue`](https://github.com/mloda-ai/mloda-registry/labels/good%20first%20issue) and [`help wanted`](https://github.com/mloda-ai/mloda-registry/labels/help%20wanted).
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full PR workflow and code style, and the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/docs/guides/07-contribute-to-official.md
+++ b/docs/guides/07-contribute-to-official.md
@@ -2,6 +2,8 @@
 
 Improve existing community plugins with bug fixes or new features.
 
+> For general PR mechanics, code style, and the full review process, see [CONTRIBUTING.md](../../CONTRIBUTING.md). This guide focuses on the workflow specific to contributing to official plugins.
+
 ## Steps
 
 1. **Fork and clone** mloda-registry:


### PR DESCRIPTION
## Summary

Mirrors the contributor-attraction work from mloda core PRs #393, #398, and #400 (tracked under tk-290) into mloda-registry. After this PR, a new contributor landing on the repo is ~10 minutes from a working dev setup, with consistent guidance across the mloda repos.

- `CODE_OF_CONDUCT.md` — short plain-English version, `conduct@mloda.ai` enforcement contact (verbatim from mloda core, mirrors mloda#393).
- `CONTRIBUTING.md` — setup steps, code style, "Ways to Contribute" reframed for plugin / guide / tooling contributors, PR workflow, license. Mirrors mloda#398 with registry-specific framing.
- `README.md` — new Contributing section linking `CONTRIBUTING.md`, the Code of Conduct, `good first issue` and `help wanted` label filters, and the Plugin Journey.
- `.github/ISSUE_TEMPLATE/` — unified `issue.yml` form (summary, reproduction or motivation, code pointers, definition of done, environment) and `config.yml` with `blank_issues_enabled: false`. Mirrors mloda#400.
- `AGENTS.md` — one-line pointer to `CLAUDE.md`, matching the workspace convention.
- `CLAUDE.md` — new "Project Practices" section (tox gate, Python range, type hints, supply-chain delay, auto-generated `pyproject.toml`, Conventional Commits with the project's `minor:` deviation per `.releaserc.yaml`) and "Issue Creation" section pointing at the new template fields.
- `docs/guides/07-contribute-to-official.md` — cross-link to `CONTRIBUTING.md`.

Refs tk-341. Platform submissions (Up For Grabs, Good First Issue, CodeTriage) and the 5-10 starter `good first issue`-labeled tasks are tracked separately under tk-290 and as a follow-on batch.

## Test plan

- [ ] CI runs tox on Python 3.10, 3.11, 3.12, 3.13 — all green.
- [ ] After merge, `https://github.com/mloda-ai/mloda-registry/community` shows >=85% completion with CoC, CONTRIBUTING, README, and issue template all green.
- [ ] Visit `/issues/new/choose` — only the unified form appears (no blank-issue link); all 5 fields render with correct required/optional flags.
- [ ] `mailto:conduct@mloda.ai` resolves; mailbox accepts a test email.
- [ ] Every relative link in `CONTRIBUTING.md` and `README.md` resolves on GitHub.
- [ ] On a follow-up PR, the GitHub "contributing-guidelines" banner appears.