### PR TITLE
feat(data_operations): migrate ffill/ema/sessionization to unique_helper_name (#245)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b88d12cf-fe57-4498-b801-e8e0927d8f33","pid":48987,"procStart":"217449","acquiredAt":1780817516679}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b88d12cf-fe57-4498-b801-e8e0927d8f33","pid":48987,"procStart":"217449","acquiredAt":1780817516679}

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Claude Code
+.claude/scheduled_tasks.lock

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/pandas_ema.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/pandas_ema.py
@@ -7,9 +7,8 @@ import pandas as pd
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
+from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
 from mloda.community.feature_groups.data_operations.row_preserving.ema.base import EmaFeatureGroup
-
-_RN_COL = "__mloda_rn__"
 
 
 class PandasEma(EmaFeatureGroup):
@@ -36,8 +35,10 @@ class PandasEma(EmaFeatureGroup):
     ) -> pd.DataFrame:
         data = data.copy()
 
+        rn_col = unique_helper_name("__mloda_rn__", set(data.columns) | {feature_name})
+
         # Tag original row order so we can restore it after sorting.
-        data[_RN_COL] = range(len(data))
+        data[rn_col] = range(len(data))
 
         ordered = data.sort_values(by=[*partition_by, order_by], na_position="last")
 
@@ -51,5 +52,5 @@ class PandasEma(EmaFeatureGroup):
             ordered[feature_name] = _ema(ordered[source_col])
 
         # Restore original row order, drop the helper column.
-        result = ordered.sort_values(by=_RN_COL).drop(columns=[_RN_COL])
+        result = ordered.sort_values(by=rn_col).drop(columns=[rn_col])
         return result

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/polars_lazy_ema.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/polars_lazy_ema.py
@@ -7,9 +7,8 @@ import polars as pl
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
+from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
 from mloda.community.feature_groups.data_operations.row_preserving.ema.base import EmaFeatureGroup
-
-_RN_COL = "__mloda_rn__"
 
 
 class PolarsLazyEma(EmaFeatureGroup):
@@ -33,8 +32,10 @@ class PolarsLazyEma(EmaFeatureGroup):
         partition_by: list[str],
         order_by: str,
     ) -> pl.LazyFrame:
+        rn_col = unique_helper_name("__mloda_rn__", set(data.collect_schema().names()) | {feature_name})
+
         # Tag original row order so we can restore it after sorting.
-        data = data.with_row_index(_RN_COL)
+        data = data.with_row_index(rn_col)
 
         # Sort within partitions by order_by (nulls last).
         sort_null_last = pl.col(order_by).is_null().cast(pl.Int8)
@@ -47,4 +48,4 @@ class PolarsLazyEma(EmaFeatureGroup):
         ordered = ordered.with_columns(ema_expr.alias(feature_name))
 
         # Restore original row order and drop the helper column.
-        return ordered.sort(_RN_COL).drop(_RN_COL)
+        return ordered.sort(rn_col).drop(rn_col)

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/pandas_ffill.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/pandas_ffill.py
@@ -7,9 +7,8 @@ import pandas as pd
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
+from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
-
-_RN_COL = "__mloda_rn__"
 
 
 class PandasFfill(FfillFeatureGroup):
@@ -35,8 +34,10 @@ class PandasFfill(FfillFeatureGroup):
     ) -> pd.DataFrame:
         data = data.copy()
 
+        rn_col = unique_helper_name("__mloda_rn__", set(data.columns) | {feature_name})
+
         # Tag original row order so we can restore it after sorting.
-        data[_RN_COL] = range(len(data))
+        data[rn_col] = range(len(data))
 
         ordered = data.sort_values(by=[*partition_by, order_by], na_position="last")
 
@@ -48,5 +49,5 @@ class PandasFfill(FfillFeatureGroup):
         ordered[feature_name] = filled
 
         # Restore original row order, drop the helper column.
-        result = ordered.sort_values(by=_RN_COL).drop(columns=[_RN_COL])
+        result = ordered.sort_values(by=rn_col).drop(columns=[rn_col])
         return result

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/polars_lazy_ffill.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/polars_lazy_ffill.py
@@ -7,9 +7,8 @@ import polars as pl
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
+from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
-
-_RN_COL = "__mloda_rn__"
 
 
 class PolarsLazyFfill(FfillFeatureGroup):
@@ -32,8 +31,10 @@ class PolarsLazyFfill(FfillFeatureGroup):
         partition_by: list[str],
         order_by: str,
     ) -> pl.LazyFrame:
+        rn_col = unique_helper_name("__mloda_rn__", set(data.collect_schema().names()) | {feature_name})
+
         # Tag original row order so we can restore it after sorting.
-        data = data.with_row_index(_RN_COL)
+        data = data.with_row_index(rn_col)
 
         # Sort within partitions by order_by (nulls last).
         sort_null_last = pl.col(order_by).is_null().cast(pl.Int8)
@@ -45,4 +46,4 @@ class PolarsLazyFfill(FfillFeatureGroup):
         ordered = ordered.with_columns(fill_expr.alias(feature_name))
 
         # Restore original row order and drop the helper column.
-        return ordered.sort(_RN_COL).drop(_RN_COL)
+        return ordered.sort(rn_col).drop(rn_col)

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pandas_sessionization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pandas_sessionization.py
@@ -7,11 +7,10 @@ import pandas as pd
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
+from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.base import (
     SessionizationFeatureGroup,
 )
-
-_RN_COL = "__mloda_rn__"
 
 
 class PandasSessionization(SessionizationFeatureGroup):
@@ -37,8 +36,10 @@ class PandasSessionization(SessionizationFeatureGroup):
     ) -> pd.DataFrame:
         data = data.copy()
 
+        rn_col = unique_helper_name("__mloda_rn__", set(data.columns) | {feature_name})
+
         # Tag original row order so we can restore it after sorting.
-        data[_RN_COL] = range(len(data))
+        data[rn_col] = range(len(data))
 
         ordered = data.sort_values(by=[*partition_by, order_col], na_position="last")
 
@@ -52,5 +53,5 @@ class PandasSessionization(SessionizationFeatureGroup):
         ordered[feature_name] = is_new.cumsum().astype("int64") - 1
 
         # Restore original row order, drop the helper column.
-        result = ordered.sort_values(by=_RN_COL).drop(columns=[_RN_COL])
+        result = ordered.sort_values(by=rn_col).drop(columns=[rn_col])
         return result

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/polars_lazy_sessionization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/polars_lazy_sessionization.py
@@ -9,11 +9,10 @@ import polars as pl
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
+from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.base import (
     SessionizationFeatureGroup,
 )
-
-_RN_COL = "__mloda_rn__"
 
 
 class PolarsLazySessionization(SessionizationFeatureGroup):
@@ -36,8 +35,10 @@ class PolarsLazySessionization(SessionizationFeatureGroup):
         threshold_seconds: int,
         partition_by: list[str],
     ) -> pl.LazyFrame:
+        rn_col = unique_helper_name("__mloda_rn__", set(data.collect_schema().names()) | {feature_name})
+
         # Tag original row order so we can restore it after sorting.
-        data = data.with_row_index(_RN_COL)
+        data = data.with_row_index(rn_col)
 
         # Sort within partitions by order_col (nulls last) so each partition is a
         # contiguous, time-ordered slice.
@@ -53,4 +54,4 @@ class PolarsLazySessionization(SessionizationFeatureGroup):
         ordered = ordered.with_columns(session.alias(feature_name))
 
         # Restore original row order and drop the helper column.
-        return ordered.sort(_RN_COL).drop(_RN_COL)
+        return ordered.sort(rn_col).drop(rn_col)

--- a/mloda/testing/feature_groups/data_operations/mixins/reserved_columns.py
+++ b/mloda/testing/feature_groups/data_operations/mixins/reserved_columns.py
@@ -1,21 +1,30 @@
-"""Reusable reserved-column acceptance test mixin for data-operations feature groups.
+"""Reusable reserved-column test mixin for data-operations feature groups.
 
-Provides a single standardized test that verifies input columns whose name
-starts with the (formerly reserved) ``__mloda_`` prefix are ACCEPTED, across
-every framework implementation of a data-operation. There is no reserved
-namespace any more: helper columns are made collision-free at runtime, so a
-user column of any name (including a ``__mloda_``-prefixed one) is processed
-normally. Each feature-group test base mixes this in and overrides the abstract
-configuration methods to adapt the generic test to its specific semantics
-(feature name, partition keys, order key).
+Provides two standardized tests, run across every framework implementation of a
+data-operation, that together prove there is no reserved namespace any more:
+helper columns are made collision-free at runtime, so a user column of any name
+(including a ``__mloda_``-prefixed one) is processed normally.
 
-The test method uses a ``test_mixin_`` prefix to match the existing
+- ``test_mixin_reserved_column_collision_accepted``: a ``__mloda_``-prefixed
+  user column is ACCEPTED (the call returns a non-``None`` result).
+- ``test_mixin_helper_column_name_collision_survives``: a user column named like
+  the FG's actual internal helper SURVIVES unchanged in input row order. This is
+  a real collision regression for row-preserving ops. It is opt-in: it runs only
+  when ``reserved_columns_helper_name`` returns a name (default ``None`` skips),
+  so ops that reduce rows or need extra options are unaffected.
+
+Each feature-group test base mixes this in and overrides the abstract
+configuration methods to adapt the generic tests to its specific semantics
+(feature name, partition keys, order key, helper name).
+
+The test methods use a ``test_mixin_`` prefix to match the existing
 convention for shared mixin tests (see ``MaskTestMixin``).
 """
 
 from __future__ import annotations
 
 import pyarrow as pa
+import pytest
 
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
 
@@ -62,6 +71,25 @@ class ReservedColumnsTestMixin:
         """
         return None
 
+    @classmethod
+    def reserved_columns_helper_name(cls) -> str | None:
+        """Internal helper column base name to exercise for collision survival.
+
+        The survival test (below) appends a user column with THIS name and
+        asserts it passes through unchanged. Set it to the base name the FG's
+        pandas / polars backends pick at runtime via ``unique_helper_name`` so
+        the test is a real collision regression for that helper.
+
+        Defaults to ``None`` (the survival test is skipped). The test is opt-in
+        because it only makes sense for row-preserving ops whose FeatureSet is
+        buildable from ``feature_name`` + ``partition_by`` + ``order_by`` alone;
+        ops that reduce rows or require extra options (e.g. a ``constant``) must
+        leave this ``None``. Override to enable it, e.g. ``"__mloda_rn__"``
+        (ffill / ema / sessionization / frame_aggregate) or
+        ``"__mloda_null_sort"`` (offset).
+        """
+        return None
+
     # -- Concrete test method --------------------------------------------------
 
     def test_mixin_reserved_column_collision_accepted(self) -> None:
@@ -89,3 +117,36 @@ class ReservedColumnsTestMixin:
         )
         result = self.implementation_class().calculate_feature(colliding_data, fs)  # type: ignore[attr-defined]
         assert result is not None
+
+    def test_mixin_helper_column_name_collision_survives(self) -> None:
+        """Mixin: a user input column named like the internal helper survives unchanged.
+
+        The pandas / polars backends pick a runtime row helper via
+        ``unique_helper_name``; a user column sharing that base name used to be
+        clobbered (pandas overwrote it with ``range(len)`` then dropped it,
+        polars ``with_row_index`` raised a DuplicateError). Because these ops
+        are row-preserving, a user column of any name must pass through with its
+        original values in input row order. The exercised helper name comes from
+        ``reserved_columns_helper_name``; ``None`` skips this op.
+        """
+        helper_name = self.reserved_columns_helper_name()
+        if helper_name is None:
+            pytest.skip("op opts out of the helper-column survival test")
+
+        base_table: pa.Table = self._arrow_table  # type: ignore[attr-defined]
+        n = base_table.num_rows
+        colliding_values = [1000 + i for i in range(n)]
+        colliding_table = base_table.append_column(
+            helper_name,
+            pa.array(colliding_values, type=pa.int64()),
+        )
+        data = self.create_test_data(colliding_table)  # type: ignore[attr-defined]
+        fs = make_feature_set(
+            self.reserved_columns_feature_name(),
+            partition_by=self.reserved_columns_partition_by(),
+            order_by=self.reserved_columns_order_by(),
+        )
+        result = self.implementation_class().calculate_feature(data, fs)  # type: ignore[attr-defined]
+        assert self.get_row_count(result) == n  # type: ignore[attr-defined]
+        survived = [int(v) for v in self.extract_column(result, helper_name)]  # type: ignore[attr-defined]
+        assert survived == colliding_values, f"user column {helper_name} changed: {survived!r}"

--- a/mloda/testing/feature_groups/data_operations/mixins/reserved_columns.py
+++ b/mloda/testing/feature_groups/data_operations/mixins/reserved_columns.py
@@ -7,11 +7,11 @@ helper columns are made collision-free at runtime, so a user column of any name
 
 - ``test_mixin_reserved_column_collision_accepted``: a ``__mloda_``-prefixed
   user column is ACCEPTED (the call returns a non-``None`` result).
-- ``test_mixin_helper_column_name_collision_survives``: a user column named like
-  the FG's actual internal helper SURVIVES unchanged in input row order. This is
+- ``test_mixin_helper_column_name_collision_survives``: user columns named like
+  the FG's actual internal helpers SURVIVE unchanged in input row order. This is
   a real collision regression for row-preserving ops. It is opt-in: it runs only
-  when ``reserved_columns_helper_name`` returns a name (default ``None`` skips),
-  so ops that reduce rows or need extra options are unaffected.
+  when ``reserved_columns_helper_names`` returns a non-empty set (default empty
+  skips), so ops that reduce rows or need extra options are unaffected.
 
 Each feature-group test base mixes this in and overrides the abstract
 configuration methods to adapt the generic tests to its specific semantics
@@ -72,23 +72,27 @@ class ReservedColumnsTestMixin:
         return None
 
     @classmethod
-    def reserved_columns_helper_name(cls) -> str | None:
-        """Internal helper column base name to exercise for collision survival.
+    def reserved_columns_helper_names(cls) -> set[str]:
+        """Internal helper column base names to exercise for collision survival.
 
-        The survival test (below) appends a user column with THIS name and
-        asserts it passes through unchanged. Set it to the base name the FG's
-        pandas / polars backends pick at runtime via ``unique_helper_name`` so
-        the test is a real collision regression for that helper.
+        The survival test (below) appends a user column for EACH name in this
+        set and asserts every one passes through unchanged. Different framework
+        backends of the same op may pick different helper bases (e.g. offset:
+        pandas ``__mloda_null_sort`` vs polars ``__mloda_orig_idx``; window
+        aggregation: pyarrow ``__mloda_wa_idx__`` vs the SQL backends'
+        ``__mloda_rn``). Listing all of them means that whichever backend the
+        concrete test runs, that backend's own helper is among the injected
+        columns and so is a real collision regression, while the others are
+        harmless passthrough checks.
 
-        Defaults to ``None`` (the survival test is skipped). The test is opt-in
-        because it only makes sense for row-preserving ops whose FeatureSet is
-        buildable from ``feature_name`` + ``partition_by`` + ``order_by`` alone;
-        ops that reduce rows or require extra options (e.g. a ``constant``) must
-        leave this ``None``. Override to enable it, e.g. ``"__mloda_rn__"``
-        (ffill / ema / sessionization / frame_aggregate) or
-        ``"__mloda_null_sort"`` (offset).
+        Defaults to an empty set (the survival test is skipped). The test is
+        opt-in because it only makes sense for row-preserving ops whose
+        FeatureSet is buildable from ``feature_name`` + ``partition_by`` +
+        ``order_by`` alone; ops that reduce rows or require extra options (e.g. a
+        ``constant``) must leave this empty. Override to enable it, e.g.
+        ``{"__mloda_rn__"}`` (ffill / ema / sessionization / frame_aggregate).
         """
-        return None
+        return set()
 
     # -- Concrete test method --------------------------------------------------
 
@@ -119,27 +123,30 @@ class ReservedColumnsTestMixin:
         assert result is not None
 
     def test_mixin_helper_column_name_collision_survives(self) -> None:
-        """Mixin: a user input column named like the internal helper survives unchanged.
+        """Mixin: user input columns named like internal helpers survive unchanged.
 
-        The pandas / polars backends pick a runtime row helper via
-        ``unique_helper_name``; a user column sharing that base name used to be
-        clobbered (pandas overwrote it with ``range(len)`` then dropped it,
-        polars ``with_row_index`` raised a DuplicateError). Because these ops
-        are row-preserving, a user column of any name must pass through with its
-        original values in input row order. The exercised helper name comes from
-        ``reserved_columns_helper_name``; ``None`` skips this op.
+        The pandas / polars / pyarrow backends pick a runtime row helper via
+        ``unique_helper_name`` (the SQL backends via ``pick_helper_column_name``);
+        a user column sharing that base name used to be clobbered (pandas
+        overwrote it with ``range(len)`` then dropped it, polars
+        ``with_row_index`` raised a DuplicateError). Because these ops are
+        row-preserving, a user column of any name must pass through with its
+        original values in input row order. The exercised helper names come from
+        ``reserved_columns_helper_names``; an empty set skips this op. All names
+        are injected at once so whichever backend runs sees its own helper among
+        them.
         """
-        helper_name = self.reserved_columns_helper_name()
-        if helper_name is None:
+        helper_names = self.reserved_columns_helper_names()
+        if not helper_names:
             pytest.skip("op opts out of the helper-column survival test")
 
         base_table: pa.Table = self._arrow_table  # type: ignore[attr-defined]
         n = base_table.num_rows
-        colliding_values = [1000 + i for i in range(n)]
-        colliding_table = base_table.append_column(
-            helper_name,
-            pa.array(colliding_values, type=pa.int64()),
-        )
+        # A distinct value range per helper column so a cross-column mix-up is caught too.
+        expected = {name: [1000 * (j + 1) + i for i in range(n)] for j, name in enumerate(sorted(helper_names))}
+        colliding_table = base_table
+        for name, values in expected.items():
+            colliding_table = colliding_table.append_column(name, pa.array(values, type=pa.int64()))
         data = self.create_test_data(colliding_table)  # type: ignore[attr-defined]
         fs = make_feature_set(
             self.reserved_columns_feature_name(),
@@ -148,5 +155,6 @@ class ReservedColumnsTestMixin:
         )
         result = self.implementation_class().calculate_feature(data, fs)  # type: ignore[attr-defined]
         assert self.get_row_count(result) == n  # type: ignore[attr-defined]
-        survived = [int(v) for v in self.extract_column(result, helper_name)]  # type: ignore[attr-defined]
-        assert survived == colliding_values, f"user column {helper_name} changed: {survived!r}"
+        for name, values in expected.items():
+            survived = [int(v) for v in self.extract_column(result, name)]  # type: ignore[attr-defined]
+            assert survived == values, f"user column {name} changed: {survived!r}"

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
@@ -237,8 +237,8 @@ class EmaTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         return "ts"
 
     @classmethod
-    def reserved_columns_helper_name(cls) -> str | None:
-        return "__mloda_rn__"
+    def reserved_columns_helper_names(cls) -> set[str]:
+        return {"__mloda_rn__"}
 
     # -- Setup: use the dedicated 12-row EMA fixture ------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
@@ -80,6 +80,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+from mloda.testing.feature_groups.data_operations.mixins.reserved_columns import ReservedColumnsTestMixin
 from mloda.user import Feature
 
 _U = timezone.utc
@@ -212,7 +213,7 @@ EXPECTED_EMA_WHOLE_SPAN3: list[Any] = [
 # ---------------------------------------------------------------------------
 
 
-class EmaTestBase(DataOpsTestBase):
+class EmaTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
     """Reusable test base for EMA on backends that compute it NATIVELY.
 
     Subclasses combine this with a framework mixin (``PandasTestMixin``,
@@ -224,6 +225,16 @@ class EmaTestBase(DataOpsTestBase):
     that actually support EMA. The reject backends use ``EmaRejectionTestBase``
     instead and inherit none of these value tests.
     """
+
+    # -- ReservedColumnsTestMixin configuration --------------------------------
+
+    @classmethod
+    def reserved_columns_feature_name(cls) -> str:
+        return "value__ema_2"
+
+    @classmethod
+    def reserved_columns_order_by(cls) -> str | None:
+        return "ts"
 
     # -- Setup: use the dedicated 12-row EMA fixture ------------------------
 
@@ -378,6 +389,31 @@ class EmaTestBase(DataOpsTestBase):
         fs = self._ema_feature_set(2)
         result = self.implementation_class().calculate_feature(self.test_data, fs)
         assert isinstance(result, self.get_expected_type())
+
+    def test_helper_column_name_collision_survives(self) -> None:
+        """A user input column named ``__mloda_rn__`` must survive unchanged.
+
+        The pandas / polars EMA backends hardcode ``__mloda_rn__`` as an
+        internal row-number helper: pandas overwrites the user column with
+        ``range(len)`` then drops it, and polars ``with_row_index("__mloda_rn__")``
+        raises a DuplicateError. Because EMA is row-preserving, a user column
+        of any name must pass through with its original values in input row order.
+        """
+        base_table: pa.Table = self._arrow_table
+        n = base_table.num_rows
+        colliding_values = [1000 + i for i in range(n)]
+        colliding_table = base_table.append_column(
+            "__mloda_rn__",
+            pa.array(colliding_values, type=pa.int64()),
+        )
+        data = self.create_test_data(colliding_table)
+        fs = self._ema_feature_set(2)
+        result = self.implementation_class().calculate_feature(data, fs)
+        assert self.get_row_count(result) == n
+        feature_col = self.extract_column(result, "value__ema_2")
+        assert len(feature_col) == n
+        survived = [int(v) for v in self.extract_column(result, "__mloda_rn__")]
+        assert survived == colliding_values, f"user column __mloda_rn__ changed: {survived!r}"
 
     # -- Option-based configuration -----------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
@@ -236,6 +236,10 @@ class EmaTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
     def reserved_columns_order_by(cls) -> str | None:
         return "ts"
 
+    @classmethod
+    def reserved_columns_helper_name(cls) -> str | None:
+        return "__mloda_rn__"
+
     # -- Setup: use the dedicated 12-row EMA fixture ------------------------
 
     def setup_method(self) -> None:
@@ -389,31 +393,6 @@ class EmaTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         fs = self._ema_feature_set(2)
         result = self.implementation_class().calculate_feature(self.test_data, fs)
         assert isinstance(result, self.get_expected_type())
-
-    def test_helper_column_name_collision_survives(self) -> None:
-        """A user input column named ``__mloda_rn__`` must survive unchanged.
-
-        The pandas / polars EMA backends hardcode ``__mloda_rn__`` as an
-        internal row-number helper: pandas overwrites the user column with
-        ``range(len)`` then drops it, and polars ``with_row_index("__mloda_rn__")``
-        raises a DuplicateError. Because EMA is row-preserving, a user column
-        of any name must pass through with its original values in input row order.
-        """
-        base_table: pa.Table = self._arrow_table
-        n = base_table.num_rows
-        colliding_values = [1000 + i for i in range(n)]
-        colliding_table = base_table.append_column(
-            "__mloda_rn__",
-            pa.array(colliding_values, type=pa.int64()),
-        )
-        data = self.create_test_data(colliding_table)
-        fs = self._ema_feature_set(2)
-        result = self.implementation_class().calculate_feature(data, fs)
-        assert self.get_row_count(result) == n
-        feature_col = self.extract_column(result, "value__ema_2")
-        assert len(feature_col) == n
-        survived = [int(v) for v in self.extract_column(result, "__mloda_rn__")]
-        assert survived == colliding_values, f"user column __mloda_rn__ changed: {survived!r}"
 
     # -- Option-based configuration -----------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
@@ -180,8 +180,8 @@ class FfillTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         return "ts"
 
     @classmethod
-    def reserved_columns_helper_name(cls) -> str | None:
-        return "__mloda_rn__"
+    def reserved_columns_helper_names(cls) -> set[str]:
+        return {"__mloda_rn__"}
 
     @classmethod
     def reference_implementation_class(cls) -> Any:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
@@ -181,7 +181,7 @@ class FfillTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
 
     @classmethod
     def reserved_columns_helper_names(cls) -> set[str]:
-        return {"__mloda_rn__"}
+        return {"__mloda_rn__", "__mloda_rn"}
 
     @classmethod
     def reference_implementation_class(cls) -> Any:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
@@ -59,6 +59,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+from mloda.testing.feature_groups.data_operations.mixins.reserved_columns import ReservedColumnsTestMixin
 from mloda.user import Feature
 
 _U = timezone.utc
@@ -156,7 +157,7 @@ NAIVE_WHOLE_TABLE_FFILL: list[Any] = [
 # ---------------------------------------------------------------------------
 
 
-class FfillTestBase(DataOpsTestBase):
+class FfillTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
     """Abstract base class for ffill-by-time framework tests.
 
     Subclasses combine this with a framework mixin (``PyArrowTestMixin``,
@@ -167,6 +168,16 @@ class FfillTestBase(DataOpsTestBase):
     ``supported_ops`` machinery here. All five backends support ffill
     natively; there are no rejections of supported inputs.
     """
+
+    # -- ReservedColumnsTestMixin configuration --------------------------------
+
+    @classmethod
+    def reserved_columns_feature_name(cls) -> str:
+        return "value__ffill"
+
+    @classmethod
+    def reserved_columns_order_by(cls) -> str | None:
+        return "ts"
 
     @classmethod
     def reference_implementation_class(cls) -> Any:
@@ -289,6 +300,31 @@ class FfillTestBase(DataOpsTestBase):
         fs = self._ffill_feature_set()
         result = self.implementation_class().calculate_feature(self.test_data, fs)
         assert isinstance(result, self.get_expected_type())
+
+    def test_helper_column_name_collision_survives(self) -> None:
+        """A user input column named ``__mloda_rn__`` must survive unchanged.
+
+        The pandas / polars ffill backends hardcode ``__mloda_rn__`` as an
+        internal row-number helper: pandas overwrites the user column with
+        ``range(len)`` then drops it, and polars ``with_row_index("__mloda_rn__")``
+        raises a DuplicateError. Because ffill is row-preserving, a user column
+        of any name must pass through with its original values in input row order.
+        """
+        base_table: pa.Table = self._arrow_table
+        n = base_table.num_rows
+        colliding_values = [1000 + i for i in range(n)]
+        colliding_table = base_table.append_column(
+            "__mloda_rn__",
+            pa.array(colliding_values, type=pa.int64()),
+        )
+        data = self.create_test_data(colliding_table)
+        fs = self._ffill_feature_set()
+        result = self.implementation_class().calculate_feature(data, fs)
+        assert self.get_row_count(result) == n
+        feature_col = self.extract_column(result, "value__ffill")
+        assert len(feature_col) == n
+        survived = [int(v) for v in self.extract_column(result, "__mloda_rn__")]
+        assert survived == colliding_values, f"user column __mloda_rn__ changed: {survived!r}"
 
     # -- Option-based configuration -----------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
@@ -180,6 +180,10 @@ class FfillTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         return "ts"
 
     @classmethod
+    def reserved_columns_helper_name(cls) -> str | None:
+        return "__mloda_rn__"
+
+    @classmethod
     def reference_implementation_class(cls) -> Any:
         # Lazy import so this testing module imports cleanly even before the
         # production code exists (Red phase). The per-backend test files import
@@ -300,31 +304,6 @@ class FfillTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         fs = self._ffill_feature_set()
         result = self.implementation_class().calculate_feature(self.test_data, fs)
         assert isinstance(result, self.get_expected_type())
-
-    def test_helper_column_name_collision_survives(self) -> None:
-        """A user input column named ``__mloda_rn__`` must survive unchanged.
-
-        The pandas / polars ffill backends hardcode ``__mloda_rn__`` as an
-        internal row-number helper: pandas overwrites the user column with
-        ``range(len)`` then drops it, and polars ``with_row_index("__mloda_rn__")``
-        raises a DuplicateError. Because ffill is row-preserving, a user column
-        of any name must pass through with its original values in input row order.
-        """
-        base_table: pa.Table = self._arrow_table
-        n = base_table.num_rows
-        colliding_values = [1000 + i for i in range(n)]
-        colliding_table = base_table.append_column(
-            "__mloda_rn__",
-            pa.array(colliding_values, type=pa.int64()),
-        )
-        data = self.create_test_data(colliding_table)
-        fs = self._ffill_feature_set()
-        result = self.implementation_class().calculate_feature(data, fs)
-        assert self.get_row_count(result) == n
-        feature_col = self.extract_column(result, "value__ffill")
-        assert len(feature_col) == n
-        survived = [int(v) for v in self.extract_column(result, "__mloda_rn__")]
-        assert survived == colliding_values, f"user column __mloda_rn__ changed: {survived!r}"
 
     # -- Option-based configuration -----------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
@@ -161,8 +161,8 @@ class FrameAggregateTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOpsTes
         return "timestamp"
 
     @classmethod
-    def reserved_columns_helper_name(cls) -> str | None:
-        return "__mloda_rn__"
+    def reserved_columns_helper_names(cls) -> set[str]:
+        return {"__mloda_rn__"}
 
     # -- MaskTestMixin configuration -------------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
@@ -160,6 +160,10 @@ class FrameAggregateTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOpsTes
     def reserved_columns_order_by(cls) -> str | None:
         return "timestamp"
 
+    @classmethod
+    def reserved_columns_helper_name(cls) -> str | None:
+        return "__mloda_rn__"
+
     # -- MaskTestMixin configuration -------------------------------------------
 
     @classmethod

--- a/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/frame_aggregate/frame_aggregate.py
@@ -162,7 +162,7 @@ class FrameAggregateTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOpsTes
 
     @classmethod
     def reserved_columns_helper_names(cls) -> set[str]:
-        return {"__mloda_rn__"}
+        return {"__mloda_rn__", "__mloda_rn"}
 
     # -- MaskTestMixin configuration -------------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -66,6 +66,12 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
     def reserved_columns_order_by(cls) -> str | None:
         return "value_int"
 
+    @classmethod
+    def reserved_columns_helper_name(cls) -> str | None:
+        # The pandas / polars backends pick this null-sort helper via
+        # unique_helper_name; a user column of the same name must survive.
+        return "__mloda_null_sort"
+
     ALL_OFFSET_TYPES = {"lag", "lead", "diff", "pct_change", "first_value", "last_value"}
 
     @classmethod

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -67,10 +67,11 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         return "value_int"
 
     @classmethod
-    def reserved_columns_helper_name(cls) -> str | None:
-        # The pandas / polars backends pick this null-sort helper via
-        # unique_helper_name; a user column of the same name must survive.
-        return "__mloda_null_sort"
+    def reserved_columns_helper_names(cls) -> set[str]:
+        # The two backends pick different row helpers via unique_helper_name:
+        # pandas uses "__mloda_null_sort", polars uses "__mloda_orig_idx".
+        # A user column of either name must survive.
+        return {"__mloda_null_sort", "__mloda_orig_idx"}
 
     ALL_OFFSET_TYPES = {"lag", "lead", "diff", "pct_change", "first_value", "last_value"}
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -68,10 +68,11 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
 
     @classmethod
     def reserved_columns_helper_names(cls) -> set[str]:
-        # The two backends pick different row helpers via unique_helper_name:
+        # The backends pick different row helpers via unique_helper_name:
         # pandas uses "__mloda_null_sort", polars uses "__mloda_orig_idx".
-        # A user column of either name must survive.
-        return {"__mloda_null_sort", "__mloda_orig_idx"}
+        # The DuckDB/SQLite backends pick "__mloda_rn" via pick_helper_column_name.
+        # A user column of any of these names must survive.
+        return {"__mloda_null_sort", "__mloda_orig_idx", "__mloda_rn"}
 
     ALL_OFFSET_TYPES = {"lag", "lead", "diff", "pct_change", "first_value", "last_value"}
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/sessionization/sessionization.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/sessionization/sessionization.py
@@ -172,8 +172,8 @@ class SessionizationTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         return "ts"
 
     @classmethod
-    def reserved_columns_helper_name(cls) -> str | None:
-        return "__mloda_rn__"
+    def reserved_columns_helper_names(cls) -> set[str]:
+        return {"__mloda_rn__"}
 
     @classmethod
     def reference_implementation_class(cls) -> Any:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/sessionization/sessionization.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/sessionization/sessionization.py
@@ -172,6 +172,10 @@ class SessionizationTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         return "ts"
 
     @classmethod
+    def reserved_columns_helper_name(cls) -> str | None:
+        return "__mloda_rn__"
+
+    @classmethod
     def reference_implementation_class(cls) -> Any:
         # Lazy import so this testing module imports cleanly even before the
         # production code exists (Red phase). The per-backend test files import
@@ -339,32 +343,6 @@ class SessionizationTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         fs = self._session_feature_set(30, "minute")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
         assert isinstance(result, self.get_expected_type())
-
-    def test_helper_column_name_collision_survives(self) -> None:
-        """A user input column named ``__mloda_rn__`` must survive unchanged.
-
-        The pandas / polars sessionization backends hardcode ``__mloda_rn__`` as
-        an internal row-number helper: pandas overwrites the user column with
-        ``range(len)`` then drops it, and polars ``with_row_index("__mloda_rn__")``
-        raises a DuplicateError. Because sessionization is row-preserving, a user
-        column of any name must pass through with its original values in input
-        row order.
-        """
-        base_table: pa.Table = self._arrow_table
-        n = base_table.num_rows
-        colliding_values = [1000 + i for i in range(n)]
-        colliding_table = base_table.append_column(
-            "__mloda_rn__",
-            pa.array(colliding_values, type=pa.int64()),
-        )
-        data = self.create_test_data(colliding_table)
-        fs = self._session_feature_set(30, "minute", partition_by=["user"], order_by="ts")
-        result = self.implementation_class().calculate_feature(data, fs)
-        assert self.get_row_count(result) == n
-        feature_col = self.extract_column(result, "ts__sessionize_30_minute")
-        assert len(feature_col) == n
-        survived = [int(v) for v in self.extract_column(result, "__mloda_rn__")]
-        assert survived == colliding_values, f"user column __mloda_rn__ changed: {survived!r}"
 
     # -- Option-based configuration -----------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/sessionization/sessionization.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/sessionization/sessionization.py
@@ -76,6 +76,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+from mloda.testing.feature_groups.data_operations.mixins.reserved_columns import ReservedColumnsTestMixin
 from mloda.user import Feature
 
 _U = timezone.utc
@@ -144,7 +145,7 @@ EXPECTED_SESSION_30_MINUTE_WHOLE: list[int] = [2, 0, 1, 2, 1, 1, 2, 1, 1]
 # ---------------------------------------------------------------------------
 
 
-class SessionizationTestBase(DataOpsTestBase):
+class SessionizationTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
     """Abstract base class for sessionization framework tests.
 
     Subclasses combine this with a framework mixin (``PandasTestMixin``,
@@ -155,6 +156,20 @@ class SessionizationTestBase(DataOpsTestBase):
     there is no ``supported_ops`` machinery here. All five backends support
     sessionization natively; there are no rejections of supported inputs.
     """
+
+    # -- ReservedColumnsTestMixin configuration --------------------------------
+
+    @classmethod
+    def reserved_columns_feature_name(cls) -> str:
+        return "ts__sessionize_30_minute"
+
+    @classmethod
+    def reserved_columns_partition_by(cls) -> list[str] | None:
+        return ["user"]
+
+    @classmethod
+    def reserved_columns_order_by(cls) -> str | None:
+        return "ts"
 
     @classmethod
     def reference_implementation_class(cls) -> Any:
@@ -324,6 +339,32 @@ class SessionizationTestBase(DataOpsTestBase):
         fs = self._session_feature_set(30, "minute")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
         assert isinstance(result, self.get_expected_type())
+
+    def test_helper_column_name_collision_survives(self) -> None:
+        """A user input column named ``__mloda_rn__`` must survive unchanged.
+
+        The pandas / polars sessionization backends hardcode ``__mloda_rn__`` as
+        an internal row-number helper: pandas overwrites the user column with
+        ``range(len)`` then drops it, and polars ``with_row_index("__mloda_rn__")``
+        raises a DuplicateError. Because sessionization is row-preserving, a user
+        column of any name must pass through with its original values in input
+        row order.
+        """
+        base_table: pa.Table = self._arrow_table
+        n = base_table.num_rows
+        colliding_values = [1000 + i for i in range(n)]
+        colliding_table = base_table.append_column(
+            "__mloda_rn__",
+            pa.array(colliding_values, type=pa.int64()),
+        )
+        data = self.create_test_data(colliding_table)
+        fs = self._session_feature_set(30, "minute", partition_by=["user"], order_by="ts")
+        result = self.implementation_class().calculate_feature(data, fs)
+        assert self.get_row_count(result) == n
+        feature_col = self.extract_column(result, "ts__sessionize_30_minute")
+        assert len(feature_col) == n
+        survived = [int(v) for v in self.extract_column(result, "__mloda_rn__")]
+        assert survived == colliding_values, f"user column __mloda_rn__ changed: {survived!r}"
 
     # -- Option-based configuration -----------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/sessionization/sessionization.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/sessionization/sessionization.py
@@ -173,7 +173,7 @@ class SessionizationTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
 
     @classmethod
     def reserved_columns_helper_names(cls) -> set[str]:
-        return {"__mloda_rn__"}
+        return {"__mloda_rn__", "__mloda_rn"}
 
     @classmethod
     def reference_implementation_class(cls) -> Any:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -76,6 +76,12 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
     def reserved_columns_feature_name(cls) -> str:
         return "value_int__sum_window"
 
+    @classmethod
+    def reserved_columns_helper_name(cls) -> str | None:
+        # The pyarrow backend picks this row-index helper via unique_helper_name;
+        # a user column of the same name must survive unchanged.
+        return "__mloda_wa_idx__"
+
     ALL_AGG_TYPES = {
         "sum",
         "avg",

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -77,10 +77,12 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
         return "value_int__sum_window"
 
     @classmethod
-    def reserved_columns_helper_name(cls) -> str | None:
-        # The pyarrow backend picks this row-index helper via unique_helper_name;
-        # a user column of the same name must survive unchanged.
-        return "__mloda_wa_idx__"
+    def reserved_columns_helper_names(cls) -> set[str]:
+        # Backends pick different row helpers: pyarrow uses "__mloda_wa_idx__"
+        # (unique_helper_name); duckdb / sqlite use "__mloda_rn"
+        # (pick_helper_column_name default). pandas / polars use no row helper for
+        # the windowed sum. A user column of any of these names must survive.
+        return {"__mloda_wa_idx__", "__mloda_rn"}
 
     ALL_AGG_TYPES = {
         "sum",


### PR DESCRIPTION
## Summary

Closes #245 (a #240 follow-up, unblocked by the mloda 0.8.0 bump).

The time-series row-preserving FGs (ffill, ema, sessionization) were the only
data-operations family still hardcoding a module-level `_RN_COL = "__mloda_rn__"`
row-index helper in their **pandas** and **polars** backends and injecting it
directly. A user input column literally named `__mloda_rn__` collided:

- pandas silently overwrote it (`data[_RN_COL] = range(len)`) then dropped it,
- polars `with_row_index("__mloda_rn__")` raised `DuplicateError`.

This is exactly the failure mode #240 set out to eliminate. The SQL backends
(DuckDB/SQLite, via `pick_helper_column_name`) and PyArrow (sort-permutation,
no named helper) were already collision-safe.

## Change

Replaced the hardcoded helper with the runtime collision-safe
`unique_helper_name("__mloda_rn__", taken)` convention, seeded with the input
columns + the output feature name, mirroring the already-migrated `offset`
backends. Behaviour is unchanged in the no-collision case (the helper returns
the base name when it is absent).

Six backend modules updated:
- `row_preserving/ffill/{pandas,polars_lazy}_ffill.py`
- `row_preserving/ema/{pandas,polars_lazy}_ema.py`
- `row_preserving/sessionization/{pandas,polars_lazy}_sessionization.py`

## Tests

Per the issue's definition of done, each of the three shared test bases
(`FfillTestBase`, `EmaTestBase`, `SessionizationTestBase`) mixes in
`ReservedColumnsTestMixin` with the right `reserved_columns_feature_name` /
`partition_by` / `order_by` overrides (sessionization partitions by `user`, not
`region`) and gains a precise regression asserting a user `__mloda_rn__` column
survives unchanged in input row order.

Before the fix these 6 cases failed (pandas: overwritten/dropped column;
polars: `DuplicateError`); after, they pass. PyArrow/DuckDB/SQLite were already
safe and stay green throughout. `EmaRejectionTestBase` is intentionally left
untouched (pyarrow/duckdb/sqlite reject EMA).

## Follow-up: survival test folded into the mixin

The three near-identical `test_helper_column_name_collision_survives` methods
were consolidated into `ReservedColumnsTestMixin` as a single **opt-in** generic
test (`test_mixin_helper_column_name_collision_survives`), driven by a
`reserved_columns_helper_names()` hook returning the **set** of helper base names
the FG's backends pick at runtime. The test injects a user column for every name
in the set and asserts each survives, so whichever backend the concrete test
runs, that backend's own helper is exercised as a real collision regression
(backends differ, so a single name would only collide on one of them):

- ffill / ema / sessionization / frame_aggregate -> `{"__mloda_rn__"}`
- offset -> `{"__mloda_null_sort", "__mloda_orig_idx"}` (pandas / polars)
- window_aggregation -> `{"__mloda_wa_idx__", "__mloda_rn"}` (pyarrow / duckdb + sqlite)

The hook defaults to an empty set (skip), so the ~10 non-row-preserving or
option-requiring mixin consumers (scalar_arithmetic, aggregation, rank, ...) are
unaffected. Net: ~75 lines of duplicated test code removed; real per-backend
survival coverage gained for offset (pandas + polars), window_aggregation
(pyarrow + duckdb + sqlite) and frame_aggregate.

## Definition of done

- [x] ffill / ema / sessionization pandas + polars backends use `unique_helper_name("__mloda_rn__", taken)`
- [x] Each of the three FG test bases mixes in `ReservedColumnsTestMixin` with the right overrides
- [x] Helper-column survival test consolidated into the mixin (opt-in via `reserved_columns_helper_names`), retrofitting offset / window_aggregation / frame_aggregate with real per-backend coverage
- [x] `tox -e python310` green (3781 passed / 141 skipped, ruff format + check, mypy --strict, bandit)

