### PR TITLE
refactor(data_operations): adopt ORDER BY rowid in sqlite time_bucketization (closes #215)

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/sqlite_time_bucketization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/sqlite_time_bucketization.py
@@ -32,8 +32,8 @@ Ordering
 --------
 
 ``calculate_feature`` is invoked many times in a single mloda run, so the
-SQL projection assigns ``ROW_NUMBER() OVER (ORDER BY rowid)`` and re-sorts
-on it before fetching, mirroring the tag-and-restore pattern in
+SQL projection re-sorts on ``rowid`` (``ORDER BY rowid``) before fetching to
+return results in input order, mirroring the tag-and-restore pattern in
 ``sqlite_datetime.py``.
 """
 
@@ -286,22 +286,20 @@ class SqliteTimeBucketization(TimeBucketizationFeatureGroup):
             round_expr = cls._round_expression(local_src, n, unit, floor_expr)
             bucket_expr = f"({round_expr}) || {tz_suffix}"
 
-        # Compute the result via a tag-and-restore SQL projection. ROW_NUMBER
-        # over rowid preserves input order; the outer SELECT sorts on it.
-        rn = "__mloda_rn__"
-        qrn = quote_ident(rn)
+        # Project the bucket value directly and re-sort on ``rowid`` so the
+        # results come back in input order, mirroring the tag-and-restore
+        # pattern in ``sqlite_datetime.py``. No window function is needed: the
+        # ordering is fully expressed by ``ORDER BY rowid``.
         quoted_feature = quote_ident(feature_name)
         quoted_table = quote_ident(data.table_name)
-        existing_cols = ", ".join(quote_ident(c) for c in data.columns)
 
         sql = (
-            f"SELECT {existing_cols}, {bucket_expr} AS {quoted_feature} "  # nosec
-            f"FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY rowid) AS {qrn} FROM {quoted_table}) "
-            f"ORDER BY {qrn}"
+            f"SELECT {bucket_expr} AS {quoted_feature} "  # nosec
+            f"FROM {quoted_table} "
+            f"ORDER BY rowid"
         )
         cursor = data.connection.execute(sql)
-        rows = cursor.fetchall()
-        result_values = [row[-1] for row in rows]
+        result_values = [row[0] for row in cursor.fetchall()]
 
         return data.append_column(feature_name, result_values)
 


### PR DESCRIPTION
## Summary

Closes #215. Removes the last hand-rolled `ROW_NUMBER() OVER (...)` SQL string in the `data_operations` tree, in `sqlite_time_bucketization.py`.

**Scope note:** PR #222 (closes #181), merged shortly after #215 was filed, already migrated **every file #215 explicitly lists** (window_aggregation, frame_aggregate, percentile, offset, binning, scalar_aggregate, rank). A case-insensitive sweep of the whole `data_operations/` tree shows the only remaining raw window string was in `sqlite_time_bucketization.py`, a file added in parallel (commit `dced6c2`) that #222 never touched. This PR finishes the one file #222 missed, restoring the `grep "OVER ("` == 0 invariant #222 established.

## Change

In `_compute_bucket`, the `ROW_NUMBER() OVER (ORDER BY rowid)` subquery was used **purely for ordering** (the helper fed only `ORDER BY`, and the code read `row[-1]` for the bucket value anyway). It needs no window function. The result is now projected directly with `ORDER BY rowid`:

```python
sql = (
    f"SELECT {bucket_expr} AS {quoted_feature} "  # nosec
    f"FROM {quoted_table} "
    f"ORDER BY rowid"
)
result_values = [row[0] for row in cursor.fetchall()]
return data.append_column(feature_name, result_values)
```

This mirrors the post-#222 sibling `sqlite_datetime.py` (which this file's docstring already cites as its pattern). The module docstring "Ordering" section is updated to match. `with_row_number()` ceremony would be redundant where `ORDER BY rowid` already fully expresses the ordering, so it is deliberately not used (consistent with `sqlite_datetime`).

## Deliberately not changed

`assert_no_reserved_columns()` is kept: `tests/test_sqlite.py` (`ReservedColumnsTestMixin`) asserts the SQLite compute calls it. Removing it would break existing tests and pull in the separate reserved-columns self-protection convention (#181/#221), which is out of scope for #215.

## Definition of done

- [x] No raw `OVER (...)` strings remain in `data_operations/` (only a harmless `rollover (` comment).
- [x] Existing tests stay green: time_bucketization suite 290 passed; full `tox` gate 3349 passed / 128 skipped, ruff format + check clean, `mypy --strict` clean, bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)