### PR TITLE
Support SQLite offset diff and pct_change

### DIFF
--- a/docs/guides/data-operation-patterns/framework-support-matrix.md
+++ b/docs/guides/data-operation-patterns/framework-support-matrix.md
@@ -31,7 +31,7 @@ One-page lookup for "does operation *X* work on framework *Y*?". Rows are the te
 | binning | full | full | full | full | full |
 | datetime | full | full | full | full | full |
 | frame_aggregate | -- | full | full | full | full |
-| offset | -- | full | full | full | partial (4/6) |
+| offset | -- | full | full | full | full |
 | percentile | -- | full | full | full | -- |
 | rank | -- | full | full | full | full |
 | scalar_aggregate | full | full | full | full | partial (6/13) |
@@ -89,8 +89,8 @@ One-page lookup for "does operation *X* work on framework *Y*?". Rows are the te
 |---|---|---|---|---|---|
 | `lag` | -- | ✓ | ✓ | ✓ | ✓ |
 | `lead` | -- | ✓ | ✓ | ✓ | ✓ |
-| `diff` | -- | ✓ | ✓ | ✓ | ✗ |
-| `pct_change` | -- | ✓ | ✓ | ✓ | ✗ |
+| `diff` | -- | ✓ | ✓ | ✓ | ✓ |
+| `pct_change` | -- | ✓ | ✓ | ✓ | ✓ |
 | `first_value` | -- | ✓ | ✓ | ✓ | ✓ |
 | `last_value` | -- | ✓ | ✓ | ✓ | ✓ |
 
@@ -167,7 +167,7 @@ One-page lookup for "does operation *X* work on framework *Y*?". Rows are the te
 
 The three divergence kinds in [Known divergences](known-divergences.md) map to the detail tables as follows:
 
-- **Excluded subtype → ✗** (SQLite `upper` / `lower` / `reverse`, SQLite `percentile`, SQLite offset `diff` / `pct_change`, PyArrow aggregation/window `median` / `mode`): the framework has a test class for this operation, but the implementation refuses to match at resolution time and the test class's `supported_*()` override mirrors the refusal so inherited tests skip cleanly.
+- **Excluded subtype → ✗** (SQLite `upper` / `lower` / `reverse`, SQLite `percentile`, PyArrow aggregation/window `median` / `mode`): the framework has a test class for this operation, but the implementation refuses to match at resolution time and the test class's `supported_*()` override mirrors the refusal so inherited tests skip cleanly.
 - **Missing framework → `--`** (PyArrow `frame_aggregate`, `offset`, `percentile`, `rank`): no production implementation exists, and the framework has no test class for the operation. The operation requires native rolling / LAG / percentile / rank that PyArrow does not provide, and the reference implementation lives in pure Python over PyArrow arrays. Adding it requires a real framework implementation, not just relaxing an exclusion.
 - **Tolerance constrained, not marked**: float-accumulation tolerance is not exposed as ✗ or `--`; it shows up as `use_approx=True` on the relevant cross-framework assertions. See the "Float accumulation order" entry in Known divergences.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/sqlite_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/sqlite_offset.py
@@ -42,18 +42,28 @@ class SqliteOffset(OffsetFeatureGroup):
 
         if offset_type.startswith("lag_"):
             offset_n = int(offset_type[len("lag_") :])
-            offset_expr = f"LAG({quoted_source}, {offset_n})"
+            offset_expr = f"LAG({quoted_source}, {offset_n}) OVER ({window_clause})"
         elif offset_type.startswith("lead_"):
             offset_n = int(offset_type[len("lead_") :])
-            offset_expr = f"LEAD({quoted_source}, {offset_n})"
+            offset_expr = f"LEAD({quoted_source}, {offset_n}) OVER ({window_clause})"
+        elif offset_type.startswith("diff_"):
+            offset_n = int(offset_type[len("diff_") :])
+            prev = f"LAG({quoted_source}, {offset_n}) OVER ({window_clause})"
+            offset_expr = f"{quoted_source} - {prev}"
+        elif offset_type.startswith("pct_change_"):
+            offset_n = int(offset_type[len("pct_change_") :])
+            prev = f"LAG({quoted_source}, {offset_n}) OVER ({window_clause})"
+            offset_expr = (
+                f"CASE WHEN {prev} IS NOT NULL AND {prev} != 0 THEN ({quoted_source} - {prev}) * 1.0 / {prev} END"
+            )
         elif offset_type in ("first_value", "last_value"):
             return cls._compute_first_last(data, feature_name, source_col, partition_by, order_by, offset_type)
         else:
-            supported = "lag, lead, first_value, last_value"
+            supported = "lag, lead, diff, pct_change, first_value, last_value"
             raise ValueError(f"Unsupported offset type for SQLite: {offset_type}. Supported types: {supported}")
 
         sql = (
-            f"SELECT {offset_expr} OVER ({window_clause}) AS {quoted_feature}, "  # nosec
+            f"SELECT {offset_expr} AS {quoted_feature}, "  # nosec
             f"ROW_NUMBER() OVER (ORDER BY rowid) AS {qrn} "
             f"FROM {quote_ident(data.table_name)} ORDER BY {qrn}"
         )

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_sqlite.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_sqlite.py
@@ -2,49 +2,16 @@
 
 from __future__ import annotations
 
-import sqlite3
 from typing import Any
 
-import pytest
-
-from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation
-
 from mloda.community.feature_groups.data_operations.row_preserving.offset.sqlite_offset import SqliteOffset
-from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.testing.feature_groups.data_operations.mixins.sqlite import SqliteTestMixin
 from mloda.testing.feature_groups.data_operations.row_preserving.offset.offset import (
     OffsetTestBase,
-    make_feature_set,
 )
 
 
 class TestSqliteOffset(SqliteTestMixin, OffsetTestBase):
     @classmethod
-    def supported_offset_types(cls) -> set[str]:
-        return {"lag", "lead", "first_value", "last_value"}
-
-    @classmethod
     def implementation_class(cls) -> Any:
         return SqliteOffset
-
-
-class TestSqliteUnsupportedTypes:
-    """Verify that SQLite raises ValueError for unsupported offset types."""
-
-    def setup_method(self) -> None:
-        self.conn = sqlite3.connect(":memory:")
-        arrow_table = PyArrowDataOpsTestDataCreator.create()
-        self.test_data = SqliteRelation.from_arrow(self.conn, arrow_table)
-
-    def teardown_method(self) -> None:
-        self.conn.close()
-
-    def test_diff_raises_value_error(self) -> None:
-        fs = make_feature_set("value_int__diff_1_offset", ["region"], "value_int")
-        with pytest.raises(ValueError, match="Unsupported offset type for SQLite: diff_1"):
-            SqliteOffset.calculate_feature(self.test_data, fs)
-
-    def test_pct_change_raises_value_error(self) -> None:
-        fs = make_feature_set("value_int__pct_change_1_offset", ["region"], "value_int")
-        with pytest.raises(ValueError, match="Unsupported offset type for SQLite: pct_change_1"):
-            SqliteOffset.calculate_feature(self.test_data, fs)


### PR DESCRIPTION
Closes #197.

Summary:
- implement SQLite diff_N and pct_change_N offsets with LAG() window expressions
- enable the inherited SQLite offset reference-comparison tests for all offset types
- update the generated framework support matrix for SQLite offset support

Validation:
- uv run pytest mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_sqlite.py -q
- uv run pytest mloda/community/feature_groups/data_operations/row_preserving/offset/tests -q
- uv run pytest mloda/community/feature_groups/data_operations/tests/test_framework_support_matrix.py -q
- uv run ruff format --check --line-length 120 .
- uv run ruff check .
- uv run mypy --strict --ignore-missing-imports .
- uv run bandit -c pyproject.toml -r -q . -x .uv-cache,.tox,.venv

Notes:
- tox -e python314 could not run on this Windows host because tox.ini invokes sh -c and sh is not installed.
- Full pytest on Windows had one unrelated existing docs path separator assertion failure in tests/test_end2end/test_lint_docs.py::test_unlinked_subdir_index_is_flagged; the offset and matrix tests pass.