### PR TITLE
fix(docs): lint bare fenced-code openers; add text tags to 11 guides

### DIFF
--- a/docs/guides/03-create-plugin-in-project.md
+++ b/docs/guides/03-create-plugin-in-project.md
@@ -12,7 +12,7 @@ Add feature groups directly to your existing project without creating a separate
 
 Create a folder structure in your project:
 
-```
+```text
 my-project/
 ├── src/
 │   └── my_app/

--- a/docs/guides/04-create-plugin-package.md
+++ b/docs/guides/04-create-plugin-package.md
@@ -19,7 +19,7 @@ Or use the "Use this template" button on GitHub.
 
 The template provides a ready-to-use structure:
 
-```
+```text
 placeholder/
 ├── feature_groups/
 │   └── my_plugin/

--- a/docs/guides/09-create-feature-group.md
+++ b/docs/guides/09-create-feature-group.md
@@ -4,7 +4,7 @@ Use this guide to find the right pattern for your feature group.
 
 ## Decision Tree
 
-```
+```text
 Q1: Does it load external data (file, DB, external API)?
     YES → Pattern 1: Root Feature (if data passed at runtime, also see Q18)
     NO  → Continue

--- a/docs/guides/10-create-compute-framework.md
+++ b/docs/guides/10-create-compute-framework.md
@@ -4,7 +4,7 @@ Use this guide to add support for a new data processing library to mloda.
 
 ## Decision Tree
 
-```
+```text
 Q1: Does your framework require a connection/session object?
     YES → Q2
     NO  → Q3

--- a/docs/guides/11-create-extender.md
+++ b/docs/guides/11-create-extender.md
@@ -4,7 +4,7 @@ Add cross-cutting concerns (logging, tracing, metrics) to mloda pipelines.
 
 ## Decision Tree
 
-```
+```text
 Q1: What do you want to wrap?
     Feature calculation → FEATURE_GROUP_CALCULATE_FEATURE
     Input validation   → VALIDATE_INPUT_FEATURE

--- a/docs/guides/compute-framework-patterns/08-framework-transformer.md
+++ b/docs/guides/compute-framework-patterns/08-framework-transformer.md
@@ -12,7 +12,7 @@ Framework transformers enable cross-framework data conversion.
 
 PyArrow serves as the interchange format. Any framework can convert to any other through PyArrow:
 
-```
+```text
 Pandas ←→ PyArrow ←→ Polars
               ↕
            DuckDB

--- a/docs/guides/compute-framework-patterns/09-testing-guide.md
+++ b/docs/guides/compute-framework-patterns/09-testing-guide.md
@@ -10,7 +10,7 @@ Test your compute framework implementation with this structured approach.
 
 ## Test Structure
 
-```
+```text
 tests/
 ├── test_my_framework.py
 ├── test_my_merge_engine.py

--- a/docs/guides/data-operation-patterns/06-window-aggregation.md
+++ b/docs/guides/data-operation-patterns/06-window-aggregation.md
@@ -14,7 +14,7 @@ Window aggregation computes a group aggregate (sum, avg, etc.) and broadcasts it
 
 The matcher accepts any token that falls inside the name regex `r".*__([\w]+)_window$"` and is also present in the supported set:
 
-```
+```text
 sum, avg, mean, count, min, max,
 std, var, std_pop, std_samp, var_pop, var_samp,
 median, mode, nunique, first, last

--- a/docs/guides/data-operation-patterns/10-adding-new-operation.md
+++ b/docs/guides/data-operation-patterns/10-adding-new-operation.md
@@ -130,7 +130,7 @@ The test methods call `_compare_with_reference`, which runs both the implementat
 
 One file per framework, all subclassing `YourOpFeatureGroup`:
 
-```
+```text
 {category}/{your_op}/
   base.py
   pyarrow_{your_op}.py

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -17,7 +17,7 @@ When you request a feature (e.g., `Feature.not_typed("price__scaled")`), mloda c
 
 The default `match_feature_group_criteria()` checks in order:
 
-```
+```text
 1. Input data match     → Root features with matching input_data()
 2. Data access match    → ConnectionMatcherMixin with data connection
 3. Exact class name     → "MyFeature" == class MyFeature

--- a/docs/guides/feature-group-patterns/17-data-connection-matching.md
+++ b/docs/guides/feature-group-patterns/17-data-connection-matching.md
@@ -34,7 +34,7 @@ class DatabaseFeature(ConnectionMatcherMixin, FeatureGroup):
 
 In `match_feature_group_criteria()`, data access matching is checked early:
 
-```
+```text
 1. Input data match     → Root features
 2. Data access match    → ConnectionMatcherMixin ← HERE
 3. Exact class name     → Default matching

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -166,6 +166,10 @@ def check_bare_fence_openers(md_file: Path, content: str) -> list[str]:
 
     GitHub renders bare openers as plain monospace with no syntax highlighting.
     Use `text` for ASCII trees/diagrams when no real language applies.
+
+    Known limitations: does not handle indented fences (CommonMark allows up to
+    3 leading spaces), tilde fences (``~~~``), or nested-fence weirdness inside
+    the same delimiter.
     """
     errors = []
     in_block = False
@@ -173,8 +177,12 @@ def check_bare_fence_openers(md_file: Path, content: str) -> list[str]:
         if line.startswith("```"):
             opening = not in_block
             in_block = not in_block
+            # Trailing whitespace alone does not qualify as a language tag, so rstrip before comparing.
             if opening and line.rstrip() == "```":
-                errors.append(f"{md_file}:{lineno}: bare fenced-code opener (missing language tag)")
+                errors.append(
+                    f"{md_file}:{lineno}:1: bare fenced-code opener (missing language tag)"
+                    " - use ```text for plain blocks"
+                )
     return errors
 
 

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -161,6 +161,23 @@ def find_orphan_guides(docs_dir: Path, contents: dict[Path, str] | None = None) 
     return errors
 
 
+def check_bare_fence_openers(md_file: Path, content: str) -> list[str]:
+    """Flag fenced-code openers (```) that lack a language tag.
+
+    GitHub renders bare openers as plain monospace with no syntax highlighting.
+    Use `text` for ASCII trees/diagrams when no real language applies.
+    """
+    errors = []
+    in_block = False
+    for lineno, line in enumerate(content.splitlines(), start=1):
+        if line.startswith("```"):
+            opening = not in_block
+            in_block = not in_block
+            if opening and line.rstrip() == "```":
+                errors.append(f"{md_file}:{lineno}: bare fenced-code opener (missing language tag)")
+    return errors
+
+
 def main() -> int:
     if not DOCS_DIR.is_dir():
         print(f"Docs directory not found: {DOCS_DIR}")
@@ -175,6 +192,7 @@ def main() -> int:
         contents[md_file.resolve()] = content
         link_errors.extend(check_relative_links_and_anchors(md_file, content))
         all_errors.extend(check_internal_imports(md_file, content))
+        all_errors.extend(check_bare_fence_openers(md_file, content))
 
     all_errors.extend(link_errors)
 


### PR DESCRIPTION
## Summary
- `scripts/lint_docs.py` now flags any \`\`\` opener that lacks a language tag.
- Fixed 11 affected files in `docs/guides/` by adding \`\`\`text for ASCII trees and decision matrices.
- `python scripts/lint_docs.py` exits 0 on the updated tree.

## Test plan
- [x] `python scripts/lint_docs.py` → exits 0
- [x] `ruff format --check`, `ruff check`, `mypy --strict` all pass for `scripts/lint_docs.py`
- [ ] Render the updated guides on GitHub and confirm decision trees / file trees now appear in monospace blocks

Closes #171