### PR TITLE
docs(guides): document DataTypeMismatchError enforcement in data-type-extraction guide

### DIFF
--- a/docs/guides/compute-framework-patterns/10-data-type-extraction.md
+++ b/docs/guides/compute-framework-patterns/10-data-type-extraction.md
@@ -90,3 +90,48 @@ def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | N
 
     return None
 ```
+
+## Validation and Mismatches
+
+After a feature is computed, mloda's `DataTypeValidator` compares the feature's declared
+`data_type` (from `return_data_type_rule()`) against the type your hook reports for the produced
+column. Validation is **skipped** whenever the feature declares no `data_type` or your hook returns
+`None`, so a framework that never overrides the hook silently performs no enforcement.
+
+When both types are present, a mismatch raises `DataTypeMismatchError`:
+
+```text
+Feature 'price': declared STRING, got INT64, coercion not supported
+```
+
+Compatibility is checked in one of two modes, selected per run via `strict_type_enforcement` on
+`mloda.run_all` (default `False`):
+
+| Mode | Flag | Rule |
+|------|------|------|
+| Lenient (default) | `strict_type_enforcement=False` | Any numeric type (`INT32`, `INT64`, `FLOAT`, `DOUBLE`) is interchangeable with any other numeric type; any timestamp type is interchangeable with any other timestamp type; every other type must match exactly. |
+| Strict | `strict_type_enforcement=True` | Only safe widening is allowed — a declared type accepts a narrower actual type: declared `INT64` accepts actual `INT32`; declared `DOUBLE` accepts actual `INT32`/`INT64`/`FLOAT`; declared `TIMESTAMP_MICROS` accepts actual `TIMESTAMP_MILLIS`. Every other pairing, including narrowing, must match exactly. |
+
+### Worked Example
+
+A feature declares `DataType.INT32` and the framework produces a `DOUBLE` column:
+
+```python
+result = mloda.run_all(features)                              # lenient: INT32 vs DOUBLE → OK (both numeric)
+result = mloda.run_all(features, strict_type_enforcement=True)  # strict: DOUBLE is a narrowing of INT32 → DataTypeMismatchError
+```
+
+Because your hook is the only thing that reports the *actual* produced type, returning an accurate
+`DataType` is what makes strict end-to-end enforcement possible; returning `None` opts the column out
+of the check entirely.
+
+## Real Implementations
+
+| File | Description |
+|------|-------------|
+| [compute_framework.py](https://github.com/mloda-ai/mloda/blob/main/mloda/core/abstract_plugins/compute_framework.py) | `_extract_column_data_type` hook + `run_validate_output_features` |
+| [datatype_validator.py](https://github.com/mloda-ai/mloda/blob/main/mloda/core/abstract_plugins/components/validators/datatype_validator.py) | `DataTypeValidator`, `DataTypeMismatchError`, strict/lenient rules |
+| [python_dict_framework.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py) | Canonical minimal `_extract_column_data_type` override |
+
+See the companion core-docs ticket [mloda-ai/mloda#465](https://github.com/mloda-ai/mloda/issues/465)
+for the conceptual reference on the hook and `return_data_type_rule` enforcement.


### PR DESCRIPTION
## Summary

Completes the remaining scope of #217. The `_extract_column_data_type` hook itself was already documented in `docs/guides/compute-framework-patterns/10-data-type-extraction.md` (added in #2faacfa, the day before the issue was filed), so this PR fills the three gaps that remained against the issue's Definition of Done:

- **`DataTypeMismatchError`** — now named, with the exact raised message as a worked example.
- **Strict vs lenient compatibility** — documents the two modes selected by `strict_type_enforcement` on `mloda.run_all` (default lenient), with the precise widening/intra-category rules and a side-by-side worked example.
- **Cross-reference to core** — adds a Real Implementations table linking the core hook, `DataTypeValidator`, the canonical `python_dict` override, and the companion core-docs ticket mloda-ai/mloda#465.

No code change in mloda core is required — the enforcement mechanism is fully implemented in 0.7.0; this is documentation only.

## Verification

Rules in the guide were cross-checked against `mloda/core/abstract_plugins/components/validators/datatype_validator.py` (`_COMPATIBLE_TYPES`, `_types_compatible`, `_types_loosely_compatible`) and the `strict_type_enforcement` flag in `mloda/core/api/request.py`. Docs-only; no markdown linter is configured in the repo and all fenced blocks carry language tags.

Closes #217