### PR TITLE
docs: add SECURITY.md and pull-request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for contributing to mloda-registry! A few notes before you submit:
+- Use a Conventional Commit style PR title (e.g. `fix:`, `feat:`, `docs:`, `chore:`).
+- Keep the description focused; delete sections that don't apply.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? One or two sentences is plenty. -->
+
+## Related issue
+
+<!-- Link the issue this closes, e.g. "Closes #123". Leave blank if none. -->
+Closes #
+
+## Type of change
+
+- [ ] Bug fix (`fix:`)
+- [ ] New feature / new plugin (`feat:`)
+- [ ] Documentation (`docs:`)
+- [ ] Refactor / maintenance (`refactor:` / `chore:`)
+- [ ] Other (explain below)
+
+## Checklist
+
+- [ ] `uv run tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`)
+- [ ] Tests added or updated for the change
+- [ ] Documentation updated where relevant
+- [ ] `pyproject.toml` not edited by hand (regenerated from `config/` via `scripts/generate_pyproject.py` if dependencies changed)
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+mloda-registry is a workspace of community and enterprise plugins under active
+development. Security fixes are applied to the latest state of the `main`
+branch and the most recent published packages. We do not backport fixes to
+older releases — please upgrade to the latest version before reporting.
+
+| Version        | Supported          |
+| -------------- | ------------------ |
+| Latest release | :white_check_mark: |
+| Older releases | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.** This keeps users protected while a fix is
+prepared.
+
+Instead, use one of these private channels:
+
+1. **GitHub Private Vulnerability Reporting** (preferred) — open the
+   [Security tab](https://github.com/mloda-ai/mloda-registry/security/advisories/new)
+   and click **Report a vulnerability**. This keeps the report, discussion, and
+   coordinated disclosure in one place.
+2. **Email** — write to **security@mloda.ai**. Encrypt with our PGP key on
+   request if the details are sensitive.
+
+Please include as much of the following as you can:
+
+- The type of issue (e.g. injection, path traversal, deserialization,
+  dependency vulnerability).
+- The affected plugin, package, module, or file path (`file.py:line` if known).
+- Step-by-step reproduction or a proof of concept.
+- The potential impact and any suggested mitigation.
+
+## What to Expect
+
+- We'll get in touch to acknowledge your report.
+- We'll assess the severity and keep you updated as we work toward a fix.
+- We're happy to credit you in the advisory once it's published, unless you
+  prefer to remain anonymous.
+
+We follow coordinated disclosure: we ask that you give us a reasonable window
+to release a fix before any public disclosure. Thank you for helping keep mloda
+and its users safe.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,8 +24,7 @@ Instead, use one of these private channels:
    [Security tab](https://github.com/mloda-ai/mloda-registry/security/advisories/new)
    and click **Report a vulnerability**. This keeps the report, discussion, and
    coordinated disclosure in one place.
-2. **Email** — write to **security@mloda.ai**. Encrypt with our PGP key on
-   request if the details are sensitive.
+2. **Email** — write to **security@mloda.ai**.
 
 Please include as much of the following as you can:
 


### PR DESCRIPTION
## Summary

Adds the two community-health files flagged as missing on the repo's
Community Standards page: a security policy and a pull-request template.

Closes #228.

## What's included

**`SECURITY.md`**
- Private disclosure channels: GitHub Private Vulnerability Reporting (preferred) and `security@mloda.ai` — mirroring the existing `conduct@mloda.ai` convention in `CODE_OF_CONDUCT.md`.
- Supported-versions note reflecting the workspace's latest-only, no-backport model.
- A checklist of useful detail to include in a report, a get-in-touch response commitment, and a coordinated-disclosure ask.

**`.github/PULL_REQUEST_TEMPLATE.md`**
- Summary, related-issue (blank `Closes #` placeholder), type-of-change, and a checklist anchored to the real gate: `uv run tox` (tests, `ruff`, `mypy --strict`, `bandit`), conventional-commit title, and the registry's "don't hand-edit `pyproject.toml`" rule.
- No issue-template frontmatter (which GitHub does not parse for PR templates).

## Notes

Docs-only change — no Python or tests affected, so the `tox` suite is unaffected. Mirrors the equivalent core-repo change in mloda-ai/mloda#471.