### PR TITLE
docs(guides): rename nonexistent ConnectionMatcherMixin to MatchData in 2 guides

### DIFF
--- a/docs/guides/compute-framework-patterns/03-stateful-connection.md
+++ b/docs/guides/compute-framework-patterns/03-stateful-connection.md
@@ -69,4 +69,4 @@ result = mloda.run_all(
 
 - **Category 1**: Inherits base structure
 - **Merge Engine** (Concept 6): Connection passed to merge engine
-- **ConnectionMatcherMixin**: Match feature groups to connections
+- **MatchData**: Match feature groups to connections

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -19,7 +19,7 @@ The default `match_feature_group_criteria()` checks in order:
 
 ```text
 1. Input data match     → Root features with matching input_data()
-2. Data access match    → ConnectionMatcherMixin with data connection
+2. Data access match    → MatchData mixin with data connection
 3. Exact class name     → "MyFeature" == class MyFeature
 4. Prefix match         → "MyFeature_x".startswith("MyFeature_")
 5. Explicit names       → name in feature_names_supported()


### PR DESCRIPTION
## Summary

Renames the stale `ConnectionMatcherMixin` references in two guides to `MatchData`, the actual `mloda.provider` export. `ConnectionMatcherMixin` is a symbol mloda does not (and never did) export, so a reader grepping for it found a class that cannot be imported.

## Changes

- `docs/guides/feature-group-patterns/14-feature-matching.md:22` — matching-priority line now reads `MatchData mixin with data connection` (matches the phrasing already used in guide 17).
- `docs/guides/compute-framework-patterns/03-stateful-connection.md:72` — Combines With entry now reads `**MatchData**: Match feature groups to connections`.

## Verification

- `grep -rn ConnectionMatcherMixin docs/` → no matches.
- `from mloda.provider import MatchData` imports cleanly; `ConnectionMatcherMixin` raises ImportError.
- Docs-only; no code change.

Closes #219