### PR TITLE
feat(lint_docs): detect orphan guides not reachable from index.md

### DIFF
--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -7,6 +7,7 @@ Exit code: 1 if any issues found, 0 otherwise.
 import functools
 import re
 import sys
+from collections import deque
 from pathlib import Path
 
 DOCS_DIR = Path(__file__).resolve().parent.parent / "docs" / "guides"
@@ -100,23 +101,28 @@ def find_orphan_guides(docs_dir: Path) -> list[str]:
     Reachability is transitive via inline markdown links. Files named ``index.md`` are
     exempt from the "must be linked" requirement (a section index does not need an
     inbound link from itself), but they do participate as relay hops in the walk.
+
+    Caveat: a subdirectory whose only file is ``index.md`` and which has no inbound
+    link from any parent is still considered reachable, because ``index.md`` files
+    are exempt from the inbound-link check.
     """
     errors = []
+    docs_root = docs_dir.resolve()
     root_index = docs_dir / INDEX_FILENAME
     if not root_index.is_file():
         return [f"{root_index}: missing root index for orphan check"]
 
     reachable: set[Path] = {root_index.resolve()}
-    frontier = [root_index.resolve()]
+    frontier: deque[Path] = deque([root_index.resolve()])
     while frontier:
-        current = frontier.pop()
+        current = frontier.popleft()
         for linked in _collect_linked_md(current):
             if linked in reachable:
                 continue
             if not linked.is_file():
                 continue
             try:
-                linked.relative_to(docs_dir.resolve())
+                linked.relative_to(docs_root)
             except ValueError:
                 continue
             reachable.add(linked)
@@ -128,7 +134,7 @@ def find_orphan_guides(docs_dir: Path) -> list[str]:
             continue
         if resolved not in reachable:
             rel = md_file.relative_to(docs_dir)
-            errors.append(f"{md_file}: orphan guide not reachable from {INDEX_FILENAME} (rel: {rel})")
+            errors.append(f"{rel}: orphan guide not reachable from {INDEX_FILENAME}")
     return errors
 
 

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -83,9 +83,13 @@ def check_internal_imports(md_file: Path, content: str) -> list[str]:
 
 
 def _collect_linked_md(md_file: Path) -> set[Path]:
-    """Return the set of .md files linked from md_file (resolved absolute paths)."""
+    """Return the set of .md files linked from md_file (resolved absolute paths).
+
+    Links inside fenced code blocks are ignored so illustrative snippets do not
+    fabricate reachability edges.
+    """
     linked: set[Path] = set()
-    content = md_file.read_text()
+    content = "".join(CODE_BLOCK_RE.split(md_file.read_text())[::2])
     for match in MARKDOWN_LINK_RE.finditer(content):
         target = match.group(1)
         if target.startswith(("http://", "https://", "mailto:")):
@@ -98,13 +102,9 @@ def _collect_linked_md(md_file: Path) -> set[Path]:
 def find_orphan_guides(docs_dir: Path) -> list[str]:
     """Flag any .md file under docs_dir that is unreachable from docs_dir/index.md.
 
-    Reachability is transitive via inline markdown links. Files named ``index.md`` are
-    exempt from the "must be linked" requirement (a section index does not need an
-    inbound link from itself), but they do participate as relay hops in the walk.
-
-    Caveat: a subdirectory whose only file is ``index.md`` and which has no inbound
-    link from any parent is still considered reachable, because ``index.md`` files
-    are exempt from the inbound-link check.
+    Reachability is transitive via inline markdown links. Only the root ``index.md``
+    is exempt from the inbound-link check (it is the BFS source); subdirectory
+    ``index.md`` files must themselves be linked from somewhere reachable.
     """
     errors = []
     docs_root = docs_dir.resolve()
@@ -112,8 +112,9 @@ def find_orphan_guides(docs_dir: Path) -> list[str]:
     if not root_index.is_file():
         return [f"{root_index}: missing root index for orphan check"]
 
-    reachable: set[Path] = {root_index.resolve()}
-    frontier: deque[Path] = deque([root_index.resolve()])
+    root_resolved = root_index.resolve()
+    reachable: set[Path] = {root_resolved}
+    frontier: deque[Path] = deque([root_resolved])
     while frontier:
         current = frontier.popleft()
         for linked in _collect_linked_md(current):
@@ -130,7 +131,7 @@ def find_orphan_guides(docs_dir: Path) -> list[str]:
 
     for md_file in sorted(docs_dir.rglob("*.md")):
         resolved = md_file.resolve()
-        if md_file.name == INDEX_FILENAME:
+        if resolved == root_resolved:
             continue
         if resolved not in reachable:
             rel = md_file.relative_to(docs_dir)
@@ -144,13 +145,17 @@ def main() -> int:
         return 1
 
     all_errors: list[str] = []
+    link_errors: list[str] = []
 
     for md_file in sorted(DOCS_DIR.rglob("*.md")):
         content = md_file.read_text()
-        all_errors.extend(check_relative_links_and_anchors(md_file, content))
+        link_errors.extend(check_relative_links_and_anchors(md_file, content))
         all_errors.extend(check_internal_imports(md_file, content))
 
-    all_errors.extend(find_orphan_guides(DOCS_DIR))
+    all_errors.extend(link_errors)
+
+    if not link_errors:
+        all_errors.extend(find_orphan_guides(DOCS_DIR))
 
     if all_errors:
         print(f"Found {len(all_errors)} doc issue(s):\n")

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -17,7 +17,11 @@ RELATIVE_LINK_RE = re.compile(r"\[.*?\]\((?!https?://|mailto:)([^)#\s]+\.md)(?:#
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
 
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)#\s]+\.md)(?:#[^)]*)?\)")
+
 CODE_BLOCK_RE = re.compile(r"^```", re.MULTILINE)
+
+INDEX_FILENAME = "index.md"
 
 
 def find_code_blocks(content: str) -> list[str]:
@@ -77,6 +81,57 @@ def check_internal_imports(md_file: Path, content: str) -> list[str]:
     return errors
 
 
+def _collect_linked_md(md_file: Path) -> set[Path]:
+    """Return the set of .md files linked from md_file (resolved absolute paths)."""
+    linked: set[Path] = set()
+    content = md_file.read_text()
+    for match in MARKDOWN_LINK_RE.finditer(content):
+        target = match.group(1)
+        if target.startswith(("http://", "https://", "mailto:")):
+            continue
+        resolved = (md_file.parent / target).resolve()
+        linked.add(resolved)
+    return linked
+
+
+def find_orphan_guides(docs_dir: Path) -> list[str]:
+    """Flag any .md file under docs_dir that is unreachable from docs_dir/index.md.
+
+    Reachability is transitive via inline markdown links. Files named ``index.md`` are
+    exempt from the "must be linked" requirement (a section index does not need an
+    inbound link from itself), but they do participate as relay hops in the walk.
+    """
+    errors = []
+    root_index = docs_dir / INDEX_FILENAME
+    if not root_index.is_file():
+        return [f"{root_index}: missing root index for orphan check"]
+
+    reachable: set[Path] = {root_index.resolve()}
+    frontier = [root_index.resolve()]
+    while frontier:
+        current = frontier.pop()
+        for linked in _collect_linked_md(current):
+            if linked in reachable:
+                continue
+            if not linked.is_file():
+                continue
+            try:
+                linked.relative_to(docs_dir.resolve())
+            except ValueError:
+                continue
+            reachable.add(linked)
+            frontier.append(linked)
+
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        resolved = md_file.resolve()
+        if md_file.name == INDEX_FILENAME:
+            continue
+        if resolved not in reachable:
+            rel = md_file.relative_to(docs_dir)
+            errors.append(f"{md_file}: orphan guide not reachable from {INDEX_FILENAME} (rel: {rel})")
+    return errors
+
+
 def main() -> int:
     if not DOCS_DIR.is_dir():
         print(f"Docs directory not found: {DOCS_DIR}")
@@ -88,6 +143,8 @@ def main() -> int:
         content = md_file.read_text()
         all_errors.extend(check_relative_links_and_anchors(md_file, content))
         all_errors.extend(check_internal_imports(md_file, content))
+
+    all_errors.extend(find_orphan_guides(DOCS_DIR))
 
     if all_errors:
         print(f"Found {len(all_errors)} doc issue(s):\n")

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -14,13 +14,27 @@ DOCS_DIR = Path(__file__).resolve().parent.parent / "docs" / "guides"
 
 INTERNAL_IMPORT_RE = re.compile(r"from mloda\.core\.")
 
-MD_LINK_RE = re.compile(r"\[[^\]]*\]\((?!https?://|mailto:)([^)#\s]+\.md)(?:#([^)\s]+))?\)")
+MD_LINK_RE = re.compile(r"\[.*?\]\((?!https?://|mailto:)([^)#\s]+\.md)(?:#([^)\s]+))?\)")
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
 
 CODE_BLOCK_RE = re.compile(r"^```", re.MULTILINE)
 
 INDEX_FILENAME = "index.md"
+
+
+def _strip_code_blocks(content: str) -> str:
+    """Remove fenced code blocks from markdown content."""
+    return "".join(CODE_BLOCK_RE.split(content)[::2])
+
+
+def _fenced_ranges(content: str) -> list[tuple[int, int]]:
+    """Return (start, end) offsets of fenced code blocks in content."""
+    fences = [m.start() for m in CODE_BLOCK_RE.finditer(content)]
+    ranges: list[tuple[int, int]] = []
+    for i in range(0, len(fences) - 1, 2):
+        ranges.append((fences[i], fences[i + 1]))
+    return ranges
 
 
 def find_code_blocks(content: str) -> list[str]:
@@ -42,7 +56,7 @@ def _slugify_heading(text: str) -> str:
 @functools.lru_cache(maxsize=None)
 def _heading_slugs(md_file: Path) -> frozenset[str]:
     slugs: set[str] = set()
-    content = "".join(CODE_BLOCK_RE.split(md_file.read_text())[::2])
+    content = _strip_code_blocks(md_file.read_text())
     for match in HEADING_RE.finditer(content):
         slugs.add(_slugify_heading(match.group(2)))
     return frozenset(slugs)
@@ -51,11 +65,15 @@ def _heading_slugs(md_file: Path) -> frozenset[str]:
 def check_relative_links_and_anchors(md_file: Path, content: str) -> list[str]:
     """Validate relative markdown links and their optional anchor fragments."""
     errors = []
+    fenced = _fenced_ranges(content)
     for match in MD_LINK_RE.finditer(content):
+        start = match.start()
+        if any(lo <= start < hi for lo, hi in fenced):
+            continue
         rel_path = match.group(1)
         anchor = match.group(2)
         target = (md_file.parent / rel_path).resolve()
-        line_num = content[: match.start()].count("\n") + 1
+        line_num = content[:start].count("\n") + 1
         if not target.exists():
             errors.append(f"{md_file}:{line_num}: broken link -> {rel_path}")
             continue
@@ -80,40 +98,48 @@ def check_internal_imports(md_file: Path, content: str) -> list[str]:
     return errors
 
 
-def _collect_linked_md(md_file: Path) -> set[Path]:
+def _collect_linked_md(md_file: Path, content: str) -> set[Path]:
     """Return the set of .md files linked from md_file (resolved absolute paths).
 
     Links inside fenced code blocks are ignored so illustrative snippets do not
     fabricate reachability edges.
     """
     linked: set[Path] = set()
-    content = "".join(CODE_BLOCK_RE.split(md_file.read_text())[::2])
-    for match in MD_LINK_RE.finditer(content):
+    stripped = _strip_code_blocks(content)
+    for match in MD_LINK_RE.finditer(stripped):
         target = match.group(1)
         resolved = (md_file.parent / target).resolve()
         linked.add(resolved)
     return linked
 
 
-def find_orphan_guides(docs_dir: Path) -> list[str]:
+def find_orphan_guides(docs_dir: Path, contents: dict[Path, str] | None = None) -> list[str]:
     """Flag any .md file under docs_dir that is unreachable from docs_dir/index.md.
 
     Reachability is transitive via inline markdown links. Only the root ``index.md``
     is exempt from the inbound-link check (it is the BFS source); subdirectory
     ``index.md`` files must themselves be linked from somewhere reachable.
+
+    Links to files outside ``docs_dir`` or to missing targets are silently skipped
+    here; the latter are surfaced by ``check_relative_links_and_anchors``.
     """
     errors = []
     docs_root = docs_dir.resolve()
     root_index = docs_dir / INDEX_FILENAME
     if not root_index.is_file():
-        return [f"{root_index}: missing root index for orphan check"]
+        return [f"{INDEX_FILENAME}: missing root index for orphan check"]
+
+    def _read(path: Path) -> str:
+        if contents is not None and path in contents:
+            return contents[path]
+        return path.read_text()
 
     root_resolved = root_index.resolve()
     reachable: set[Path] = {root_resolved}
     frontier: deque[Path] = deque([root_resolved])
     while frontier:
         current = frontier.popleft()
-        for linked in _collect_linked_md(current):
+        for linked in _collect_linked_md(current, _read(current)):
             if linked in reachable:
                 continue
             if not linked.is_file():
@@ -142,16 +168,18 @@ def main() -> int:
 
     all_errors: list[str] = []
     link_errors: list[str] = []
+    contents: dict[Path, str] = {}
 
     for md_file in sorted(DOCS_DIR.rglob("*.md")):
         content = md_file.read_text()
+        contents[md_file.resolve()] = content
         link_errors.extend(check_relative_links_and_anchors(md_file, content))
         all_errors.extend(check_internal_imports(md_file, content))
 
     all_errors.extend(link_errors)
 
     if not link_errors:
-        all_errors.extend(find_orphan_guides(DOCS_DIR))
+        all_errors.extend(find_orphan_guides(DOCS_DIR, contents))
 
     if all_errors:
         print(f"Found {len(all_errors)} doc issue(s):\n")

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -14,11 +14,9 @@ DOCS_DIR = Path(__file__).resolve().parent.parent / "docs" / "guides"
 
 INTERNAL_IMPORT_RE = re.compile(r"from mloda\.core\.")
 
-RELATIVE_LINK_RE = re.compile(r"\[.*?\]\((?!https?://|mailto:)([^)#\s]+\.md)(?:#([^)\s]+))?\)")
+MD_LINK_RE = re.compile(r"\[[^\]]*\]\((?!https?://|mailto:)([^)#\s]+\.md)(?:#([^)\s]+))?\)")
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
-
-MARKDOWN_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)#\s]+\.md)(?:#[^)]*)?\)")
 
 CODE_BLOCK_RE = re.compile(r"^```", re.MULTILINE)
 
@@ -53,7 +51,7 @@ def _heading_slugs(md_file: Path) -> frozenset[str]:
 def check_relative_links_and_anchors(md_file: Path, content: str) -> list[str]:
     """Validate relative markdown links and their optional anchor fragments."""
     errors = []
-    for match in RELATIVE_LINK_RE.finditer(content):
+    for match in MD_LINK_RE.finditer(content):
         rel_path = match.group(1)
         anchor = match.group(2)
         target = (md_file.parent / rel_path).resolve()
@@ -90,10 +88,8 @@ def _collect_linked_md(md_file: Path) -> set[Path]:
     """
     linked: set[Path] = set()
     content = "".join(CODE_BLOCK_RE.split(md_file.read_text())[::2])
-    for match in MARKDOWN_LINK_RE.finditer(content):
+    for match in MD_LINK_RE.finditer(content):
         target = match.group(1)
-        if target.startswith(("http://", "https://", "mailto:")):
-            continue
         resolved = (md_file.parent / target).resolve()
         linked.add(resolved)
     return linked

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -82,18 +82,11 @@ def test_http_link_does_not_count_as_local(tmp_path: Path) -> None:
     assert any("foo.md" in err for err in errors)
 
 
-def test_link_text_with_brackets_still_parsed(tmp_path: Path) -> None:
-    """Lock in the grammar shift: text uses [^]]* so a nested ] in text breaks the match.
-
-    A link like ``[a [nested] label](foo.md)`` is parsed as if the link target is whatever
-    follows the last ``]`` in the prefix. With our regex, ``[a [nested]`` matches as the
-    text portion, then the body must immediately be ``(``, but the next char is ` ` so
-    the match fails — foo.md ends up unreachable. Document the limitation in a test.
-    """
+def test_nested_bracket_link_text_is_reachable(tmp_path: Path) -> None:
+    """A link with nested brackets in its text must still resolve to the target."""
     _write(tmp_path / "index.md", "# Root\n\n[a [nested] label](foo.md)\n")
     _write(tmp_path / "foo.md", "# Foo\n")
-    errors = lint_docs.find_orphan_guides(tmp_path)
-    assert any("foo.md" in err for err in errors)
+    assert lint_docs.find_orphan_guides(tmp_path) == []
 
 
 def test_missing_root_index_returns_sentinel(tmp_path: Path) -> None:
@@ -116,6 +109,7 @@ def test_broken_link_suppresses_orphan_cascade(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Regression for fix 3: broken-link errors suppress the orphan check in main()."""
+    # "plgins" is an intentional typo: it's what makes the link broken for this test.
     _write(tmp_path / "index.md", "# Root\n\n[Plugins](plgins/index.md)\n")
     _write(tmp_path / "plugins" / "index.md", "# Plugins\n\n[A](a.md)\n")
     _write(tmp_path / "plugins" / "a.md", "# A\n")
@@ -140,3 +134,83 @@ def test_clean_tree_runs_orphan_check(
     assert rc == 1
     assert "orphan guide" in out
     assert "orphan.md" in out
+
+
+def test_fenced_broken_link_is_ignored_by_link_check(tmp_path: Path) -> None:
+    """Broken links inside ``` fences must not be flagged by the relative-link check."""
+    md_file = tmp_path / "a.md"
+    content = "# A\n\n```markdown\n[fake](missing.md)\n```\n"
+    _write(md_file, content)
+    assert lint_docs.check_relative_links_and_anchors(md_file, content) == []
+
+
+def test_check_relative_links_flags_broken_link(tmp_path: Path) -> None:
+    md_file = tmp_path / "a.md"
+    content = "# A\n\n[x](missing.md)\n"
+    _write(md_file, content)
+    errors = lint_docs.check_relative_links_and_anchors(md_file, content)
+    assert len(errors) == 1
+    assert "broken link" in errors[0]
+    assert "missing.md" in errors[0]
+
+
+def test_check_relative_links_flags_broken_anchor(tmp_path: Path) -> None:
+    a_file = tmp_path / "a.md"
+    content = "# A\n\n[link](b.md#nope)\n"
+    _write(a_file, content)
+    _write(tmp_path / "b.md", "# B\n\n## real\n")
+    errors = lint_docs.check_relative_links_and_anchors(a_file, content)
+    assert len(errors) == 1
+    assert "broken anchor" in errors[0]
+    assert "#nope" in errors[0]
+
+
+def test_check_relative_links_accepts_valid_anchor(tmp_path: Path) -> None:
+    a_file = tmp_path / "a.md"
+    content = "# A\n\n[link](b.md#real)\n"
+    _write(a_file, content)
+    _write(tmp_path / "b.md", "# B\n\n## real\n")
+    assert lint_docs.check_relative_links_and_anchors(a_file, content) == []
+
+
+def test_link_cycle_terminates(tmp_path: Path) -> None:
+    _write(tmp_path / "index.md", "# Root\n\n[A](a.md)\n")
+    _write(tmp_path / "a.md", "# A\n\n[B](b.md)\n")
+    _write(tmp_path / "b.md", "# B\n\n[A](a.md)\n")
+    assert lint_docs.find_orphan_guides(tmp_path) == []
+
+
+def test_multiple_orphans_reported_sorted(tmp_path: Path) -> None:
+    _write(tmp_path / "index.md", "# Root\n")
+    _write(tmp_path / "z_orphan.md", "# Z\n")
+    _write(tmp_path / "a_orphan.md", "# A\n")
+    _write(tmp_path / "m_orphan.md", "# M\n")
+    errors = lint_docs.find_orphan_guides(tmp_path)
+    orphan_errors = [err for err in errors if "orphan.md" in err]
+    assert len(orphan_errors) == 3
+    names = [err.split(":")[0] for err in orphan_errors]
+    assert names == ["a_orphan.md", "m_orphan.md", "z_orphan.md"]
+
+
+def test_check_internal_imports_flags_mloda_core_import(tmp_path: Path) -> None:
+    md_file = tmp_path / "a.md"
+    content = "# A\n\n```python\nfrom mloda.core.something import X\n```\n"
+    _write(md_file, content)
+    errors = lint_docs.check_internal_imports(md_file, content)
+    assert len(errors) == 1
+    assert "internal import" in errors[0]
+    assert "mloda.core" in errors[0]
+
+
+def test_check_internal_imports_ignores_prose_match(tmp_path: Path) -> None:
+    """The internal-import check must only scan inside fenced code blocks."""
+    md_file = tmp_path / "a.md"
+    content = "# A\n\nDo not write `from mloda.core.` in prose, but here we just mention it.\n"
+    _write(md_file, content)
+    assert lint_docs.check_internal_imports(md_file, content) == []
+
+
+def test_missing_root_index_uses_relative_path(tmp_path: Path) -> None:
+    errors = lint_docs.find_orphan_guides(tmp_path)
+    assert len(errors) == 1
+    assert str(tmp_path) not in errors[0]

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -1,0 +1,142 @@
+"""Tests for scripts/lint_docs.py.
+
+The lint script is not a packaged module, so it's loaded via a sys.path
+insert. ``tests/**`` has ``E402`` ignored in ruff config so the post-path
+import does not trip the linter.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import lint_docs
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def test_empty_tree_only_root_index(tmp_path: Path) -> None:
+    _write(tmp_path / "index.md", "# Root\n")
+    assert lint_docs.find_orphan_guides(tmp_path) == []
+
+
+def test_linked_guide_not_flagged(tmp_path: Path) -> None:
+    _write(tmp_path / "index.md", "# Root\n\n[Guide](guide.md)\n")
+    _write(tmp_path / "guide.md", "# Guide\n")
+    assert lint_docs.find_orphan_guides(tmp_path) == []
+
+
+def test_unlinked_guide_flagged(tmp_path: Path) -> None:
+    _write(tmp_path / "index.md", "# Root\n")
+    _write(tmp_path / "orphan.md", "# Orphan\n")
+    errors = lint_docs.find_orphan_guides(tmp_path)
+    assert len(errors) == 1
+    assert "orphan.md" in errors[0]
+
+
+def test_transitive_reach_via_subdir_index(tmp_path: Path) -> None:
+    _write(tmp_path / "index.md", "# Root\n\n[Sub](sub/index.md)\n")
+    _write(tmp_path / "sub" / "index.md", "# Sub\n\n[Leaf](leaf.md)\n")
+    _write(tmp_path / "sub" / "leaf.md", "# Leaf\n")
+    assert lint_docs.find_orphan_guides(tmp_path) == []
+
+
+def test_unlinked_subdir_index_is_flagged(tmp_path: Path) -> None:
+    """Regression for the fixed CONFIRMED hole: subdir index.md is no longer exempt."""
+    _write(tmp_path / "index.md", "# Root\n")
+    _write(tmp_path / "sub" / "index.md", "# Sub\n\n[Leaf](leaf.md)\n")
+    _write(tmp_path / "sub" / "leaf.md", "# Leaf\n")
+    errors = lint_docs.find_orphan_guides(tmp_path)
+    flagged = {err.split(":")[0] for err in errors}
+    assert "sub/index.md" in flagged
+    assert "sub/leaf.md" in flagged
+
+
+def test_link_inside_code_fence_is_ignored(tmp_path: Path) -> None:
+    """Regression for the fenced-code fix: links inside ``` blocks don't fabricate edges."""
+    _write(
+        tmp_path / "index.md",
+        "# Root\n\n```markdown\n[fake](only-in-fence.md)\n```\n",
+    )
+    _write(tmp_path / "only-in-fence.md", "# OnlyInFence\n")
+    errors = lint_docs.find_orphan_guides(tmp_path)
+    assert any("only-in-fence.md" in err for err in errors)
+
+
+def test_anchor_bearing_link_reaches_target(tmp_path: Path) -> None:
+    _write(tmp_path / "index.md", "# Root\n\n[Guide](guide.md#section)\n")
+    _write(tmp_path / "guide.md", "# Guide\n\n## Section\n")
+    assert lint_docs.find_orphan_guides(tmp_path) == []
+
+
+def test_http_link_does_not_count_as_local(tmp_path: Path) -> None:
+    _write(tmp_path / "index.md", "# Root\n\n[Ext](https://example.com/foo.md)\n")
+    _write(tmp_path / "foo.md", "# Local foo\n")
+    errors = lint_docs.find_orphan_guides(tmp_path)
+    assert any("foo.md" in err for err in errors)
+
+
+def test_link_text_with_brackets_still_parsed(tmp_path: Path) -> None:
+    """Lock in the grammar shift: text uses [^]]* so a nested ] in text breaks the match.
+
+    A link like ``[a [nested] label](foo.md)`` is parsed as if the link target is whatever
+    follows the last ``]`` in the prefix. With our regex, ``[a [nested]`` matches as the
+    text portion, then the body must immediately be ``(``, but the next char is ` ` so
+    the match fails — foo.md ends up unreachable. Document the limitation in a test.
+    """
+    _write(tmp_path / "index.md", "# Root\n\n[a [nested] label](foo.md)\n")
+    _write(tmp_path / "foo.md", "# Foo\n")
+    errors = lint_docs.find_orphan_guides(tmp_path)
+    assert any("foo.md" in err for err in errors)
+
+
+def test_missing_root_index_returns_sentinel(tmp_path: Path) -> None:
+    errors = lint_docs.find_orphan_guides(tmp_path)
+    assert len(errors) == 1
+    assert "missing root index" in errors[0]
+
+
+def test_link_outside_docs_dir_does_not_crash(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside.md"
+    outside.write_text("# Outside\n")
+    docs = tmp_path / "docs"
+    _write(docs / "index.md", "# Root\n\n[Outside](../outside.md)\n")
+    assert lint_docs.find_orphan_guides(docs) == []
+
+
+def test_broken_link_suppresses_orphan_cascade(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Regression for fix 3: broken-link errors suppress the orphan check in main()."""
+    _write(tmp_path / "index.md", "# Root\n\n[Plugins](plgins/index.md)\n")
+    _write(tmp_path / "plugins" / "index.md", "# Plugins\n\n[A](a.md)\n")
+    _write(tmp_path / "plugins" / "a.md", "# A\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "broken link" in out
+    assert "orphan guide" not in out
+
+
+def test_clean_tree_runs_orphan_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write(tmp_path / "index.md", "# Root\n")
+    _write(tmp_path / "orphan.md", "# Orphan\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "orphan guide" in out
+    assert "orphan.md" in out


### PR DESCRIPTION
## Summary
- Adds `find_orphan_guides()` to `scripts/lint_docs.py` that BFS-walks markdown links starting at `docs/guides/index.md`.
- Any `.md` file under `docs/guides/` not in the reachable set is flagged. `index.md` files are exempt from the inbound check but still serve as relay hops (so pattern-subdir indices count as references for their children).
- Links to `http(s)/mailto` and anchor fragments (`#section`) are skipped.

## Test plan
- [x] `python scripts/lint_docs.py` → exits 0 on current `docs/guides/`
- [x] Adding a stray `docs/guides/_orphan_test.md` reproduces the failure
- [x] `ruff format --check`, `ruff check`, `mypy --strict` all pass

Closes #172