### PR TITLE
docs(agents): forbid Python fallbacks for CFW-unsupported inputs/ops

### DIFF
--- a/.claude/agents/green-agent.md
+++ b/.claude/agents/green-agent.md
@@ -41,7 +41,7 @@ When implementing a compute framework (CFW) backend, do not work around a missin
 
 **Precedents (see PR #204):**
 - `sqlite_time_bucketization._assert_source_column_is_timestamp` rejects non-UTC tz-aware sources because SQLite TEXT storage cannot encode IANA zones.
-- `duckdb_time_bucketization.TestDuckdbDateSourceRejected` covers rejection of bare `DATE` columns where sub-day rounding fails inside the engine.
+- `test_duckdb.TestDuckdbDateSourceRejected` covers up-front rejection of bare `DATE` columns, since sub-day bucket ops fail inside the engine.
 
 ## mloda Framework Knowledge
 - Understands plugin-based architecture (Feature Groups, Compute Frameworks, Extenders)

--- a/.claude/agents/green-agent.md
+++ b/.claude/agents/green-agent.md
@@ -27,7 +27,21 @@ Test-Driven Development Green Phase specialist. Writes minimal code to make fail
 - **NEVER** implement beyond what the tests require
 - **NEVER** add features not covered by failing tests
 - **NEVER** break existing tests
+- **NEVER** work around a missing CFW capability with a Python fallback inside the backend module
 - **MUST** validate all tests pass after implementation
+
+## CFW Backend Rules
+
+When implementing a compute framework (CFW) backend, do not work around a missing native capability by computing the result in Python (e.g. fetching rows, computing in Python, pushing them back). If the CFW cannot natively support the input or operation, reject it in `_assert_*` / validation with a clear `ValueError` that names the limitation and suggests an alternative backend. Loud rejection beats silent emulation.
+
+**Why:**
+- **Correctness drift.** Python-side emulation tends to diverge from engine semantics under edge cases (timezones, nulls, precision). The SQLite DST month-floor bug in PR #204 was a concrete example: a wall-clock-then-reattach SQL strategy gave a 1-hour error vs. PyArrow because SQLite TEXT storage loses the IANA zone.
+- **Hidden performance cliffs.** Pulling rows out of the engine into Python and re-pushing them is invisible at call time and orders of magnitude slower than the engine's native path.
+- **Hides scope problems.** If a backend can't support a feature, that should be loud (so the user picks a different backend or upstreams the gap), not papered over.
+
+**Precedents (see PR #204):**
+- `sqlite_time_bucketization._assert_source_column_is_timestamp` rejects non-UTC tz-aware sources because SQLite TEXT storage cannot encode IANA zones.
+- `duckdb_time_bucketization.TestDuckdbDateSourceRejected` covers rejection of bare `DATE` columns where sub-day rounding fails inside the engine.
 
 ## mloda Framework Knowledge
 - Understands plugin-based architecture (Feature Groups, Compute Frameworks, Extenders)

--- a/.claude/agents/red-agent.md
+++ b/.claude/agents/red-agent.md
@@ -25,6 +25,7 @@ Test-Driven Development Red Phase specialist. Creates failing tests that clearly
 ## Constraints
 - **NEVER** write implementation code - only tests
 - **NEVER** make tests pass - they must fail initially
+- **NEVER** write tests that exercise a Python fallback inside a CFW backend; for CFW-unsupported inputs/ops, write a rejection test that expects a `ValueError`
 - **MUST** validate test failures before completion
 - **MUST** ensure tests fail for the expected reasons, not due to syntax errors
 
@@ -33,6 +34,7 @@ Test-Driven Development Red Phase specialist. Creates failing tests that clearly
 - Follows mloda-registry project structure (tests/ directory)
 - Integrates with tox for test execution
 - Understands mloda-registry plugin architecture for testing
+- For CFW backends: when an input or operation is not natively supported, the test asserts a clear `ValueError` at validation rather than exercising a Python fallback (see the Green agent's "CFW Backend Rules" section and the rejection precedents in PR #204).
 
 ## Workflow
 1. Analyze the requirements to be tested

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 4. **Validation**: Ensure tests pass and no regressions
 5. **Repeat**: Continue cycle for next requirement
 
+## CFW Backend Rejection over Python Fallback
+
+When a compute framework backend cannot natively support an input or operation, reject it up-front with a clear `ValueError` rather than computing the result in Python inside the backend module. Both Red and Green agents must follow this rule (see `.claude/agents/green-agent.md` "CFW Backend Rules" for the full statement, rationale, and precedents; the Red agent writes a rejection test, not a fallback test). Reviewers should enforce it as well.
+
 ## Deadlock Protection
 
 **CRITICAL**: If Red or Green agents get stuck or fail repeatedly:


### PR DESCRIPTION
## Summary

Documents the rule from #206: when a compute framework (CFW) backend cannot natively support an input or operation, reject it up-front with a clear `ValueError` rather than computing the result in Python inside the backend module.

- **`green-agent.md` (primary owner):** new `## CFW Backend Rules` section with the rule, rationale (correctness drift / hidden performance cliffs / hides scope problems), and precedents; plus a new `NEVER` line in `## Constraints`.
- **`red-agent.md` (secondary):** symmetric `NEVER` line and a `Testing Framework Knowledge` bullet so Red writes a rejection test, not a fallback test.
- **`CLAUDE.md`:** brief cross-reference between the TDD Workflow and Deadlock Protection sections so reviewers also enforce it.

Precedents are cited by symbol name with `(see PR #204)` because they live on the still-open `feat/time-bucketization` branch (#204) rather than `main`. Both names verified to exist in that PR's current diff:
- `sqlite_time_bucketization._assert_source_column_is_timestamp`
- `duckdb_time_bucketization.TestDuckdbDateSourceRejected`

No tooling change (per the issue's DoD).

## Definition of done (from #206)

- [x] Rule documented in the Green agent instructions (primary owner)
- [x] Cross-referenced briefly in `CLAUDE.md`
- [x] Examples link to existing rejection precedents
- [x] No tooling change required

## Test plan

- [ ] Skim the diff for tone match with the rest of `.claude/agents/`
- [ ] Confirm the precedent names still resolve once #204 lands on main; if either symbol gets renamed, follow up with a small docs commit

Closes #206