### PR TITLE
feat(data_operations): declare return_data_type_rule for deterministic-output ops (#216)

### DIFF
--- a/mloda/community/feature_groups/data_operations/aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/base.py
@@ -192,7 +192,7 @@ class AggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Declare INT64 for count/nunique (counting ops); other aggregates stay open."""
         try:
             agg_type = cls._extract_aggregation_type(feature)
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         if agg_type in {"count", "nunique"}:
             return DataType.INT64

--- a/mloda/community/feature_groups/data_operations/aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -185,6 +186,17 @@ class AggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if agg_type is None:
             raise ValueError(f"Could not extract aggregation type for {feature_name}")
         return str(agg_type)
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare INT64 for count/nunique (counting ops); other aggregates stay open."""
+        try:
+            agg_type = cls._extract_aggregation_type(feature)
+        except Exception:
+            return None
+        if agg_type in {"count", "nunique"}:
+            return DataType.INT64
+        return None
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
@@ -299,6 +299,34 @@ class TestConfigBasedFeatures:
         assert result_map[None] == -10
 
 
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type only for deterministic ops.
+
+    count/nunique always return INT64 regardless of input. sum/avg depend on
+    the input column type, so the rule must return None for them.
+    """
+
+    @pytest.mark.parametrize("operation", ["count", "nunique"])
+    def test_deterministic_ops_return_int64(self, operation: str) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature(
+            f"value_int__{operation}_agg",
+            options=Options(context={"partition_by": ["region"]}),
+        )
+        assert AggregationFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+    @pytest.mark.parametrize("operation", ["sum", "avg"])
+    def test_input_dependent_ops_return_none(self, operation: str) -> None:
+        from mloda.user import Feature
+
+        feature = Feature(
+            f"value_int__{operation}_agg",
+            options=Options(context={"partition_by": ["region"]}),
+        )
+        assert AggregationFeatureGroup.return_data_type_rule(feature) is None
+
+
 class TestAggregationMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
@@ -8,6 +8,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
@@ -308,8 +309,6 @@ class TestReturnDataTypeRule:
 
     @pytest.mark.parametrize("operation", ["count", "nunique"])
     def test_deterministic_ops_return_int64(self, operation: str) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature(
             f"value_int__{operation}_agg",
             options=Options(context={"partition_by": ["region"]}),
@@ -318,8 +317,6 @@ class TestReturnDataTypeRule:
 
     @pytest.mark.parametrize("operation", ["sum", "avg"])
     def test_input_dependent_ops_return_none(self, operation: str) -> None:
-        from mloda.user import Feature
-
         feature = Feature(
             f"value_int__{operation}_agg",
             options=Options(context={"partition_by": ["region"]}),

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -229,7 +229,7 @@ class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         try:
             op_token = cls._extract_resample_op(feature)
             _, _, agg = _parse_resample_op(op_token)
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         if agg == "count":
             return DataType.INT64

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -221,6 +222,18 @@ class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if time_column is None:
             raise ValueError("resample requires a 'time_column' in Options context.")
         return str(time_column)
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare INT64 for count buckets; other aggregations stay open."""
+        try:
+            op_token = cls._extract_resample_op(feature)
+            _, _, agg = _parse_resample_op(op_token)
+        except Exception:
+            return None
+        if agg == "count":
+            return DataType.INT64
+        return None
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_changing.resample.base import (
     ResampleFeatureGroup,
@@ -19,14 +20,10 @@ class TestReturnDataTypeRule:
     """
 
     def test_count_returns_int64(self) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature("value__resample_5_minute_count", options=Options())
         assert ResampleFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 
     @pytest.mark.parametrize("agg", ["mean", "sum"])
     def test_input_dependent_ops_return_none(self, agg: str) -> None:
-        from mloda.user import Feature
-
         feature = Feature(f"value__resample_5_minute_{agg}", options=Options())
         assert ResampleFeatureGroup.return_data_type_rule(feature) is None

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
@@ -1,0 +1,32 @@
+"""Tests for ResampleFeatureGroup base class."""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.core.abstract_plugins.components.options import Options
+
+from mloda.community.feature_groups.data_operations.row_changing.resample.base import (
+    ResampleFeatureGroup,
+)
+
+
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type only for deterministic ops.
+
+    A bucket count always returns INT64. mean / sum depend on the input column
+    type, so the rule must return None for them.
+    """
+
+    def test_count_returns_int64(self) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature("value__resample_5_minute_count", options=Options())
+        assert ResampleFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+    @pytest.mark.parametrize("agg", ["mean", "sum"])
+    def test_input_dependent_ops_return_none(self, agg: str) -> None:
+        from mloda.user import Feature
+
+        feature = Feature(f"value__resample_5_minute_{agg}", options=Options())
+        assert ResampleFeatureGroup.return_data_type_rule(feature) is None

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -87,7 +87,7 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Declare INT64: both bin and qbin emit integer bin indices."""
         try:
             op, _ = cls._extract_binning_params(feature)
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         if op in {"bin", "qbin"}:
             return DataType.INT64

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -80,6 +81,17 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         n_bins = int(n)
         cls._validate_n_bins(n_bins, feature_name)
         return str(op), n_bins
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare INT64: both bin and qbin emit integer bin indices."""
+        try:
+            op, _ = cls._extract_binning_params(feature)
+        except Exception:
+            return None
+        if op in {"bin", "qbin"}:
+            return DataType.INT64
+        return None
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         _feature_name = str(feature_name)

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -8,6 +8,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.binning.base import (
     BINNING_OPS,
@@ -131,14 +132,10 @@ class TestReturnDataTypeRule:
     """
 
     def test_bin_returns_int64(self) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature("value_int__bin_5", options=Options())
         assert BinningFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 
     def test_qbin_returns_int64(self) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature("value_int__qbin_4", options=Options())
         assert BinningFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -124,6 +124,25 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type for deterministic ops.
+
+    Both bin and qbin emit integer bin indices, so the rule returns INT64.
+    """
+
+    def test_bin_returns_int64(self) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature("value_int__bin_5", options=Options())
+        assert BinningFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+    def test_qbin_returns_int64(self) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature("value_int__qbin_4", options=Options())
+        assert BinningFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+
 class TestBinningMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
@@ -131,7 +131,7 @@ class DateTimeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Declare the deterministic output type: all datetime ops are integer-valued."""
         try:
             cls._extract_datetime_op(feature)
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         return DataType.INT64
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -124,6 +125,15 @@ class DateTimeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if op is None:
             raise ValueError(f"Could not extract datetime operation for {feature_name}")
         return str(op)
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare the deterministic output type: all datetime ops are integer-valued."""
+        try:
+            cls._extract_datetime_op(feature)
+        except Exception:
+            return None
+        return DataType.INT64
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         _feature_name = str(feature_name)

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
@@ -8,6 +8,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.datetime.base import (
     DATETIME_OPS,
@@ -126,8 +127,6 @@ class TestReturnDataTypeRule:
         ["year", "month", "day", "hour", "minute", "second", "dayofweek", "is_weekend", "quarter"],
     )
     def test_deterministic_ops_return_int64(self, operation: str) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature(f"timestamp__{operation}", options=Options())
         assert DateTimeFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
@@ -114,6 +114,24 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type for deterministic ops.
+
+    All datetime ops are deterministic integer extractions (is_weekend is
+    implemented as integer 1/0, so INT64 rather than BOOLEAN).
+    """
+
+    @pytest.mark.parametrize(
+        "operation",
+        ["year", "month", "day", "hour", "minute", "second", "dayofweek", "is_weekend", "quarter"],
+    )
+    def test_deterministic_ops_return_int64(self, operation: str) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature(f"timestamp__{operation}", options=Options())
+        assert DateTimeFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+
 class TestDateTimeMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -323,6 +324,17 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "partition_by": feature.options.get(cls.PARTITION_BY),
             "order_by": feature.options.get(cls.ORDER_BY),
         }
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare INT64 for count (a counting op); other aggregates stay open."""
+        try:
+            agg_type = cls._extract_params(feature)["agg_type"]
+        except Exception:
+            return None
+        if agg_type == "count":
+            return DataType.INT64
+        return None
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -330,7 +330,7 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Declare INT64 for count (a counting op); other aggregates stay open."""
         try:
             agg_type = cls._extract_params(feature)["agg_type"]
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         if agg_type == "count":
             return DataType.INT64

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -254,6 +254,32 @@ class TestExtractParams:
         assert params["partition_by"] == ["region"]
 
 
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type only for deterministic ops.
+
+    A rolling count always returns INT64. A rolling sum depends on the input
+    column type, so the rule must return None for it.
+    """
+
+    def test_count_returns_int64(self) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature(
+            "sales__count_rolling_3",
+            options=Options(context={"partition_by": ["region"], "order_by": "timestamp"}),
+        )
+        assert FrameAggregateFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+    def test_sum_returns_none(self) -> None:
+        from mloda.user import Feature
+
+        feature = Feature(
+            "sales__sum_rolling_3",
+            options=Options(context={"partition_by": ["region"], "order_by": "timestamp"}),
+        )
+        assert FrameAggregateFeatureGroup.return_data_type_rule(feature) is None
+
+
 class TestFrameAggregateMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.base import (
     FrameAggregateFeatureGroup,
@@ -262,8 +263,6 @@ class TestReturnDataTypeRule:
     """
 
     def test_count_returns_int64(self) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature(
             "sales__count_rolling_3",
             options=Options(context={"partition_by": ["region"], "order_by": "timestamp"}),
@@ -271,8 +270,6 @@ class TestReturnDataTypeRule:
         assert FrameAggregateFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 
     def test_sum_returns_none(self) -> None:
-        from mloda.user import Feature
-
         feature = Feature(
             "sales__sum_rolling_3",
             options=Options(context={"partition_by": ["region"], "order_by": "timestamp"}),

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -190,7 +190,7 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Declare DOUBLE for pct_change_N (a ratio); other offsets stay open."""
         try:
             offset_type = cls._extract_offset_type(feature)
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         if offset_type.startswith("pct_change_"):
             suffix = offset_type[len("pct_change_") :]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -183,6 +184,19 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if offset_type is None:
             raise ValueError(f"Could not extract offset type for {feature_name}")
         return str(offset_type)
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare DOUBLE for pct_change_N (a ratio); other offsets stay open."""
+        try:
+            offset_type = cls._extract_offset_type(feature)
+        except Exception:
+            return None
+        if offset_type.startswith("pct_change_"):
+            suffix = offset_type[len("pct_change_") :]
+            if suffix.isdigit() and int(suffix) >= 1:
+                return DataType.DOUBLE
+        return None
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -8,6 +8,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.offset.base import OffsetFeatureGroup
 
@@ -183,8 +184,6 @@ class TestReturnDataTypeRule:
     """
 
     def test_pct_change_returns_double(self) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature(
             "value_int__pct_change_1_offset",
             options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),
@@ -196,8 +195,6 @@ class TestReturnDataTypeRule:
         ["lag_1", "lead_1", "diff_1", "first_value", "last_value"],
     )
     def test_input_dependent_ops_return_none(self, offset_type: str) -> None:
-        from mloda.user import Feature
-
         feature = Feature(
             f"value_int__{offset_type}_offset",
             options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -174,6 +174,37 @@ class TestConfigBasedFeatures:
         assert result.num_rows == 12
 
 
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type only for deterministic ops.
+
+    pct_change_N always returns a fractional ratio (DOUBLE). lag / lead / diff /
+    first_value / last_value preserve the input column type, so the rule must
+    return None for them.
+    """
+
+    def test_pct_change_returns_double(self) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature(
+            "value_int__pct_change_1_offset",
+            options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),
+        )
+        assert OffsetFeatureGroup.return_data_type_rule(feature) == DataType.DOUBLE
+
+    @pytest.mark.parametrize(
+        "offset_type",
+        ["lag_1", "lead_1", "diff_1", "first_value", "last_value"],
+    )
+    def test_input_dependent_ops_return_none(self, offset_type: str) -> None:
+        from mloda.user import Feature
+
+        feature = Feature(
+            f"value_int__{offset_type}_offset",
+            options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),
+        )
+        assert OffsetFeatureGroup.return_data_type_rule(feature) is None
+
+
 class TestOffsetMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -200,6 +201,28 @@ class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if rank_type is None:
             raise ValueError(f"Could not extract rank type for {feature_name}")
         return str(rank_type)
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare deterministic rank output types.
+
+        row_number / rank / dense_rank / ntile_N are integer ranks (INT64);
+        percent_rank is a fractional rank (DOUBLE). top_N / bottom_N (and any
+        unparseable input) stay open and return None.
+        """
+        try:
+            rank_type = cls._extract_rank_type(feature)
+        except Exception:
+            return None
+        if rank_type in {"row_number", "rank", "dense_rank"}:
+            return DataType.INT64
+        if rank_type == "percent_rank":
+            return DataType.DOUBLE
+        if rank_type.startswith("ntile_"):
+            suffix = rank_type[len("ntile_") :]
+            if suffix.isdigit() and int(suffix) >= 1:
+                return DataType.INT64
+        return None
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -212,7 +212,7 @@ class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """
         try:
             rank_type = cls._extract_rank_type(feature)
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         if rank_type in {"row_number", "rank", "dense_rank"}:
             return DataType.INT64

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -9,6 +9,7 @@ import pytest
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.rank.base import (
     RankFeatureGroup,
@@ -288,8 +289,6 @@ class TestReturnDataTypeRule:
 
     @pytest.mark.parametrize("rank_type", ["row_number", "rank", "dense_rank", "ntile_4"])
     def test_integer_rank_ops_return_int64(self, rank_type: str) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature(
             f"value_int__{rank_type}_ranked",
             options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),
@@ -297,8 +296,6 @@ class TestReturnDataTypeRule:
         assert RankFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 
     def test_percent_rank_returns_double(self) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature(
             "value_int__percent_rank_ranked",
             options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),
@@ -307,8 +304,6 @@ class TestReturnDataTypeRule:
 
     @pytest.mark.parametrize("rank_type", ["top_3", "bottom_3"])
     def test_deferred_ops_return_none(self, rank_type: str) -> None:
-        from mloda.user import Feature
-
         feature = Feature(
             f"value_int__{rank_type}_ranked",
             options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -278,6 +278,44 @@ class TestConfigBasedFeatures:
         assert result.num_rows == 12
 
 
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type for deterministic rank ops.
+
+    row_number / rank / dense_rank / ntile_N are integer ranks (INT64).
+    percent_rank is a fractional rank (DOUBLE). top_N / bottom_N are deferred
+    and not yet declared, so the rule must return None for them.
+    """
+
+    @pytest.mark.parametrize("rank_type", ["row_number", "rank", "dense_rank", "ntile_4"])
+    def test_integer_rank_ops_return_int64(self, rank_type: str) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature(
+            f"value_int__{rank_type}_ranked",
+            options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),
+        )
+        assert RankFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+    def test_percent_rank_returns_double(self) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature(
+            "value_int__percent_rank_ranked",
+            options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),
+        )
+        assert RankFeatureGroup.return_data_type_rule(feature) == DataType.DOUBLE
+
+    @pytest.mark.parametrize("rank_type", ["top_3", "bottom_3"])
+    def test_deferred_ops_return_none(self, rank_type: str) -> None:
+        from mloda.user import Feature
+
+        feature = Feature(
+            f"value_int__{rank_type}_ranked",
+            options=Options(context={"partition_by": ["region"], "order_by": "value_int"}),
+        )
+        assert RankFeatureGroup.return_data_type_rule(feature) is None
+
+
 class TestRankMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
@@ -100,7 +100,7 @@ class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Declare INT64 for count (a counting op); other aggregates stay open."""
         try:
             agg_type = cls._extract_aggregation_type(feature)
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         if agg_type == "count":
             return DataType.INT64

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -93,6 +94,17 @@ class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if agg_type is None:
             raise ValueError(f"Could not extract aggregation type for {feature_name}")
         return str(agg_type)
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare INT64 for count (a counting op); other aggregates stay open."""
+        try:
+            agg_type = cls._extract_aggregation_type(feature)
+        except Exception:
+            return None
+        if agg_type == "count":
+            return DataType.INT64
+        return None
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         _feature_name = str(feature_name)

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
@@ -9,7 +9,7 @@ import pytest
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
-from mloda.user import Feature
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
     AGGREGATION_TYPES,
@@ -244,8 +244,6 @@ class TestReturnDataTypeRule:
     """
 
     def test_count_returns_int64(self) -> None:
-        from mloda.user import DataType
-
         feature = Feature("value_int__count_scalar", options=Options())
         assert ScalarAggregateFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
@@ -236,6 +236,24 @@ class TestAggregationTypeExtraction:
         assert result == agg_type
 
 
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type only for deterministic ops.
+
+    count always returns INT64. sum depends on the input column type, so the
+    rule must return None for it.
+    """
+
+    def test_count_returns_int64(self) -> None:
+        from mloda.user import DataType
+
+        feature = Feature("value_int__count_scalar", options=Options())
+        assert ScalarAggregateFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+    def test_sum_returns_none(self) -> None:
+        feature = Feature("value_int__sum_scalar", options=Options())
+        assert ScalarAggregateFeatureGroup.return_data_type_rule(feature) is None
+
+
 class TestScalarAggregateMatchValidation(MatchValidationTestBase):
     """Shared match-validation tests adapted for scalar aggregate."""
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -228,7 +228,7 @@ class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Declare INT64 for count/nunique (counting ops); other aggregates stay open."""
         try:
             agg_type = cls._extract_aggregation_type(feature)
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         if agg_type in {"count", "nunique"}:
             return DataType.INT64

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -221,6 +222,17 @@ class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if agg_type is None:
             raise ValueError(f"Could not extract aggregation type for {feature_name}")
         return str(agg_type)
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare INT64 for count/nunique (counting ops); other aggregates stay open."""
+        try:
+            agg_type = cls._extract_aggregation_type(feature)
+        except Exception:
+            return None
+        if agg_type in {"count", "nunique"}:
+            return DataType.INT64
+        return None
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -8,6 +8,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
@@ -274,8 +275,6 @@ class TestReturnDataTypeRule:
 
     @pytest.mark.parametrize("operation", ["count", "nunique"])
     def test_deterministic_ops_return_int64(self, operation: str) -> None:
-        from mloda.user import DataType, Feature
-
         feature = Feature(
             f"value_int__{operation}_window",
             options=Options(context={"partition_by": ["region"]}),
@@ -283,8 +282,6 @@ class TestReturnDataTypeRule:
         assert WindowAggregationFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 
     def test_avg_returns_none(self) -> None:
-        from mloda.user import Feature
-
         feature = Feature(
             "value_int__avg_window",
             options=Options(context={"partition_by": ["region"]}),

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -265,6 +265,33 @@ class TestConfigBasedFeatures:
         assert result_col == expected
 
 
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type only for deterministic ops.
+
+    count/nunique always return INT64. avg depends on the input column type, so
+    the rule must return None for it.
+    """
+
+    @pytest.mark.parametrize("operation", ["count", "nunique"])
+    def test_deterministic_ops_return_int64(self, operation: str) -> None:
+        from mloda.user import DataType, Feature
+
+        feature = Feature(
+            f"value_int__{operation}_window",
+            options=Options(context={"partition_by": ["region"]}),
+        )
+        assert WindowAggregationFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+    def test_avg_returns_none(self) -> None:
+        from mloda.user import Feature
+
+        feature = Feature(
+            "value_int__avg_window",
+            options=Options(context={"partition_by": ["region"]}),
+        )
+        assert WindowAggregationFeatureGroup.return_data_type_rule(feature) is None
+
+
 class TestWindowAggregationMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/string/base.py
+++ b/mloda/community/feature_groups/data_operations/string/base.py
@@ -114,7 +114,7 @@ class StringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Declare INT64 for length (an integer-valued op); other ops stay open."""
         try:
             op = cls._extract_string_op(feature)
-        except Exception:
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
             return None
         if op == "length":
             return DataType.INT64

--- a/mloda/community/feature_groups/data_operations/string/base.py
+++ b/mloda/community/feature_groups/data_operations/string/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -107,6 +108,17 @@ class StringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if op is None:
             raise ValueError(f"Could not extract string operation for {feature_name}")
         return str(op)
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare INT64 for length (an integer-valued op); other ops stay open."""
+        try:
+            op = cls._extract_string_op(feature)
+        except Exception:
+            return None
+        if op == "length":
+            return DataType.INT64
+        return None
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/string/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_base.py
@@ -8,7 +8,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
-from mloda.user import Feature
+from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.string.base import (
     STRING_OPS,
@@ -149,8 +149,6 @@ class TestReturnDataTypeRule:
     """
 
     def test_length_returns_int64(self) -> None:
-        from mloda.user import DataType
-
         feature = Feature("name__length", options=Options())
         assert StringFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 

--- a/mloda/community/feature_groups/data_operations/string/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_base.py
@@ -140,6 +140,26 @@ class TestValidateStringMatch:
         assert StringFeatureGroup._validate_string_match("name__capitalize", "capitalize", "name") is False
 
 
+class TestReturnDataTypeRule:
+    """return_data_type_rule should fix the output type only for deterministic ops.
+
+    length always returns an integer character count (INT64). upper / lower /
+    trim / reverse are string-returning ops that are deferred for now, so the
+    rule must return None for them.
+    """
+
+    def test_length_returns_int64(self) -> None:
+        from mloda.user import DataType
+
+        feature = Feature("name__length", options=Options())
+        assert StringFeatureGroup.return_data_type_rule(feature) == DataType.INT64
+
+    @pytest.mark.parametrize("operation", ["upper", "lower", "trim", "reverse"])
+    def test_deferred_ops_return_none(self, operation: str) -> None:
+        feature = Feature(f"name__{operation}", options=Options())
+        assert StringFeatureGroup.return_data_type_rule(feature) is None
+
+
 class TestStringMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:


### PR DESCRIPTION
Closes #216.

## What

mloda 0.7.0 (mloda#434) turned `return_data_type_rule` into an enforced contract: every compute framework now extracts the actual output column type after computing and validates it against any declared return type. No community feature group declared a return type, so none of their outputs were validated.

This PR declares `return_data_type_rule` on ten `data_operations` base classes, but **only for operations whose output type is deterministic from the feature config and numeric** ("Tier 1").

| Group | Deterministic op(s) | Declared type |
|---|---|---|
| datetime | year/month/day/hour/minute/second/dayofweek/quarter/is_weekend | `INT64` |
| aggregation, window_aggregation | count, nunique | `INT64` |
| scalar_aggregate, frame_aggregate, resample | count | `INT64` |
| rank | row_number/rank/dense_rank, ntile_N | `INT64` |
| rank | percent_rank | `DOUBLE` |
| binning | bin, qbin | `INT64` |
| offset | pct_change_N | `DOUBLE` |
| string | length | `INT64` |

## Design notes

- **Reuses each group's existing op-extractor** (`_extract_datetime_op`, `_extract_aggregation_type`, `_extract_rank_type`, etc.) — no feature-name re-parsing (anti-duplication).
- **Never raises during setup**: each rule wraps extraction in `try/except` and returns `None` on failure.
- **Declared wide on purpose.** The validator is lenient by default (all numeric types interchangeable) and applies widening in strict mode (`INT64 ← {INT32,INT64}`, `DOUBLE ← {FLOAT,DOUBLE,INT32,INT64}`). Declaring the wide type is robust to backends that disagree on width (e.g. pyarrow int64 vs pandas/polars int32 for datetime parts; polars `length` → u32). A narrow `INT32` declaration would fail strict mode on those backends, so wide is the *correct* choice, not just convenient.
- **`is_weekend` is declared `INT64`, not `BOOLEAN`** — it is implemented as integer `1/0` in every backend, so a `BOOLEAN` declaration would fail validation even in lenient mode. The declared type is derived from the actual per-backend output dtype, not from semantic intent.

## Deliberately out of scope (Tier 2 follow-up)

Left open (`return None`) pending per-backend dtype confirmation, since these are exact-match (non-numeric) or input-dependent:
- Input-type-dependent ops: sum/avg/min/max/std/var/median/mode/first/last, all arithmetic, ema, ffill, percentile, offset lag/lead/diff/first_value/last_value.
- Non-numeric exact-match: string upper/lower/trim/reverse (→ STRING), rank top_N/bottom_N (→ BOOLEAN), time_bucketization (timestamp; precision collapses on SQLite/Spark/Iceberg).

## Testing

- New `TestReturnDataTypeRule` unit tests per group assert the declared type for deterministic ops and `None` for the rest (43 cases).
- Declaring a return type activates 0.7.0 output validation, so the **existing per-backend integration tests now validate the declared types end to end** across pandas/polars/pyarrow/duckdb. Full suite: **3646 passed, 128 skipped**.
- Gate: `ruff format --check`, `ruff check`, `bandit` all clean; `mypy --strict` introduces zero net-new errors (diff vs. base is line-number shifts only).

Pure opt-in enhancement; safe under 0.7.0 (the validator skips features whose `data_type is None`).