### PR TITLE
chore(deps): bump mloda to 0.8.0 and declare pyarrow test dep

### DIFF
--- a/config/packages.toml
+++ b/config/packages.toml
@@ -10,34 +10,34 @@
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/registry"
 
 [packages.mloda-testing]
 description = "Test utilities for mloda plugin development"
-dependencies = ["mloda>=0.7.0", "pytest>=9.0.3"]
+dependencies = ["mloda>=0.8.0", "pytest>=9.0.3"]
 path = "mloda/testing"
 optional_dependencies = { dev = ["pytest>=9.0.3"] }
 
 [packages.mloda-community]
 description = "All community plugins for mloda"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/community"
 
 [packages.mloda-enterprise]
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/enterprise"
 
 [packages.mloda-community-example]
 description = "Example community FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/community/feature_groups/example"
 optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-example-b"] }
 
 [packages.mloda-enterprise-example]
 description = "Example enterprise FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/enterprise/feature_groups/example"
 
 [packages.mloda-community-example-a]
@@ -52,29 +52,29 @@ path = "mloda/community/feature_groups/example/example_b"
 
 [packages.mloda-community-compute-frameworks-example]
 description = "Example community ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/community/compute_frameworks/example"
 
 [packages.mloda-community-extenders-example]
 description = "Example community Extender plugin for mloda"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/community/extenders/example"
 
 [packages.mloda-enterprise-compute-frameworks-example]
 description = "Example enterprise ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/enterprise/compute_frameworks/example"
 
 [packages.mloda-enterprise-extenders-example]
 description = "Example enterprise Extender plugin for mloda"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/enterprise/extenders/example"
 
 # --- Data Operations ---
 
 [packages.mloda-community-data-operations]
 description = "Shared base classes for data operation feature groups"
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 path = "mloda/community/feature_groups/data_operations"
 optional_dependencies = { all = ["mloda-community-window-aggregation", "mloda-community-aggregation", "mloda-community-rank", "mloda-community-offset", "mloda-community-frame-aggregate", "mloda-community-scalar-aggregate", "mloda-community-scalar-arithmetic", "mloda-community-point-arithmetic", "mloda-community-datetime", "mloda-community-string", "mloda-community-binning", "mloda-community-percentile", "mloda-community-time-bucketization", "mloda-community-ffill", "mloda-community-ema", "mloda-community-sessionization", "mloda-community-resample"] }
 

--- a/docs/guides/compute-framework-patterns/06-merge-engine.md
+++ b/docs/guides/compute-framework-patterns/06-merge-engine.md
@@ -18,6 +18,21 @@ The merge engine handles join operations between datasets.
 | `merge_full_outer()` | FULL OUTER JOIN | All rows from both |
 | `merge_append()` | UNION ALL | Concatenate (with duplicates) |
 | `merge_union()` | UNION | Concatenate (deduplicated) |
+| `merge_asof()` | ASOF JOIN | Point-in-time / as-of match (by-key equi + nearest-time); opt-in |
+
+`merge_asof()` is opt-in: like every method above, the base implementation raises
+`ValueError` until overridden, so implement it only for frameworks that need
+point-in-time joins. Its signature differs from the others — it takes an extra
+`asof_config: AsOfJoinConfig` (`left_time_column`, `right_time_column`, `direction`,
+`tolerance`, `allow_exact_matches`):
+
+```python
+def merge_asof(self, left_data, right_data, left_index: Index, right_index: Index,
+               asof_config: AsOfJoinConfig) -> Any:
+    ...
+```
+
+See `pandas_merge_engine.py` (linked below) for a reference implementation.
 
 ## Complete Example
 

--- a/docs/guides/feature-group-patterns/08-links-joins.md
+++ b/docs/guides/feature-group-patterns/08-links-joins.md
@@ -60,6 +60,21 @@ def test_input_features_with_link():
 | `Link.outer()` | FULL OUTER JOIN | `outer_on()` |
 | `Link.append()` | UNION ALL | `append_on()` |
 | `Link.union()` | UNION | `union_on()` |
+| `Link.asof()` | ASOF JOIN (point-in-time) | `asof_on()` |
+
+ASOF (point-in-time) joins match each left row to the nearest right row by time.
+`Link.asof()` / `Link.asof_on()` require the keyword args `left_time_column=` and
+`right_time_column=`, and accept `direction` (`"backward"` default, `"forward"`,
+`"nearest"`), `tolerance`, and `allow_exact_matches` (default `True`) — pandas
+`merge_asof` semantics. The by-key `Index` is the equi match; the time columns drive
+the inequality match.
+
+```python
+link = Link.asof_on(
+    EventFeatureGroup, PriceFeatureGroup,
+    left_time_column="event_ts", right_time_column="quote_ts",
+)
+```
 
 ## Using JoinSpec (Explicit Control)
 

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example community ComputeFramework plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example community Extender plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Shared base classes for data operation feature groups"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example community FeatureGroup plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "All community plugins for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example enterprise ComputeFramework plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example enterprise Extender plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example enterprise FeatureGroup plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Plugin discovery and search for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/testing/pyproject.toml
+++ b/mloda/testing/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Test utilities for mloda plugin development"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.7.0", "pytest>=9.0.3"]
+dependencies = ["mloda>=0.8.0", "pytest>=9.0.3"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Development workspace for mloda registry packages"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 dependencies = [
-    "mloda>=0.7.0",
+    "mloda>=0.8.0",
 ]
 authors = [
     { name = "Tom Kaltofen", email = "info@mloda.ai" }
@@ -30,6 +30,7 @@ dev = [
     "duckdb",
     "pandas",
     "polars",
+    "pyarrow",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -328,13 +328,10 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyarrow" },
-]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/2c/6e9f216065dfb4fdba91e2e04e117fb54e38439e781407089f0f4c22a54a/mloda-0.7.0-py3-none-any.whl", hash = "sha256:61d02cb1a59944f219fb1e051ffdd96813cfa23d8d832d35a1772e062e2068a1", size = 419808, upload-time = "2026-05-30T15:45:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d8/b4f8beceec599fe75b4956fc8614ead1d40bc0642e6562c18c2c683f2685/mloda-0.8.0-py3-none-any.whl", hash = "sha256:521e0425169a99370b3d1cdf9fd480ebecb3f9a0ec67c62fe6a321ca8e3bcabe", size = 428976, upload-time = "2026-06-05T17:24:09.732Z" },
 ]
 
 [[package]]
@@ -346,7 +343,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.7.0" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.8.0" }]
 
 [[package]]
 name = "mloda-community-aggregation"
@@ -464,7 +461,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -505,7 +502,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "mloda-community-aggregation", marker = "extra == 'all'" },
     { name = "mloda-community-binning", marker = "extra == 'all'" },
     { name = "mloda-community-datetime", marker = "extra == 'all'" },
@@ -620,7 +617,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "mloda-community-example-a", marker = "extra == 'all'" },
     { name = "mloda-community-example-b", marker = "extra == 'all'" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
@@ -688,7 +685,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1301,7 +1298,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.7.0" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.8.0" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
@@ -1319,7 +1316,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1341,7 +1338,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1363,7 +1360,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1385,7 +1382,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "mloda-testing", marker = "extra == 'dev'", editable = "mloda/testing" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1407,6 +1404,7 @@ dev = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "polars" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "python-dateutil" },
@@ -1421,10 +1419,11 @@ dev = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
     { name = "duckdb", marker = "extra == 'dev'" },
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'dev'" },
     { name = "polars", marker = "extra == 'dev'" },
+    { name = "pyarrow", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-dateutil", marker = "extra == 'dev'" },
@@ -1452,7 +1451,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.7.0" },
+    { name = "mloda", specifier = ">=0.8.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]


### PR DESCRIPTION
## Summary

Bumps the mloda core dependency from `>=0.7.0` to `>=0.8.0` across `config/packages.toml` and the root workspace pyproject, regenerates all per-package `pyproject.toml` files via `scripts/generate_pyproject.py`, and refreshes `uv.lock` (`uv lock --upgrade-package mloda`).

## Why the extra pyarrow line

mloda 0.8.0 makes **PyArrow an optional dependency** rather than a required one. The registry test suite imports `pyarrow` directly (e.g. the data-operations conftests) and previously received it transitively through mloda. The version bump alone left the tox `dev` env without pyarrow and broke test collection:

```
ModuleNotFoundError: No module named 'pyarrow'
```

Fix: declare `pyarrow` explicitly in the root `[project.optional-dependencies].dev` extras alongside the other dataframe backends (`duckdb`, `pandas`, `polars`), surfacing what was always a genuine test dependency.

## Docs guide audit (0.7.0 → 0.8.0)

Audited every commit between mloda 0.7.0 and 0.8.0 against `docs/guides/`. Only the new **ASOF (point-in-time) join** (mloda#462) left a guide gap, now fixed in this PR:

- `feature-group-patterns/08-links-joins.md` — added `Link.asof()` / `asof_on()` to the Join Types table.
- `compute-framework-patterns/06-merge-engine.md` — added `merge_asof()` to the Required Methods table, flagged opt-in with its distinct `asof_config` signature.

All other 0.7.0→0.8.0 changes needed no guide update: collision-safe helper naming (core-internal; no new public helper), the `_extract_column_data_type` contract (docs-only upstream; registry guide already consistent), pyarrow-optional (guides only list it as a backend / test oracle), and `propagate_context_keys` (already documented in `22-feature-config.md` and `11-options.md`).

Still follow-up **code** work, not in this PR: native per-backend ASOF merge-engine implementations, and the helper-naming migration tracked in #245.

## Notes

- mloda is exempt from the repo's 7-day `exclude-newer` defer (`exclude-newer-package = { mloda = false }`), so 0.8.0 resolves immediately despite being released today.
- 0.8.0 ships no breaking changes per the release notes.

## Validation

`uv run tox` is green:

- 3744 passed, 128 skipped
- `ruff format --check` + `ruff check`: clean
- `mypy --strict`: no issues in 390 files
- `bandit`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
