### PR TITLE
fix(data_operations): pin DuckDB session timezone to UTC for time_bucketization (closes #238)

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
@@ -124,14 +124,8 @@ class DuckdbTimeBucketization(TimeBucketizationFeatureGroup):
         if op not in TIME_BUCKETIZATION_OPS:
             raise ValueError(f"Unsupported bucket op {op!r} for DuckDB; supported: {sorted(TIME_BUCKETIZATION_OPS)}.")
 
-        # Pin the session timezone to UTC and leave it set (issue #238).
-        # DuckDB relations are LAZY: DATE_TRUNC/time_bucket and the TIMESTAMPTZ
-        # rendering are evaluated at materialization (to_arrow_table), which
-        # happens outside this method. They use the connection's session zone,
-        # so on a non-UTC session they produce wrong instants. We must NOT
-        # save+restore the prior zone (it would be restored before lazy
-        # evaluation runs); set it persistently so bucketing stays UTC-anchored
-        # regardless of the host/session zone.
+        # Pin the session timezone to UTC so DATE_TRUNC/time_bucket stay
+        # UTC-anchored regardless of the host/session zone (issue #238).
         data.connection.execute("SET TimeZone='UTC'")
 
         quoted_source = quote_ident(source_col)

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
@@ -124,6 +124,16 @@ class DuckdbTimeBucketization(TimeBucketizationFeatureGroup):
         if op not in TIME_BUCKETIZATION_OPS:
             raise ValueError(f"Unsupported bucket op {op!r} for DuckDB; supported: {sorted(TIME_BUCKETIZATION_OPS)}.")
 
+        # Pin the session timezone to UTC and leave it set (issue #238).
+        # DuckDB relations are LAZY: DATE_TRUNC/time_bucket and the TIMESTAMPTZ
+        # rendering are evaluated at materialization (to_arrow_table), which
+        # happens outside this method. They use the connection's session zone,
+        # so on a non-UTC session they produce wrong instants. We must NOT
+        # save+restore the prior zone (it would be restored before lazy
+        # evaluation runs); set it persistently so bucketing stays UTC-anchored
+        # regardless of the host/session zone.
+        data.connection.execute("SET TimeZone='UTC'")
+
         quoted_source = quote_ident(source_col)
         quoted_feature = quote_ident(feature_name)
         floor_expr = _floor_expr(quoted_source, n, unit)

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py
@@ -13,7 +13,9 @@ from mloda.community.feature_groups.data_operations.row_preserving.time_bucketiz
 )
 from mloda.testing.feature_groups.data_operations.mixins.duckdb import DuckdbTestMixin
 from mloda.testing.feature_groups.data_operations.row_preserving.time_bucketization.time_bucketization import (
+    EXPECTED_FLOOR_1_DAY,
     TimeBucketizationTestBase,
+    _create_bucket_arrow_table,
 )
 
 
@@ -48,3 +50,45 @@ class TestDuckdbDateSourceRejected:
         fs = make_feature_set("timestamp__floor_1_day")
         with pytest.raises(ValueError, match=r"(?i)timestamp|datetime|DATE"):
             DuckdbTimeBucketization.calculate_feature(rel, fs)
+
+
+class TestDuckdbTimeBucketizationNonUtcSession:
+    """Bucketization must produce UTC-anchored instants regardless of session TZ (issue #238).
+
+    DuckDB's ``DATE_TRUNC`` / ``time_bucket`` operate in the connection's
+    session timezone. On a non-UTC session, a UTC input such as
+    ``2023-01-01 00:00 UTC`` floors to *local* midnight (a different instant)
+    instead of UTC midnight. The feature group must pin the session timezone
+    to UTC inside ``_compute_bucket`` so the result is correct no matter what
+    the session timezone was preset to.
+
+    This test builds its own connection (rather than the mixin's) so it can
+    deterministically reproduce the bug by setting a non-UTC session timezone,
+    independent of the host OS timezone.
+    """
+
+    def test_floor_1_day_utc_anchored_on_non_utc_session(self) -> None:
+        import duckdb
+        from datetime import datetime
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
+        from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+
+        con = duckdb.connect()
+        # Preset a NON-UTC session timezone; this is what triggers the bug.
+        con.execute("SET TimeZone='America/New_York'")
+
+        rel = DuckdbRelation.from_arrow(con, _create_bucket_arrow_table())
+        fs = make_feature_set("timestamp__floor_1_day")
+        result = DuckdbTimeBucketization.calculate_feature(rel, fs)
+
+        col = list(result.to_arrow_table().column("timestamp__floor_1_day").to_pylist())
+
+        assert len(col) == len(EXPECTED_FLOOR_1_DAY), f"row count {len(col)} != expected {len(EXPECTED_FLOOR_1_DAY)}"
+        for i, (actual, expected) in enumerate(zip(col, EXPECTED_FLOOR_1_DAY)):
+            if expected is None:
+                assert actual is None, f"row {i}: expected None, got {actual!r}"
+            else:
+                # Both are tz-aware datetimes; ``==`` compares instants.
+                if isinstance(actual, str):
+                    actual = datetime.fromisoformat(actual)
+                assert actual == expected, f"row {i}: {actual!r} != {expected!r}"


### PR DESCRIPTION
## Summary

Fixes #238. The DuckDB `time_bucketization` tests failed on any host whose session/OS timezone is not UTC. DuckDB's `DATE_TRUNC` / `time_bucket` operate in the connection's **session timezone** (derived from the OS), so a UTC input such as `2023-01-01 00:00 UTC` floored to *local* midnight, producing a different instant (off by the UTC offset) tagged with the local zone. The UTC expected fixtures then failed the instant-level `==` comparison. CI runs in UTC, so the breakage only surfaced on developer machines in other zones (18 failures observed under `TZ=Europe/Berlin`).

This is a genuine instant-level discrepancy, not just a zone-label mismatch: `2023-01-01 00:00 UTC` came back as `2023-01-01 00:00 CET` (= `2022-12-31 23:00 UTC`). A comparison-only loosening would have masked it.

## Fix

Pin the session timezone to UTC on the relation's connection inside `DuckdbTimeBucketization._compute_bucket`, and leave it set:

```python
data.connection.execute("SET TimeZone='UTC'")
```

This makes `DATE_TRUNC` / `time_bucket` evaluate in UTC and the rendered `TIMESTAMPTZ` carry UTC. It is **not** save+restored: DuckDB relations are lazy, and the truncation + rendering are evaluated at materialization (`to_arrow_table`) outside this method, so restoring the prior zone would re-introduce the bug.

**mloda core:** no change needed. The DuckDB compute framework and `DuckdbRelation` live in core, but the fix lives entirely in this registry repo's feature group, which already has access to the connection via the public `data.connection` property. Only the DuckDB backend is touched.

## Test

Added `TestDuckdbTimeBucketizationNonUtcSession`, which builds its own connection, presets a non-UTC session timezone (`America/New_York`), and asserts UTC-anchored output. It reproduces the bug **deterministically regardless of the host OS timezone** (verified failing on `main` under `TZ=UTC`, `TZ=Asia/Tokyo`, and unset TZ).

## Definition of done

- [x] DuckDB `time_bucketization` tests pass under both `TZ=UTC` and `TZ=Europe/Berlin` (38 passed each).
- [x] Fix targets timezone handling (session pinned to UTC), not the assertion.
- [x] No regression to SQLite/pandas/polars/pyarrow paths (full tb suite: 291 passed under Berlin).
- [x] Full `tox` gate green (pytest 3604 passed, ruff format, ruff check, mypy --strict, bandit).