### PR TITLE
docs: add missing pattern guide indices

### DIFF
--- a/docs/guides/compute-framework-patterns/index.md
+++ b/docs/guides/compute-framework-patterns/index.md
@@ -1,0 +1,24 @@
+# Compute Framework Patterns
+
+# Compute Framework Patterns
+
+Compute framework patterns describe execution strategies, dependency handling, filtering, transformations, and testing approaches across supported processing engines.
+
+See also: [Create a compute framework plugin](../10-create-compute-framework.md)
+
+## Guides
+
+1. [Stateless eager](01-stateless-eager.md) - Immediate execution patterns without persistent state
+2. [Stateless lazy](02-stateless-lazy.md) - Lazy evaluation and deferred execution patterns
+3. [Stateful connection](03-stateful-connection.md) - Stateful processing and persistent connection handling
+4. [Zero dependency Frameworks](04-zero-dependency.md) - Minimal dependency compute framework implementations
+5. [Data lake](05-data-lake.md) - Data lake integration and storage-oriented execution patterns
+6. [Merge engine](06-merge-engine.md) - Merge and reconciliation execution strategies
+7. [Filter engine](07-filter-engine.md) - Filtering and conditional processing pipelines
+8. [Framework transformer](08-framework-transformer.md) - Cross-framework transformation and compatibility patterns
+9. [Testing guide](09-testing-guide.md) - Testing standards and validation approaches for compute frameworks
+
+## Related Guides
+
+- [Feature Group Patterns](../feature-group-patterns/index.md)
+- [Data Operation Patterns](../data-operation-patterns/index.md)

--- a/docs/guides/feature-group-patterns/index.md
+++ b/docs/guides/feature-group-patterns/index.md
@@ -1,0 +1,38 @@
+# Feature Group Patterns
+
+Feature group patterns define reusable approaches for organizing, transforming, validating, and connecting features across frameworks and execution environments.
+
+See also: [Create a feature group](../09-create-feature-group.md)
+
+## Guides
+
+1. [Root features](01-root-features.md) - Base input features and feature group foundations
+2. [Simple Derived features](02-derived-features.md) - Features generated from existing features
+3. [Chained features](03-chained-features.md) - Sequential feature dependencies and pipelines
+4. [Multi-input features](04-multi-input-features.md) - Combining multiple inputs into derived features
+5. [Multi-output features](05-multi-output-features.md) - Producing multiple outputs from a feature group
+6. [Artifact features](06-artifact-features.md) - Features backed by stored artifacts or assets
+7. [Index features](07-index-features.md) - Index-based feature handling and lookup behavior
+8. [Links joins](08-links-joins.md) - Linking and joining feature groups together
+9. [Framework specific](09-framework-specific.md) - Framework-dependent feature implementations
+10. [Testing guide](10-testing-guide.md) - Testing strategies and validation practices
+11. [Options](11-options.md) - Configurable feature group options and behaviors
+12. [calculate_feature](12-calculate-feature.md) - Calculation patterns for feature generation
+13. [Feature naming](13-feature-naming.md) - Naming conventions and organization rules
+14. [Feature matching](14-feature-matching.md) - Matching and alignment strategies for features
+15. [Filter concepts](15-filter-concepts.md) - Feature filtering logic and concepts
+16. [Validators](16-validators.md) - Validation rules and feature integrity checks
+17. [Data connection matching](17-data-connection-matching.md) - Matching features with data connections
+18. [Datatypes](18-datatypes.md) - Supported feature data types and compatibility
+19. [Domain](19-domain.md) - Using domains to organize and match features with specific FeatureGroups
+20. [Versioning](20-versioning.md) - Feature version management and compatibility
+21. [Experimental shortcuts](21-experimental-shortcuts.md) - Helper patterns for faster feature prototyping and workflow experimentation
+22. [Feature config](22-feature-config.md) - Configuration structures for features
+23. [Streaming](23-streaming.md) - Streaming feature processing patterns
+24. [Realtime Execution](24-realtime.md) - Realtime feature computation and serving
+25. [Masking](25-masking.md) - Feature masking and sensitive data handling
+
+## Related Guides
+
+- [Compute Framework Patterns](../compute-framework-patterns/index.md)
+- [Data Operation Patterns](../data-operation-patterns/index.md)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -43,7 +43,23 @@ Extend mloda's capabilities with custom plugins.
 
 ---
 
-## 5. Data Operation Patterns
+## 5. Feature Group Patterns
+
+Reusable patterns and guides for feature engineering, joins, validation, streaming, masking, and feature organization.
+
+- [Feature group patterns index](feature-group-patterns/index.md) - Start here for feature group design and implementation patterns
+
+---
+
+## 6. Compute Framework Patterns
+
+Execution models, framework abstractions, dependency handling, and compute engine implementation guides.
+
+- [Compute framework patterns index](compute-framework-patterns/index.md) - Start here for compute framework architecture and execution patterns
+
+---
+
+## 7. Data Operation Patterns
 
 Contracts, cross-framework semantics, and extension path for the built-in data operations (row-preserving, aggregation, string).
 


### PR DESCRIPTION
## Changes made

* Added `docs/guides/feature-group-patterns/index.md`
* Added `docs/guides/compute-framework-patterns/index.md`
* Added links to both sections from `docs/guides/index.md`
* Mirrored the structure used by `data-operation-patterns/index.md`
* Verified documentation linting with `scripts/lint_docs.py`

Closes #174
