### PR TITLE
docs(data_operations): record return_data_type_rule failure-handling decision + completeness/invariant guards (#244)

### DIFF
--- a/docs/guides/data-operation-patterns/16-return-data-type-rule.md
+++ b/docs/guides/data-operation-patterns/16-return-data-type-rule.md
@@ -1,0 +1,98 @@
+# `return_data_type_rule` failure handling
+
+Why every `return_data_type_rule` in `data_operations` wraps op-extraction in a broad `except Exception: return None`, what that trades away, and the decision recorded for issue [#244](https://github.com/mloda-ai/mloda-registry/issues/244).
+
+**What**: The failure-handling contract for `return_data_type_rule` on the ten `data_operations` base classes that declare a deterministic output type.
+**When**: Read this before adding a type rule to a new operation, before narrowing the catch, or before moving the defensiveness into mloda core.
+**Why**: The broad catch is a deliberate trade. It keeps planning crash-free at the cost of observability, and the same boilerplate is duplicated ten times and growing. The trade deserves to be recorded once rather than re-litigated per operation.
+**Where**: `return_data_type_rule` on the base classes under `mloda/community/feature_groups/data_operations/`, the framework call site `engine.set_data_type` in mloda core, and the cross-cutting guard test `tests/test_return_data_type_rule_invariants.py`.
+**How**: This page states the invariant, maps the trade onto the three data-governance roles it affects, weighs the options, and records what was adopted now versus deferred.
+
+---
+
+## The invariant: planning must never raise
+
+mloda core calls the rule unguarded. In `engine.set_data_type`:
+
+```python
+def set_data_type(self, feature, feature_group_class):
+    fg_data_type = feature_group_class.return_data_type_rule(feature)
+    ...
+```
+
+There is no `try/except` around that call. If a rule raises, planning crashes for the whole graph, not just the one feature whose type could not be determined. `return_data_type_rule` is a planning-time hint: a feature group telling the engine "I always emit this type, validate downstream against it." A hint that cannot be computed must degrade to "type undeclared" (`None`), never abort the build. **This is the invariant: `return_data_type_rule` must return, never raise, for any feature the framework hands it, including a malformed one.** It is the reason the broad catch exists, and `tests/test_return_data_type_rule_invariants.py::test_invariant_never_raises` exists to keep it from regressing.
+
+## The shape, and the three outcomes it collapses
+
+Each of the ten rules follows the same shape (here, aggregation):
+
+```python
+@classmethod
+def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+    try:
+        agg_type = cls._extract_aggregation_type(feature)
+    except Exception:  # best-effort during planning; failure leaves the type undeclared
+        return None
+    if agg_type in {"count", "nunique"}:
+        return DataType.INT64
+    return None
+```
+
+`None` is returned on three distinct paths that look identical from outside:
+
+1. **Intended open type.** The op is genuinely input-dependent (e.g. `sum` over an unknown numeric column). `None` is correct.
+2. **Acceptable degradation.** The feature is malformed and cannot be parsed. `None` is the safe answer; validation simply does not engage for that feature.
+3. **Hidden bug.** A typo, a renamed helper, a refactor that broke `_extract_*` raises `AttributeError`/`NameError`. The catch swallows it, the rule returns `None`, and 0.7.0 output-type validation is silently disabled for that feature. No log, no warning, no test failure. It is indistinguishable from path 1.
+
+Path 3 is the cost. A regression can ship and look exactly like normal operation.
+
+## Why narrowing the catch is not trivial
+
+The obvious fix, `except ValueError`, is unsafe. The leaf extractors do raise `ValueError`, but at least one rule routes through a shared helper that raises other types. `FrameAggregateFeatureGroup.return_data_type_rule` calls `_extract_params`, whose config-based branch does `source_features[0]` after `_extract_source_features` -> `options.get_in_features()`. On a malformed config feature, `get_in_features()` raises:
+
+- `ValueError` when the `in_features` key is missing or empty (`if not val: raise ValueError(...)`), and
+- `TypeError` when an `in_features` entry is neither a `Feature` nor a `str` (`raise TypeError(f"Cannot convert {type(item)} ...")`).
+
+So a naive narrow-to-`ValueError` would let a `TypeError` from a malformed feature propagate and break the never-raises invariant. Narrowing safely requires either auditing every `_extract_*` and `get_in_features` path to guarantee a single domain error, or widening the catch to the full set of data-shape errors (`ValueError, IndexError, TypeError, KeyError`) and only then letting `AttributeError`/`NameError` through as the "this is a bug" signal. Narrowing and observability are therefore coupled: you cannot make the swallow informative without first deciding which exceptions mean "bad data" and which mean "bad code."
+
+## Who this affects: data users, providers, stewards
+
+The trade is easiest to reason about through the three roles that touch a declared output type.
+
+| Role | Relies on the type rule for | What silent path-3 failure costs them |
+|---|---|---|
+| **Data user** (consumes features) | The declared output type as a contract: downstream schema checks, type-safe joins, validation catching a wrong-typed column before it reaches a model or a dashboard. | Validation silently stops engaging for the affected feature. A type regression flows downstream undetected. The contract erodes quietly, and erosion that is invisible is the kind users stop trusting. |
+| **Data provider** (authors / registers feature groups) | Fast feedback when their extraction logic breaks. They write the rule and the extractor it calls. | Their own bug (renamed helper, typo) is swallowed. Local runs look green; the rule "works" by returning `None`. They get no signal until a data user notices wrong types in production. |
+| **Data steward** (governs quality, lineage, contracts across the platform) | Being able to answer "which features have a declared, enforced output type, and which are intentionally open?" | The swallow makes intended-open (path 1) and accidentally-broken (path 3) indistinguishable. A coverage or lineage audit cannot tell a deliberate open type from a disabled one. Governance metrics degrade with no signal. |
+
+The down-the-road consequence sits underneath all three: **the per-rule `try/except` proliferates.** It is on ten base classes today and grows by one with every new deterministic operation. Each copy is a place where a future author can narrow the exception set wrong, or forget to narrow at all. Ten hand-maintained copies of a safety-critical catch is a maintenance liability independent of any single bug, and it is the central argument for eventually centralizing the defensiveness rather than duplicating it.
+
+## Options weighed
+
+These are not mutually exclusive; the decision combines three of them.
+
+1. **Tighten the extraction contract.** Guarantee that extractors and the helpers they call raise only a known domain error (`ValueError`, or a dedicated `ExtractionError`), then narrow the catch to that. *Cost:* audit of every `_extract_*` + `_extract_source_features`/`get_in_features` path, plus an enforcement test, before the narrow is safe. Highest correctness, highest up-front cost.
+2. **Narrow to realistic data-shape failures** (`ValueError, IndexError, TypeError, KeyError`) and let `AttributeError`/`NameError` propagate so genuine bugs surface. *Cost:* the propagating bug now crashes planning, which trades one failure mode (silent) for another (loud but graph-wide). Acceptable only once core owns the never-raises wrapper (option 4), otherwise it reintroduces the very fragility the broad catch prevents.
+3. **Make the swallow observable.** Keep the broad catch but log/warn when it fires so silent validation-disabling is detectable. *Cost:* the rule is on the per-feature planning hot path, so logging every malformed-but-acceptable feature (path 2) is noise. Observability is only useful if it distinguishes expected data-shape errors (silent or debug) from unexpected `AttributeError`/`NameError` (warning) which means it depends on option 1 or 2 having classified the exceptions first.
+4. **Lift the defensiveness into mloda core.** The engine already calls `return_data_type_rule` at one site. Wrapping that single call defensively (catch + classify + log, return `None`) would remove the per-rule boilerplate from all ten registry classes and every other plugin's type rule at once. *Tradeoff to state honestly:* this changes a framework contract. Today an unguarded rule that raises crashes planning; a core wrapper makes **every** plugin's type rule best-effort, overriding crash-on-raise for plugins that might prefer to fail loud. That is defensible for a planning-time hint, but it is not a unilateral edit. It belongs in mloda core, coordinated, not folded into a registry PR.
+5. **Guard with a completeness test instead of a runtime catch.** Assert that each supported deterministic op yields its expected non-`None` type, so an extraction regression (path 3) fails CI rather than silently returning `None` at runtime. *This is the reconciliation of the apparent conflict.* "Never crash at planning time" and "surface real bugs" cannot both hold for path 3 at runtime, but they can hold across the lifecycle: the broad catch keeps runtime crash-free, and the completeness test moves bug-detection to CI, where a crash is exactly what you want.
+
+## Decision
+
+Adopt **5 + 3 + the explicit invariant now**, in this registry. Recommend **4** as the long-term direction and scope it as a coordinated follow-up in mloda core. Defer **1/2** until **4** lands (narrowing is only safe once core owns the never-raises guarantee).
+
+Concretely, in this PR:
+
+- **Completeness guarantee (option 5).** `tests/test_return_data_type_rule_invariants.py::test_completeness` enumerates, for all ten base classes, a representative feature for each deterministic op and asserts the rule returns the expected non-`None` `DataType`. This is the spine: any extraction regression that would have silently returned `None` (path 3) now fails CI. It supersedes the per-operation `TestReturnDataTypeRule` cases by reframing them as a single completeness contract rather than ten independent spot checks.
+- **Invariant test (restates the contract).** `test_invariant_never_raises` feeds malformed and garbage features to every rule and asserts each returns (`None` is acceptable) and never raises. This pins the reason the broad catch exists so a future narrow cannot quietly regress it.
+- **This document (option 3, the recordable half).** The broad catch stays, but its cost is now written down and discoverable, mapped to the three roles, with the proliferation consequence named. Runtime logging is deferred to the core wrapper, where classification (option 1/2) makes it actionable rather than noisy.
+
+Deferred, with a follow-up filed against mloda core:
+
+- **Core wrapper (option 4).** Wrap `engine.set_data_type`'s call to `return_data_type_rule` in a defensive catch that classifies the exception (data-shape -> debug, unexpected -> warning with feature + FG class + exception), returns `None`, and centralizes the never-raises invariant as a framework property. Once it lands, the ten registry catches can be removed and the rules left to raise naturally, with the completeness test still guarding correctness in CI. Tracked cross-repo in [mloda-ai/mloda#485](https://github.com/mloda-ai/mloda/issues/485).
+
+## Regression signals
+
+- `test_completeness` fails if any deterministic op stops returning its declared type (catches path-3 bugs in CI).
+- `test_invariant_never_raises` fails if any rule raises on a malformed feature (guards the never-raises invariant against a future narrow).
+- If the core wrapper (option 4) lands and the registry catches are removed, both tests must still pass unchanged; that is the acceptance criterion for the removal.

--- a/docs/guides/data-operation-patterns/index.md
+++ b/docs/guides/data-operation-patterns/index.md
@@ -23,5 +23,6 @@ Read them after you are comfortable with the [feature-group patterns](../feature
 13. [EMA](13-ema.md) - Exponential moving average (`{col}__ema_{span}`), per partition; pandas / polars native, SQL backends reject
 14. [Resample](14-resample.md) - Collapse events onto a regular time grid (`{col}__resample_{n}_{unit}_{agg}`); the first `row_changing` operation
 15. [Sessionization](15-sessionization.md) - Assign a gap-threshold session id on an ordered timestamp (`{ts}__sessionize_{n}_{unit}`), per partition (row-preserving)
-16. [Known divergences](known-divergences.md) - Audited cases where a framework would diverge from the PyArrow reference, with the mitigation for each
-17. [Framework support matrix](framework-support-matrix.md) - Operation x framework capability table, generated from `supported_*()` test overrides
+16. [`return_data_type_rule` failure handling](16-return-data-type-rule.md) - Why the type rules swallow extraction errors, the data-user/provider/steward trade, and the completeness-test + core-wrapper decision (#244)
+17. [Known divergences](known-divergences.md) - Audited cases where a framework would diverge from the PyArrow reference, with the mitigation for each
+18. [Framework support matrix](framework-support-matrix.md) - Operation x framework capability table, generated from `supported_*()` test overrides

--- a/docs/guides/feature-group-patterns/18-datatypes.md
+++ b/docs/guides/feature-group-patterns/18-datatypes.md
@@ -67,6 +67,8 @@ class UserCount(FeatureGroup):
         return DataType.INT64
 ```
 
+The rule is a planning-time hint and must never raise (the engine calls it unguarded). For the failure-handling contract when the type depends on parsing the feature, and how the `data_operations` rules degrade to `None` rather than crash, see [`return_data_type_rule` failure handling](../data-operation-patterns/16-return-data-type-rule.md).
+
 ## Validation Modes
 
 **Lenient (default):** Allows safe type widening (INT32→INT64, FLOAT→DOUBLE)

--- a/mloda/community/feature_groups/data_operations/tests/test_return_data_type_rule_invariants.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_return_data_type_rule_invariants.py
@@ -1,0 +1,212 @@
+"""Cross-cutting guards for ``return_data_type_rule`` across all ten data operations.
+
+These two tests codify the decision recorded in
+``docs/guides/data-operation-patterns/16-return-data-type-rule.md`` for issue
+`#244 <https://github.com/mloda-ai/mloda-registry/issues/244>`_. They consolidate
+the per-operation ``TestReturnDataTypeRule`` spot checks into two contracts that
+span every base class that declares a deterministic output type.
+
+Two guarantees:
+
+- ``test_completeness`` (doc option 5): for every supported *deterministic* op,
+  a representative feature must make ``return_data_type_rule`` return its expected
+  non-``None`` ``DataType``. This is the spine that catches the "hidden bug" path:
+  a broken ``_extract_*`` helper that the broad ``except Exception`` would silently
+  swallow into ``None``, disabling output-type validation with no signal. If an
+  extraction regression ships, this test fails in CI rather than degrading quietly.
+
+- ``test_invariant_never_raises`` (the explicit invariant): ``return_data_type_rule``
+  is a planning-time hint that mloda core calls unguarded in ``engine.set_data_type``.
+  A rule that raises crashes planning for the whole graph, so the rule must always
+  RETURN (``None`` is an acceptable answer) and NEVER raise, even for malformed or
+  garbage features. This pins the reason the broad catch exists so a future narrow
+  cannot quietly regress it.
+
+The (base class, representative feature, expected ``DataType``) tuples mirror the
+existing ``TestReturnDataTypeRule`` classes in each operation's ``tests/test_base.py``;
+they are not invented here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.user import DataType
+
+from mloda.community.feature_groups.data_operations.aggregation.base import AggregationFeatureGroup
+from mloda.community.feature_groups.data_operations.row_changing.resample.base import ResampleFeatureGroup
+from mloda.community.feature_groups.data_operations.row_preserving.binning.base import BinningFeatureGroup
+from mloda.community.feature_groups.data_operations.row_preserving.datetime.base import DateTimeFeatureGroup
+from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.base import (
+    FrameAggregateFeatureGroup,
+)
+from mloda.community.feature_groups.data_operations.row_preserving.offset.base import OffsetFeatureGroup
+from mloda.community.feature_groups.data_operations.row_preserving.rank.base import RankFeatureGroup
+from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
+    ScalarAggregateFeatureGroup,
+)
+from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
+    WindowAggregationFeatureGroup,
+)
+
+# StringFeatureGroup lives under data_operations.string (not row_preserving).
+from mloda.community.feature_groups.data_operations.string.base import StringFeatureGroup
+
+
+# The ten base classes that declare a deterministic output type. Kept as a named
+# tuple so both tests can assert they cover all ten.
+ALL_BASE_CLASSES: tuple[type[FeatureGroup], ...] = (
+    AggregationFeatureGroup,
+    BinningFeatureGroup,
+    DateTimeFeatureGroup,
+    FrameAggregateFeatureGroup,
+    OffsetFeatureGroup,
+    RankFeatureGroup,
+    ResampleFeatureGroup,
+    ScalarAggregateFeatureGroup,
+    StringFeatureGroup,
+    WindowAggregationFeatureGroup,
+)
+
+
+def _opts(**context: object) -> Options:
+    """Build an Options carrying only a planning context (matches the source tests)."""
+    return Options(context=dict(context)) if context else Options()
+
+
+# (base class, representative feature, expected non-None DataType) for every supported
+# deterministic op, one row per op. Names and options copied verbatim from each
+# operation's TestReturnDataTypeRule in tests/test_base.py; do not invent new ones.
+COMPLETENESS_CASES: list[tuple[type[FeatureGroup], Feature, DataType]] = [
+    # aggregation: count / nunique -> INT64 (sum/avg are input-dependent -> None, not listed)
+    (AggregationFeatureGroup, Feature("value_int__count_agg", options=_opts(partition_by=["region"])), DataType.INT64),
+    (
+        AggregationFeatureGroup,
+        Feature("value_int__nunique_agg", options=_opts(partition_by=["region"])),
+        DataType.INT64,
+    ),
+    # binning: bin / qbin -> INT64
+    (BinningFeatureGroup, Feature("value_int__bin_5", options=Options()), DataType.INT64),
+    (BinningFeatureGroup, Feature("value_int__qbin_4", options=Options()), DataType.INT64),
+    # datetime: all ops are deterministic integer extractions -> INT64
+    (DateTimeFeatureGroup, Feature("timestamp__year", options=Options()), DataType.INT64),
+    (DateTimeFeatureGroup, Feature("timestamp__month", options=Options()), DataType.INT64),
+    (DateTimeFeatureGroup, Feature("timestamp__day", options=Options()), DataType.INT64),
+    (DateTimeFeatureGroup, Feature("timestamp__hour", options=Options()), DataType.INT64),
+    (DateTimeFeatureGroup, Feature("timestamp__minute", options=Options()), DataType.INT64),
+    (DateTimeFeatureGroup, Feature("timestamp__second", options=Options()), DataType.INT64),
+    (DateTimeFeatureGroup, Feature("timestamp__dayofweek", options=Options()), DataType.INT64),
+    (DateTimeFeatureGroup, Feature("timestamp__is_weekend", options=Options()), DataType.INT64),
+    (DateTimeFeatureGroup, Feature("timestamp__quarter", options=Options()), DataType.INT64),
+    # frame_aggregate: count -> INT64 (sum etc. input-dependent -> None)
+    (
+        FrameAggregateFeatureGroup,
+        Feature("sales__count_rolling_3", options=_opts(partition_by=["region"], order_by="timestamp")),
+        DataType.INT64,
+    ),
+    # offset: pct_change -> DOUBLE (lag/lead/diff/first_value/last_value preserve input -> None)
+    (
+        OffsetFeatureGroup,
+        Feature("value_int__pct_change_1_offset", options=_opts(partition_by=["region"], order_by="value_int")),
+        DataType.DOUBLE,
+    ),
+    # rank: row_number / rank / dense_rank / ntile -> INT64, percent_rank -> DOUBLE
+    (
+        RankFeatureGroup,
+        Feature("value_int__row_number_ranked", options=_opts(partition_by=["region"], order_by="value_int")),
+        DataType.INT64,
+    ),
+    (
+        RankFeatureGroup,
+        Feature("value_int__rank_ranked", options=_opts(partition_by=["region"], order_by="value_int")),
+        DataType.INT64,
+    ),
+    (
+        RankFeatureGroup,
+        Feature("value_int__dense_rank_ranked", options=_opts(partition_by=["region"], order_by="value_int")),
+        DataType.INT64,
+    ),
+    (
+        RankFeatureGroup,
+        Feature("value_int__ntile_4_ranked", options=_opts(partition_by=["region"], order_by="value_int")),
+        DataType.INT64,
+    ),
+    (
+        RankFeatureGroup,
+        Feature("value_int__percent_rank_ranked", options=_opts(partition_by=["region"], order_by="value_int")),
+        DataType.DOUBLE,
+    ),
+    # resample: count -> INT64 (mean/sum input-dependent -> None)
+    (ResampleFeatureGroup, Feature("value__resample_5_minute_count", options=Options()), DataType.INT64),
+    # scalar_aggregate: count -> INT64 (sum input-dependent -> None)
+    (ScalarAggregateFeatureGroup, Feature("value_int__count_scalar", options=Options()), DataType.INT64),
+    # string: length -> INT64 (upper/lower/trim/reverse deferred -> None)
+    (StringFeatureGroup, Feature("name__length", options=Options()), DataType.INT64),
+    # window_aggregation: count / nunique -> INT64 (avg input-dependent -> None)
+    (
+        WindowAggregationFeatureGroup,
+        Feature("value_int__count_window", options=_opts(partition_by=["region"])),
+        DataType.INT64,
+    ),
+    (
+        WindowAggregationFeatureGroup,
+        Feature("value_int__nunique_window", options=_opts(partition_by=["region"])),
+        DataType.INT64,
+    ),
+]
+
+
+def test_completeness_covers_every_base_class() -> None:
+    """Sanity: the completeness table must touch all ten base classes (catches a
+    new deterministic operation added without a representative row here)."""
+    covered = {cls for cls, _feature, _expected in COMPLETENESS_CASES}
+    assert covered == set(ALL_BASE_CLASSES)
+
+
+@pytest.mark.parametrize(
+    "feature_group_class, feature, expected",
+    COMPLETENESS_CASES,
+    ids=[f"{cls.__name__}:{feature.name}" for cls, feature, _expected in COMPLETENESS_CASES],
+)
+def test_completeness(feature_group_class: type[FeatureGroup], feature: Feature, expected: DataType) -> None:
+    """Every supported deterministic op returns its declared non-None DataType.
+
+    A broken ``_extract_*`` helper would be swallowed by the rule's broad catch and
+    silently return ``None`` (doc path 3). This assertion turns that into a CI failure.
+    """
+    result = feature_group_class.return_data_type_rule(feature)
+    assert result == expected
+
+
+# Malformed / garbage features: a name that matches no pattern, plus a config-style
+# feature whose empty Options drives frame_aggregate's _extract_params through
+# get_in_features() (which raises ValueError/TypeError) -- confirming the broad catch
+# holds rather than letting the exception propagate.
+MALFORMED_FEATURES: list[Feature] = [
+    Feature("totally_unparseable_name"),
+    # Empty in_features: frame_aggregate._extract_source_features -> get_in_features()
+    # raises ValueError ("Input features not found in options"). Other rules just miss.
+    Feature("frame_agg_no_in_features", options=Options()),
+    # A garbage name with an explicit (empty-context) Options object.
+    Feature("__bad__", options=Options()),
+]
+
+
+@pytest.mark.parametrize(
+    "feature_group_class",
+    ALL_BASE_CLASSES,
+    ids=[cls.__name__ for cls in ALL_BASE_CLASSES],
+)
+def test_invariant_never_raises(feature_group_class: type[FeatureGroup]) -> None:
+    """``return_data_type_rule`` must return (``None`` is acceptable) and never raise.
+
+    Planning calls the rule unguarded; a raise crashes the whole graph. For every
+    base class and every malformed feature, the rule must degrade to ``None`` or a
+    ``DataType`` instead of propagating an exception.
+    """
+    for feature in MALFORMED_FEATURES:
+        result = feature_group_class.return_data_type_rule(feature)
+        assert result is None or isinstance(result, DataType)


### PR DESCRIPTION
Closes #244.

#244 is an analysis/decision issue: decide how `return_data_type_rule`'s broad `except Exception: return None` should handle failure across the ten `data_operations` base classes. This PR records that decision and lands the guards it calls for.

## What the broad catch trades away

`return_data_type_rule` is a planning-time hint; mloda core calls it **unguarded** in `engine.set_data_type`, so a raising rule crashes the whole graph. The broad catch keeps planning crash-free, but `None` then collapses three outcomes that look identical: intended-open type, acceptable degradation on a malformed feature, and a **hidden bug** (renamed helper / typo) that silently disables output-type validation with no log, no warning, no test failure.

## Decision (framed by data-governance role)

The cost lands differently on each role, and that framing drives the choice:

- **Data users** rely on the declared type as a contract; a silent path-3 failure erodes it invisibly.
- **Data providers** lose fast feedback: their own extraction bug is swallowed and looks green locally.
- **Data stewards** can no longer tell an intentionally-open type from an accidentally-disabled one in a coverage/lineage audit.

Adopted now, in this repo:
- **Completeness guarantee** (`test_completeness`): every deterministic op must return its declared non-`None` `DataType`, so an extraction regression fails **CI** instead of silently returning `None` at runtime. This reconciles "never crash at planning time" with "surface real bugs" across the lifecycle.
- **Explicit invariant** (`test_invariant_never_raises`): the rule must return (`None` ok) and never raise on malformed features, pinning the reason the broad catch exists so a future narrow cannot regress it.
- **The decision doc** makes the cost discoverable and maps it to the three roles.

Deferred (contract change, coordinated cross-repo): lift the defensiveness into mloda core so the never-raises guarantee lives at the single call site and the ten per-rule `try/except` blocks can be removed. Tracked in **mloda-ai/mloda#485**.

## Changes

- `docs/guides/data-operation-patterns/16-return-data-type-rule.md` — decision record; wired into the patterns index and cross-linked from `feature-group-patterns/18-datatypes.md`.
- `mloda/community/feature_groups/data_operations/tests/test_return_data_type_rule_invariants.py` — cross-cutting completeness + invariant guards over all ten base classes (36 cases).

## Verification

- New tests: `36 passed`.
- `ruff format --check`, `ruff check`: clean on the new file.
- `mypy --strict` over `data_operations/`: 69 errors, identical to `main` baseline (zero new; none in the new file).
