### PR TITLE
docs: remove duplicate compute framework heading

### DIFF
--- a/docs/guides/compute-framework-patterns/index.md
+++ b/docs/guides/compute-framework-patterns/index.md
@@ -1,6 +1,5 @@
 # Compute Framework Patterns
 
-# Compute Framework Patterns
 
 Compute framework patterns describe execution strategies, dependency handling, filtering, transformations, and testing approaches across supported processing engines.
 


### PR DESCRIPTION
## Changes made

* Removed the duplicate `# Compute Framework Patterns` heading from `docs/guides/compute-framework-patterns/index.md`
* Verified documentation linting with `scripts/lint_docs.py`

Closes #176
