### PR TITLE
feat(lint_docs): validate anchor fragments resolve to existing headings

### DIFF
--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -12,7 +12,9 @@ DOCS_DIR = Path(__file__).resolve().parent.parent / "docs" / "guides"
 
 INTERNAL_IMPORT_RE = re.compile(r"from mloda\.core\.")
 
-RELATIVE_LINK_RE = re.compile(r"\[.*?\]\((\.[^)]+\.md)\)")
+RELATIVE_LINK_RE = re.compile(r"\[.*?\]\((?!https?://|mailto:)([^)#\s]+\.md)(?:#([^)\s]+))?\)")
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
 
 CODE_BLOCK_RE = re.compile(r"^```", re.MULTILINE)
 
@@ -26,14 +28,38 @@ def find_code_blocks(content: str) -> list[str]:
     return blocks
 
 
+def _slugify_heading(text: str) -> str:
+    """Convert markdown heading text to its GFM-style anchor slug.
+
+    Rules: lowercase, strip inline code backticks, replace spaces with hyphens,
+    keep alphanumerics, hyphens, and underscores; drop everything else.
+    """
+    text = text.lower().replace("`", "")
+    text = text.replace(" ", "-")
+    return re.sub(r"[^\w-]", "", text)
+
+
+def _heading_slugs(md_file: Path) -> set[str]:
+    slugs: set[str] = set()
+    for match in HEADING_RE.finditer(md_file.read_text()):
+        slugs.add(_slugify_heading(match.group(2)))
+    return slugs
+
+
 def check_relative_links(md_file: Path, content: str) -> list[str]:
     errors = []
     for match in RELATIVE_LINK_RE.finditer(content):
         rel_path = match.group(1)
+        anchor = match.group(2)
         target = (md_file.parent / rel_path).resolve()
+        line_num = content[: match.start()].count("\n") + 1
         if not target.exists():
-            line_num = content[: match.start()].count("\n") + 1
             errors.append(f"{md_file}:{line_num}: broken link -> {rel_path}")
+            continue
+        if anchor and target.is_file():
+            slug = _slugify_heading(anchor)
+            if slug not in _heading_slugs(target):
+                errors.append(f"{md_file}:{line_num}: broken anchor -> {rel_path}#{anchor}")
     return errors
 
 

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -4,6 +4,7 @@ Run: python scripts/lint_docs.py
 Exit code: 1 if any issues found, 0 otherwise.
 """
 
+import functools
 import re
 import sys
 from pathlib import Path
@@ -29,36 +30,35 @@ def find_code_blocks(content: str) -> list[str]:
 
 
 def _slugify_heading(text: str) -> str:
-    """Convert markdown heading text to its GFM-style anchor slug.
-
-    Rules: lowercase, strip inline code backticks, replace spaces with hyphens,
-    keep alphanumerics, hyphens, and underscores; drop everything else.
-    """
+    """Simplified GFM-style slug: lowercase, strip backticks, spaces->hyphens, drop non-[\\w-]. Does NOT handle duplicate-heading disambiguation (`-1`, `-2`) or stripping of inline markdown formatting beyond backticks."""
     text = text.lower().replace("`", "")
     text = text.replace(" ", "-")
     return re.sub(r"[^\w-]", "", text)
 
 
-def _heading_slugs(md_file: Path) -> set[str]:
+@functools.lru_cache(maxsize=None)
+def _heading_slugs(md_file: Path) -> frozenset[str]:
     slugs: set[str] = set()
     for match in HEADING_RE.finditer(md_file.read_text()):
         slugs.add(_slugify_heading(match.group(2)))
-    return slugs
+    return frozenset(slugs)
 
 
-def check_relative_links(md_file: Path, content: str) -> list[str]:
+def check_relative_links_and_anchors(md_file: Path, content: str) -> list[str]:
+    """Validate relative markdown links and their optional anchor fragments."""
     errors = []
     for match in RELATIVE_LINK_RE.finditer(content):
         rel_path = match.group(1)
         anchor = match.group(2)
         target = (md_file.parent / rel_path).resolve()
-        line_num = content[: match.start()].count("\n") + 1
         if not target.exists():
+            line_num = content[: match.start()].count("\n") + 1
             errors.append(f"{md_file}:{line_num}: broken link -> {rel_path}")
             continue
         if anchor and target.is_file():
             slug = _slugify_heading(anchor)
             if slug not in _heading_slugs(target):
+                line_num = content[: match.start()].count("\n") + 1
                 errors.append(f"{md_file}:{line_num}: broken anchor -> {rel_path}#{anchor}")
     return errors
 
@@ -86,7 +86,7 @@ def main() -> int:
 
     for md_file in sorted(DOCS_DIR.rglob("*.md")):
         content = md_file.read_text()
-        all_errors.extend(check_relative_links(md_file, content))
+        all_errors.extend(check_relative_links_and_anchors(md_file, content))
         all_errors.extend(check_internal_imports(md_file, content))
 
     if all_errors:

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -30,7 +30,7 @@ def find_code_blocks(content: str) -> list[str]:
 
 
 def _slugify_heading(text: str) -> str:
-    """Simplified GFM-style slug: lowercase, strip backticks, spaces->hyphens, drop non-[\\w-]. Does NOT handle duplicate-heading disambiguation (`-1`, `-2`) or stripping of inline markdown formatting beyond backticks."""
+    """GFM-style slug; ignores duplicate-heading disambiguation and inline formatting beyond backticks."""
     text = text.lower().replace("`", "")
     text = text.replace(" ", "-")
     return re.sub(r"[^\w-]", "", text)
@@ -39,7 +39,8 @@ def _slugify_heading(text: str) -> str:
 @functools.lru_cache(maxsize=None)
 def _heading_slugs(md_file: Path) -> frozenset[str]:
     slugs: set[str] = set()
-    for match in HEADING_RE.finditer(md_file.read_text()):
+    content = "".join(CODE_BLOCK_RE.split(md_file.read_text())[::2])
+    for match in HEADING_RE.finditer(content):
         slugs.add(_slugify_heading(match.group(2)))
     return frozenset(slugs)
 
@@ -51,14 +52,13 @@ def check_relative_links_and_anchors(md_file: Path, content: str) -> list[str]:
         rel_path = match.group(1)
         anchor = match.group(2)
         target = (md_file.parent / rel_path).resolve()
+        line_num = content[: match.start()].count("\n") + 1
         if not target.exists():
-            line_num = content[: match.start()].count("\n") + 1
             errors.append(f"{md_file}:{line_num}: broken link -> {rel_path}")
             continue
-        if anchor and target.is_file():
+        if anchor:
             slug = _slugify_heading(anchor)
             if slug not in _heading_slugs(target):
-                line_num = content[: match.start()].count("\n") + 1
                 errors.append(f"{md_file}:{line_num}: broken anchor -> {rel_path}#{anchor}")
     return errors
 


### PR DESCRIPTION
## Summary
- `RELATIVE_LINK_RE` now captures the optional `#anchor` fragment, and was widened to also accept bare relative paths (still excludes `http(s)` and `mailto:`).
- For every `*.md#anchor` link, headings of the target file are slugified GFM-style (lowercase, backticks stripped, spaces to hyphens, non-`[\w-]` dropped) and compared against the anchor's own slug. Mismatches surface as `broken anchor`.

## Test plan
- [x] `python scripts/lint_docs.py` → exits 0 on current docs (the three pre-existing anchors validate cleanly)
- [x] Renaming an anchor in a referenced heading (`#context-propagation` → `#renamed-anchor`) reproduces the failure
- [x] `ruff format --check`, `ruff check`, `mypy --strict` all pass

Closes #173