### PR TITLE
docs(agents): make CFW-rejection precedent pointers durable (closes #208)

### DIFF
--- a/.claude/agents/green-agent.md
+++ b/.claude/agents/green-agent.md
@@ -39,9 +39,9 @@ When implementing a compute framework (CFW) backend, do not work around a missin
 - **Hidden performance cliffs.** Pulling rows out of the engine into Python and re-pushing them is invisible at call time and orders of magnitude slower than the engine's native path.
 - **Hides scope problems.** If a backend can't support a feature, that should be loud (so the user picks a different backend or upstreams the gap), not papered over.
 
-**Precedents (see PR #204):**
-- `sqlite_time_bucketization._assert_source_column_is_timestamp` rejects non-UTC tz-aware sources because SQLite TEXT storage cannot encode IANA zones.
-- `test_duckdb.TestDuckdbDateSourceRejected` covers up-front rejection of bare `DATE` columns, since sub-day bucket ops fail inside the engine.
+**Precedents:**
+- `sqlite_time_bucketization._assert_source_column_is_timestamp` (`mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/sqlite_time_bucketization.py`) rejects non-UTC tz-aware sources because SQLite TEXT storage cannot encode IANA zones.
+- `test_duckdb.TestDuckdbDateSourceRejected` (`mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py`) covers up-front rejection of bare `DATE` columns, since sub-day bucket ops fail inside the engine.
 
 ## mloda Framework Knowledge
 - Understands plugin-based architecture (Feature Groups, Compute Frameworks, Extenders)

--- a/.claude/agents/red-agent.md
+++ b/.claude/agents/red-agent.md
@@ -34,7 +34,7 @@ Test-Driven Development Red Phase specialist. Creates failing tests that clearly
 - Follows mloda-registry project structure (tests/ directory)
 - Integrates with tox for test execution
 - Understands mloda-registry plugin architecture for testing
-- For CFW backends: when an input or operation is not natively supported, the test asserts a clear `ValueError` at validation rather than exercising a Python fallback (see the Green agent's "CFW Backend Rules" section and the rejection precedents in PR #204).
+- For CFW backends: when an input or operation is not natively supported, the test asserts a clear `ValueError` at validation rather than exercising a Python fallback (see the Green agent's "CFW Backend Rules" section and the rejection precedents it cites: `sqlite_time_bucketization._assert_source_column_is_timestamp` and `test_duckdb.TestDuckdbDateSourceRejected`).
 
 ## Workflow
 1. Analyze the requirements to be tested


### PR DESCRIPTION
## Summary

Closes #208. PR #204 has merged to `main`, so the two CFW-rejection precedent symbols now resolve on `main`. This replaces the temporary `(see PR #204)` qualifiers with durable references.

- `green-agent.md` — `**Precedents:**` now cites the source file path next to each symbol instead of pointing at PR #204.
- `red-agent.md` — names the precedent symbols inline instead of referencing "the rejection precedents in PR #204".

## Definition of done

- [x] Confirmed both precedent symbols resolve on `main`:
  - `sqlite_time_bucketization._assert_source_column_is_timestamp` (`mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/sqlite_time_bucketization.py`)
  - `test_duckdb.TestDuckdbDateSourceRejected` (`mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py`)
- [x] Replaced the `(see PR #204)` qualifiers with durable references (file paths / inline symbol names).
- [x] Neither symbol was renamed before #204 landed, so no citation updates were needed.

## Notes

The remaining `PR #204` mention on `green-agent.md` line 38 ("The SQLite DST month-floor bug in PR #204 was a concrete example") is intentionally kept: it is a historical pointer to where a documented bug was found, not a symbol-resolution pointer, and a merged PR number is itself durable.

Docs-only change; no code or tests affected.