### PR TITLE
chore(deps): bump mloda to 0.6.2 and adopt new DuckdbRelation API

### DIFF
--- a/config/packages.toml
+++ b/config/packages.toml
@@ -10,34 +10,34 @@
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/registry"
 
 [packages.mloda-testing]
 description = "Test utilities for mloda plugin development"
-dependencies = ["mloda>=0.6.1", "pytest>=9.0.3"]
+dependencies = ["mloda>=0.6.2", "pytest>=9.0.3"]
 path = "mloda/testing"
 optional_dependencies = { dev = ["pytest>=9.0.3"] }
 
 [packages.mloda-community]
 description = "All community plugins for mloda"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/community"
 
 [packages.mloda-enterprise]
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/enterprise"
 
 [packages.mloda-community-example]
 description = "Example community FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/community/feature_groups/example"
 optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-example-b"] }
 
 [packages.mloda-enterprise-example]
 description = "Example enterprise FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/enterprise/feature_groups/example"
 
 [packages.mloda-community-example-a]
@@ -52,29 +52,29 @@ path = "mloda/community/feature_groups/example/example_b"
 
 [packages.mloda-community-compute-frameworks-example]
 description = "Example community ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/community/compute_frameworks/example"
 
 [packages.mloda-community-extenders-example]
 description = "Example community Extender plugin for mloda"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/community/extenders/example"
 
 [packages.mloda-enterprise-compute-frameworks-example]
 description = "Example enterprise ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/enterprise/compute_frameworks/example"
 
 [packages.mloda-enterprise-extenders-example]
 description = "Example enterprise Extender plugin for mloda"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/enterprise/extenders/example"
 
 # --- Data Operations ---
 
 [packages.mloda-community-data-operations]
 description = "Shared base classes for data operation feature groups"
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 path = "mloda/community/feature_groups/data_operations"
 optional_dependencies = { all = ["mloda-community-window-aggregation", "mloda-community-aggregation", "mloda-community-rank", "mloda-community-offset", "mloda-community-frame-aggregate", "mloda-community-scalar-aggregate", "mloda-community-datetime", "mloda-community-string", "mloda-community-binning", "mloda-community-percentile"] }
 

--- a/docs/guides/data-operation-patterns/02-row-preserving-contract.md
+++ b/docs/guides/data-operation-patterns/02-row-preserving-contract.md
@@ -57,8 +57,8 @@ From `mloda/community/feature_groups/data_operations/row_preserving/binning/duck
 # reorders rows via ORDER BY; tag positions with ROW_NUMBER()
 # and restore via .order() to match PyArrow output.
 qrn = quote_ident("__mloda_rn__")
-with_rn   = data.select(_raw_sql=f"*, ROW_NUMBER() OVER () AS {qrn}")
-with_qbin = with_rn.select(_raw_sql=f"*, {expr} AS {quoted_feature}")
+with_rn   = data.project(f"*, ROW_NUMBER() OVER () AS {qrn}")
+with_qbin = with_rn.project(f"*, {expr} AS {quoted_feature}")
 sorted_rel = with_qbin.order(qrn)
 # drop __mloda_rn__ from the final projection
 ```

--- a/docs/guides/data-operation-patterns/05-binning.md
+++ b/docs/guides/data-operation-patterns/05-binning.md
@@ -69,10 +69,10 @@ The `PARTITION BY CASE WHEN ...` clause is what ensures NULL/NaN rows do not par
 ```python
 # Paraphrased from duckdb_binning.py
 qrn = quote_ident("__mloda_rn__")
-with_rn    = data.select(_raw_sql=f"*, ROW_NUMBER() OVER () AS {qrn}")
-with_qbin  = with_rn.select(_raw_sql=f"*, {ntile_expression} AS {quoted_feature}")
+with_rn    = data.project(f"*, ROW_NUMBER() OVER () AS {qrn}")
+with_qbin  = with_rn.project(f"*, {ntile_expression} AS {quoted_feature}")
 sorted_rel = with_qbin.order(qrn)
-# project out __mloda_rn__ in the final select
+# project out __mloda_rn__ in the final projection
 ```
 
 1. Tag each input row with `ROW_NUMBER() OVER ()` before the window runs.

--- a/memory-bank/pyproject-generation.md
+++ b/memory-bank/pyproject-generation.md
@@ -65,7 +65,7 @@ optional_dependencies = { dev = ["mloda-testing", "pytest"] }
 ```toml
 [packages.mloda-community]
 description = "All community plugins for mloda"
-dependencies = ["mloda>=0.4.3"]
+dependencies = ["mloda>=X.Y.Z"]
 path = "mloda/community"
 # Generates: package-dir = {"" = "../.."}, packages = ["mloda.community.*"]
 ```

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "Example community ComputeFramework plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "Example community Extender plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
@@ -72,6 +72,6 @@ class DuckdbAggregation(AggregationFeatureGroup):
 
         # Use lazy relation methods (aggregate + order) instead of eager query()
         # so DuckDB defers execution until the result is consumed.
-        rel = data._relation.aggregate(f"{partition_cols}, {agg_expr} AS {quoted_feature}", partition_cols)
+        rel: DuckdbRelation = data.aggregate(f"{partition_cols}, {agg_expr} AS {quoted_feature}", partition_cols)
         rel = rel.order(partition_cols)
-        return DuckdbRelation(data.connection, rel)
+        return rel

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "Shared base classes for data operation feature groups"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/duckdb_binning.py
@@ -47,7 +47,7 @@ class DuckdbBinning(BinningFeatureGroup):
                 f") AS INTEGER), {n_bins - 1}) END"
             )
             raw_sql = f"*, {expr} AS {quoted_feature}"
-            result: DuckdbRelation = data.select(_raw_sql=raw_sql)
+            result: DuckdbRelation = data.project(raw_sql)
             return result
 
         if op == "qbin":
@@ -63,11 +63,11 @@ class DuckdbBinning(BinningFeatureGroup):
                 f"AND NOT isnan({quoted_source}) THEN 1 END "
                 f"ORDER BY {quoted_source}) - 1, {n_bins - 1}) END"
             )
-            with_rn = data.select(_raw_sql=f"*, ROW_NUMBER() OVER () AS {qrn}")
-            with_qbin = with_rn.select(_raw_sql=f"*, {expr} AS {quoted_feature}")
+            with_rn = data.project(f"*, ROW_NUMBER() OVER () AS {qrn}")
+            with_qbin = with_rn.project(f"*, {expr} AS {quoted_feature}")
             sorted_rel = with_qbin.order(qrn)
             keep = ", ".join(quote_ident(c) for c in sorted_rel.columns if c != "__mloda_rn__")
-            qbin_result: DuckdbRelation = sorted_rel.select(_raw_sql=keep)
+            qbin_result: DuckdbRelation = sorted_rel.project(keep)
             return qbin_result
 
         raise ValueError(f"Unsupported binning operation for DuckDB: {op}")

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/duckdb_datetime.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/duckdb_datetime.py
@@ -52,5 +52,5 @@ class DuckdbDateTimeExtraction(DateTimeFeatureGroup):
         quoted_feature = quote_ident(feature_name)
 
         raw_sql = f"*, {expr} AS {quoted_feature}"
-        result: DuckdbRelation = data.select(_raw_sql=raw_sql)
+        result: DuckdbRelation = data.project(raw_sql)
         return result

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
@@ -95,7 +95,7 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
         # ORDER BY in the window frame reorders rows; tag with ROW_NUMBER(),
         # compute, then .order(qrn) to restore original order.
         # Step 1: tag rows with original position
-        rel = data._relation.project(f"*, ROW_NUMBER() OVER () AS {qrn}")  # nosec
+        rel = data.project(f"*, ROW_NUMBER() OVER () AS {qrn}")  # nosec
 
         # Step 2: compute window function with frame
         raw_sql = (  # nosec
@@ -110,4 +110,4 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
         keep = ", ".join(quote_ident(c) for c in rel.columns if c != _RN_COL)
         rel = rel.project(keep)
 
-        return DuckdbRelation(data.connection, rel)
+        return rel

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/duckdb_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/duckdb_offset.py
@@ -63,11 +63,11 @@ class DuckdbOffset(OffsetFeatureGroup):
                 f"ROW_NUMBER() OVER () AS {qrn} "
                 f"FROM __t ORDER BY {qrn}"
             )
-            new_rel = data._relation.query("__t", sql)
+            new_rel = data.query("__t", sql)
             result_rel = new_rel.project(
                 ", ".join(quote_ident(c) for c in [col for col in new_rel.columns if col != _RN_COL])
             )
-            return DuckdbRelation(data.connection, result_rel)
+            return result_rel
         elif offset_type == "first_value":
             offset_expr = f"FIRST_VALUE({quoted_source} IGNORE NULLS)"
             # PyArrow parity: the reference scans the entire partition for
@@ -92,8 +92,8 @@ class DuckdbOffset(OffsetFeatureGroup):
             f"ROW_NUMBER() OVER () AS {qrn} "
             f"FROM __t ORDER BY {qrn}"
         )
-        new_rel = data._relation.query("__t", sql)
+        new_rel = data.query("__t", sql)
         result_rel = new_rel.project(
             ", ".join(quote_ident(c) for c in [col for col in new_rel.columns if col != _RN_COL])
         )
-        return DuckdbRelation(data.connection, result_rel)
+        return result_rel

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/duckdb_percentile.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/duckdb_percentile.py
@@ -44,5 +44,5 @@ class DuckdbPercentile(PercentileFeatureGroup):
         raw_sql = (
             f"*, QUANTILE_CONT({source_sql}, {percentile}) OVER (PARTITION BY {partition_clause}) AS {quoted_feature}"
         )
-        result: DuckdbRelation = data.select(_raw_sql=raw_sql)
+        result: DuckdbRelation = data.project(raw_sql)
         return result

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
@@ -85,9 +85,9 @@ class DuckdbRank(RankFeatureGroup):
                 f"ROW_NUMBER() OVER () AS {qrn} "
                 f"FROM __t ORDER BY {qrn}"
             )
-        new_rel = data._relation.query("__t", sql)
+        new_rel: DuckdbRelation = data.query("__t", sql)
         # Drop the helper column
         result_rel = new_rel.project(
             ", ".join(quote_ident(c) for c in [col for col in new_rel.columns if col != _RN_COL])
         )
-        return DuckdbRelation(data.connection, result_rel)
+        return result_rel

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/duckdb_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/duckdb_scalar_aggregate.py
@@ -58,5 +58,5 @@ class DuckdbScalarAggregate(ScalarAggregateFeatureGroup):
             source_sql = build_sql_case_when(mask_spec, quoted_source)
 
         raw_sql = f"*, {agg_func}({source_sql}) OVER () AS {quoted_feature}"
-        result: DuckdbRelation = data.select(_raw_sql=raw_sql)
+        result: DuckdbRelation = data.project(raw_sql)
         return result

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
@@ -107,7 +107,7 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
         order_clause = f"ORDER BY {quote_ident(order_by)}" if order_by else ""
 
         # Step 1: tag rows with their original position
-        rel = data._relation.project(f"*, ROW_NUMBER() OVER () AS {qrn}")
+        rel = data.project(f"*, ROW_NUMBER() OVER () AS {qrn}")
 
         # Step 2: compute with full frame and ORDER BY for deterministic results
         rel = rel.project(
@@ -121,4 +121,4 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
         keep = ", ".join(quote_ident(c) for c in rel.columns if c != _RN_COL)
         rel = rel.project(keep)
 
-        return DuckdbRelation(data.connection, rel)
+        return rel

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
@@ -58,9 +58,9 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
     ) -> DuckdbRelation:
         assert_no_reserved_columns(data.columns, framework="DuckDB", operation="window aggregation")
 
-        # Safety: _raw_sql is composed entirely from quote_ident()-quoted identifiers
-        # and hardcoded SQL function names from _DUCKDB_AGG_FUNCS. No user-controlled
-        # strings are interpolated without quoting.
+        # Safety: the projection string is composed entirely from quote_ident()-quoted
+        # identifiers and hardcoded SQL function names from _DUCKDB_AGG_FUNCS. No
+        # user-controlled strings are interpolated without quoting.
         quoted_source = quote_ident(source_col)
         quoted_feature = quote_ident(feature_name)
         partition_clause = ", ".join(quote_ident(col) for col in partition_by)
@@ -71,7 +71,7 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
 
         if agg_type == "nunique":
             raw_sql = f"*, COUNT(DISTINCT {source_sql}) OVER (PARTITION BY {partition_clause}) AS {quoted_feature}"
-            result: DuckdbRelation = data.select(_raw_sql=raw_sql)
+            result: DuckdbRelation = data.project(raw_sql)
             return result
 
         if agg_type in ("first", "last"):
@@ -81,7 +81,7 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
         if agg_func is None:
             raise unsupported_agg_type_error(agg_type, _DUCKDB_AGG_FUNCS.keys(), framework="DuckDB")
         raw_sql = f"*, {agg_func}({source_sql}) OVER (PARTITION BY {partition_clause}) AS {quoted_feature}"
-        result = data.select(_raw_sql=raw_sql)
+        result = data.project(raw_sql)
         return result
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/string/duckdb_string.py
+++ b/mloda/community/feature_groups/data_operations/string/duckdb_string.py
@@ -45,5 +45,5 @@ class DuckdbStringOps(StringFeatureGroup):
         quoted_feature = quote_ident(feature_name)
 
         raw_sql = f"*, {expr} AS {quoted_feature}"
-        result: DuckdbRelation = data.select(_raw_sql=raw_sql)
+        result: DuckdbRelation = data.project(raw_sql)
         return result

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "Example community FeatureGroup plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "All community plugins for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "Example enterprise ComputeFramework plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "Example enterprise Extender plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "Example enterprise FeatureGroup plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "Plugin discovery and search for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1"]
+dependencies = ["mloda>=0.6.2"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/testing/pyproject.toml
+++ b/mloda/testing/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.1"
 description = "Test utilities for mloda plugin development"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.6.1", "pytest>=9.0.3"]
+dependencies = ["mloda>=0.6.2", "pytest>=9.0.3"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Development workspace for mloda registry packages"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "mloda>=0.6.1",
+    "mloda>=0.6.2",
 ]
 authors = [
     { name = "Tom Kaltofen", email = "info@mloda.ai" }

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-24T19:33:07.414576269Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -242,29 +242,29 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.6.1"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/92/b2b98f60f38499c69263e0118d1fdf1a7e116d4c328ef8bd09eaf708ea56/mloda-0.6.1-py3-none-any.whl", hash = "sha256:81e0336fc3c2d6888d12aae52f5f31917ceca1b8b1aadfdd996fc05b623345e1", size = 402433, upload-time = "2026-04-09T10:23:43.872Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7a/ccca4ed4bb16817bd4e9b2b5f85e34a3a930332ea3a37c159a9034102c2c/mloda-0.6.2-py3-none-any.whl", hash = "sha256:a97efe7dbb547f7d1b9e53a2a7765c45990feffc4111f0088aa133a49a69a64a", size = 406590, upload-time = "2026-05-07T22:47:16.359Z" },
 ]
 
 [[package]]
 name = "mloda-community"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community" }
 dependencies = [
     { name = "mloda" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.6.1" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.6.2" }]
 
 [[package]]
 name = "mloda-community-aggregation"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/aggregation" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -314,7 +314,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-binning"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/binning" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -364,7 +364,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-compute-frameworks-example"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/compute_frameworks/example" }
 dependencies = [
     { name = "mloda" },
@@ -378,7 +378,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -386,7 +386,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-data-operations"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations" }
 dependencies = [
     { name = "mloda" },
@@ -412,7 +412,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "mloda-community-aggregation", marker = "extra == 'all'" },
     { name = "mloda-community-binning", marker = "extra == 'all'" },
     { name = "mloda-community-datetime", marker = "extra == 'all'" },
@@ -430,7 +430,7 @@ provides-extras = ["dev", "all"]
 
 [[package]]
 name = "mloda-community-datetime"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/datetime" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -452,7 +452,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-example"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/example" }
 dependencies = [
     { name = "mloda" },
@@ -470,7 +470,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "mloda-community-example-a", marker = "extra == 'all'" },
     { name = "mloda-community-example-b", marker = "extra == 'all'" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
@@ -480,7 +480,7 @@ provides-extras = ["dev", "all"]
 
 [[package]]
 name = "mloda-community-example-a"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/example/example_a" }
 dependencies = [
     { name = "mloda-community-example" },
@@ -502,7 +502,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-example-b"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/example/example_b" }
 dependencies = [
     { name = "mloda-community-example" },
@@ -524,7 +524,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-extenders-example"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/extenders/example" }
 dependencies = [
     { name = "mloda" },
@@ -538,7 +538,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -546,7 +546,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-frame-aggregate"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -590,7 +590,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-offset"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/offset" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -634,7 +634,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-percentile"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/percentile" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -678,7 +678,7 @@ provides-extras = ["dev", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-rank"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/rank" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -722,7 +722,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-scalar-aggregate"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -772,7 +772,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-string"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/string" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -794,7 +794,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-window-aggregation"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -844,18 +844,18 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-enterprise"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/enterprise" }
 dependencies = [
     { name = "mloda" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.6.1" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.6.2" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/enterprise/compute_frameworks/example" }
 dependencies = [
     { name = "mloda" },
@@ -869,7 +869,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -877,7 +877,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-enterprise-example"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/enterprise/feature_groups/example" }
 dependencies = [
     { name = "mloda" },
@@ -891,7 +891,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -899,7 +899,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-enterprise-extenders-example"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/enterprise/extenders/example" }
 dependencies = [
     { name = "mloda" },
@@ -913,7 +913,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -921,7 +921,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-registry"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/registry" }
 dependencies = [
     { name = "mloda" },
@@ -935,7 +935,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "mloda-testing", marker = "extra == 'dev'", editable = "mloda/testing" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -971,7 +971,7 @@ dev = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
     { name = "duckdb", marker = "extra == 'dev'" },
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'dev'" },
     { name = "polars", marker = "extra == 'dev'" },
@@ -988,7 +988,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-testing"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "mloda/testing" }
 dependencies = [
     { name = "mloda" },
@@ -1002,7 +1002,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.6.1" },
+    { name = "mloda", specifier = ">=0.6.2" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]


### PR DESCRIPTION
## Summary

Bumps `mloda` from `>=0.6.1` to `>=0.6.2` and completes the `DuckdbRelation` public-API adoption in `data_operations`. **Closes #160.**

### Commits

1. **`chore(deps): bump mloda to 0.6.2 and adopt new DuckdbRelation API`**
   - Bumps `mloda` pin in `config/packages.toml` and root `pyproject.toml`; regenerates per-package `pyproject.toml` files; refreshes `uv.lock`.
   - Migrates 10 `DuckdbRelation.select(_raw_sql=...)` call sites across 7 DuckDB plugins to the new `DuckdbRelation.project(...)` API. Without this, 231 DuckDB tests fail under `mloda 0.6.2` because the kwarg was removed.
   - Updates the two pattern docs (`02-row-preserving-contract.md`, `05-binning.md`) and a doc comment that referenced the old call shape.
   - Normalizes a stale `mloda>=0.4.3` example in `memory-bank/pyproject-generation.md`.

2. **`refactor(duckdb): drop remaining _relation private accesses (closes #160)`**
   - Swaps the last six `data._relation.X(...)` accesses to the public `data.X(...)` methods now exposed in `mloda 0.6.2`: `aggregation/duckdb_aggregation.py:75`, `row_preserving/window_aggregation/duckdb_window_aggregation.py:110`, `row_preserving/frame_aggregate/duckdb_frame_aggregate.py:98`, `row_preserving/offset/duckdb_offset.py:66 + 95`, `row_preserving/rank/duckdb_rank.py:88`.
   - Public methods return `DuckdbRelation`, so the trailing `DuckdbRelation(data.connection, rel)` re-wrap collapses to a plain `return rel` at all six sites.
   - Adds two local annotations (`rel: DuckdbRelation = ...`) in `duckdb_aggregation.py` and `duckdb_rank.py` to keep mypy --strict quiet where the parameter is `data: Any` (matches the pre-existing pattern in `duckdb_window_aggregation.py:74`). Properly typing those parameters would touch the abstract base class signature and is intentionally **out of scope** for this PR — left as-is.

After the second commit:

- `grep -rn "_raw_sql" mloda/ docs/` -> 0 hits.
- `grep -rn "_relation\." mloda/community/feature_groups/data_operations/` -> 0 hits.
- Both verification checkboxes from #160 are satisfied.

## Scope note: nice-to-haves not included

mloda-ai/mloda#389 listed several nice-to-have follow-ups (`with_row_number`, structured `window`, collision-safe helper-column naming) that #404 explicitly deferred. They are tracked upstream in **mloda-ai/mloda#405** (open) and downstream in this repo as **#181**. Closing #160 with this PR does not orphan that work.

## Test plan

- [x] `python scripts/generate_pyproject.py --check` -- all 23 generated files match config
- [x] `uv lock --upgrade-package mloda` -- lockfile resolved to `mloda 0.6.2` (12 specifiers, 1 package version)
- [x] `uv run tox` after both commits -- 2602 passed, 119 skipped; ruff format/check, mypy strict, bandit all clean
- [x] CI green on this PR (build 3.10/3.11/3.12/3.13, lint-docs, package-integrity)