### PR TITLE
docs(guides): document and exercise the 0.8.0 as-of (point-in-time) join (closes #198)

### DIFF
--- a/docs/guides/data-operation-patterns/framework-support-matrix.md
+++ b/docs/guides/data-operation-patterns/framework-support-matrix.md
@@ -17,6 +17,10 @@ One-page lookup for "does operation *X* work on framework *Y*?". Rows are the el
 - A ✗ is not a bug. It is a deliberate exclusion documented in [Known divergences](known-divergences.md) or recorded by a `supported_*()` override in `*/tests/test_{framework}.py`. See the matching entry there before attempting to add support.
 - The matrix does not list every percentile quantile. For `percentile` and `datetime` the op either ships in full or does not ship at all: see the detail tables, where the single "(all)" row reflects that absence of a `supported_*()` method. For `frame_aggregate` the per-frame-type detail breaks out time-window units (`time:second`, ..., `time:year`) so framework-specific unit gaps (e.g. SQLite/Pandas rejecting `time:month`) surface as ✗ rather than being hidden behind a single `time` row.
 
+## Not in this matrix: joins
+
+This matrix only covers data-operation feature groups (single-source column transforms). Joins are a separate concern handled by the compute frameworks' merge engines in core, not by registry feature groups, so they do not appear above. The **as-of (point-in-time) join** added in mloda 0.8.0 has its own per-backend support table and a worked example in [Links and joins](../feature-group-patterns/08-links-joins.md#as-of-point-in-time-joins).
+
 ---
 
 <!-- BEGIN GENERATED: framework-support-matrix -->

--- a/docs/guides/feature-group-patterns/08-links-joins.md
+++ b/docs/guides/feature-group-patterns/08-links-joins.md
@@ -62,19 +62,106 @@ def test_input_features_with_link():
 | `Link.union()` | UNION | `union_on()` |
 | `Link.asof()` | ASOF JOIN (point-in-time) | `asof_on()` |
 
-ASOF (point-in-time) joins match each left row to the nearest right row by time.
-`Link.asof()` / `Link.asof_on()` require the keyword args `left_time_column=` and
-`right_time_column=`, and accept `direction` (`"backward"` default, `"forward"`,
-`"nearest"`), `tolerance`, and `allow_exact_matches` (default `True`) — pandas
-`merge_asof` semantics. The by-key `Index` is the equi match; the time columns drive
-the inequality match.
+ASOF (point-in-time) joins match each left row to the right row that was valid at
+the left row's timestamp. See [As-of (point-in-time) joins](#as-of-point-in-time-joins)
+below for the keyword reference, per-backend support, and a runnable end-to-end example.
+
+## As-of (point-in-time) joins
+
+A plain `Link.inner()` / `Link.left()` is an equi-join: rows pair up only when their
+join keys are exactly equal. An as-of join (added in mloda 0.8.0) adds a per-row time
+match on top of that: for each left row, mloda picks the right row that was valid at
+the left row's timestamp. This is the join that recsys, slowly-changing-dimension
+lookups, and event-vs-state pipelines need, and it cannot be expressed as an equi-join.
+
+Two matches happen at once:
+
+- **Equi match on the by-key.** The join `Index` (derived from `index_columns()` when
+  you use `asof_on`, or given explicitly via `JoinSpec` when you use `asof`) is matched
+  for equality, exactly like an inner join. Rows only pair up within the same key.
+- **Inequality match on time.** Within each key, the left row's `left_time_column` is
+  matched against the right row's `right_time_column` according to `direction`.
+
+| Keyword | Default | Meaning |
+|---|---|---|
+| `left_time_column` | required | Time column on the left side. |
+| `right_time_column` | required | Time column on the right side. |
+| `direction` | `"backward"` | `"backward"`: latest right row at or before the left time. `"forward"`: earliest right row at or after it. `"nearest"`: whichever is closest in time. |
+| `tolerance` | `None` | Maximum allowed time gap; a left row with no right match inside the gap gets nulls. Accepts a number or a `timedelta`. |
+| `allow_exact_matches` | `True` | Whether an exactly-equal timestamp counts as a match. |
+
+These follow pandas `merge_asof` semantics. The keyword arguments are keyword-only on
+both factories (`Link.asof(left_spec, right_spec, *, left_time_column=..., ...)` and
+`Link.asof_on(LeftFG, RightFG, *, left_time_column=..., ...)`).
+
+### Backend support
+
+| Backend | As-of | Notes |
+|---|---|---|
+| PyArrow | yes | Runs pandas `merge_asof` on the converted frame. |
+| Pandas | yes | Native `pd.merge_asof`. |
+| Polars (lazy) | yes | Native `join_asof`. |
+| DuckDB | yes | SQL `ASOF JOIN`. Rejects `direction="nearest"` and a `timedelta` tolerance with a `ValueError`; pass a numeric tolerance instead. |
+| SQLite | yes | SQL window functions. Same restriction as DuckDB: no `nearest`, numeric tolerance only. |
+
+`direction="nearest"` and `timedelta` tolerances work on the in-memory backends
+(PyArrow, Pandas, Polars) but are rejected up front on the SQL backends rather than
+emulated in Python. Pick a backend that supports the knobs your join needs.
+
+### Defining the link
+
+With `asof_on`, both sides expose the by-key through `index_columns()`:
 
 ```python
+from mloda.user import Link
+
 link = Link.asof_on(
-    EventFeatureGroup, PriceFeatureGroup,
-    left_time_column="event_ts", right_time_column="quote_ts",
+    EventFeatureGroup,
+    QuoteFeatureGroup,
+    left_time_column="event_ts",
+    right_time_column="quote_ts",
+    direction="backward",
 )
 ```
+
+When a side has no `index_columns()`, name the by-key explicitly with `JoinSpec`:
+
+```python
+from mloda.user import Index, JoinSpec, Link
+
+link = Link.asof(
+    JoinSpec(EventFeatureGroup, Index(("symbol",))),
+    JoinSpec(QuoteFeatureGroup, Index(("symbol",))),
+    left_time_column="event_ts",
+    right_time_column="quote_ts",
+    direction="backward",
+)
+```
+
+### Running it
+
+The join fires when a consumer feature group requests features that resolve to both
+linked sides; mloda hands the merged frame to that group's `calculate_feature`. Pass
+the link to `run_all` (the `links` parameter is a `set`):
+
+```python
+from mloda.user import Feature, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+results = mloda.run_all(
+    [Feature("asof_event_id"), Feature("asof_event_price")],
+    compute_frameworks={PandasDataFrame},
+    links={link},
+    plugin_collector=PluginCollector.enabled_feature_groups(
+        {EventFeatureGroup, QuoteFeatureGroup, EventPriceFeatureGroup}
+    ),
+)
+```
+
+A complete, runnable version (two `DataCreator`-backed source feature groups, a small
+hand-traced dataset, and the backward-join semantics asserted row by row) lives in the
+registry test suite:
+[`tests/test_end2end/test_asof_join_example.py`](https://github.com/mloda-ai/mloda-registry/blob/main/tests/test_end2end/test_asof_join_example.py).
 
 ## Using JoinSpec (Explicit Control)
 

--- a/docs/guides/feature-group-patterns/08-links-joins.md
+++ b/docs/guides/feature-group-patterns/08-links-joins.md
@@ -98,15 +98,17 @@ both factories (`Link.asof(left_spec, right_spec, *, left_time_column=..., ...)`
 
 | Backend | As-of | Notes |
 |---|---|---|
-| PyArrow | yes | Runs pandas `merge_asof` on the converted frame. |
+| PyArrow | not supported (needs fix) | The current core implementation falls back to pandas (`to_pandas` then `pd.merge_asof` then `from_pandas`): it requires pandas to be installed and is not a native Arrow join. Treated as unsupported pending a native/reject fix, tracked in [mloda#488](https://github.com/mloda-ai/mloda/issues/488). Use Pandas or Polars instead. |
 | Pandas | yes | Native `pd.merge_asof`. |
 | Polars (lazy) | yes | Native `join_asof`. |
 | DuckDB | yes | SQL `ASOF JOIN`. Rejects `direction="nearest"` and a `timedelta` tolerance with a `ValueError`; pass a numeric tolerance instead. |
 | SQLite | yes | SQL window functions. Same restriction as DuckDB: no `nearest`, numeric tolerance only. |
 
-`direction="nearest"` and `timedelta` tolerances work on the in-memory backends
-(PyArrow, Pandas, Polars) but are rejected up front on the SQL backends rather than
-emulated in Python. Pick a backend that supports the knobs your join needs.
+`direction="nearest"` and `timedelta` tolerances work on the Pandas and Polars
+backends but are rejected up front on the SQL backends rather than emulated in Python.
+PyArrow is not a supported target for as-of joins yet (see the note above and
+[mloda#488](https://github.com/mloda-ai/mloda/issues/488)). Pick a backend that
+supports the knobs your join needs.
 
 ### Defining the link
 

--- a/tests/test_end2end/test_asof_join_example.py
+++ b/tests/test_end2end/test_asof_join_example.py
@@ -1,0 +1,199 @@
+"""End-to-end worked example of mloda 0.8.0's ASOF (point-in-time) join.
+
+This module is a *readable* example, not a red-phase failing test: mloda 0.8.0
+already implements the ASOF join in core, so the test PASSES on first run. It is
+kept as a regression/example that pins the point-in-time semantics, and the ASOF
+join guide links to it.
+
+Scenario (tiny and hand-traceable)
+----------------------------------
+Two source feature groups, both pandas data sources backed by ``DataCreator``:
+
+* ``AsofEventSource`` (LEFT / events): columns ``id``, ``symbol``, ``event_ts``.
+* ``AsofQuoteSource`` (RIGHT / quotes): columns ``symbol``, ``quote_ts``, ``price``.
+
+Both declare ``index_columns() -> [Index(("symbol",))]`` so the ASOF link can
+derive the equi by-key (``symbol``) automatically. ``Link.asof_on(...)`` then
+performs a *backward* as-of join: for each event row it picks the quote with the
+same ``symbol`` whose ``quote_ts`` is the latest value ``<= event_ts``.
+``allow_exact_matches=True`` (the default) means an event whose timestamp equals
+a quote timestamp matches that quote.
+
+Quote price timelines (per symbol)::
+
+    AAA:  10:00 -> 100      BBB:  10:00 -> 200
+          10:30 -> 110            10:30 -> 220
+
+Hand-traced expected price in effect at each event (backward, exact allowed)::
+
+    id  symbol  event_ts   reasoning                                  -> price
+    0   AAA     10:00      exact match on AAA@10:00                    -> 100
+    1   AAA     10:15      latest AAA quote <= 10:15 is AAA@10:00      -> 100
+    2   AAA     10:45      latest AAA quote <= 10:45 is AAA@10:30      -> 110
+    3   BBB     10:30      exact match on BBB@10:30                    -> 220
+    4   BBB     11:00      latest BBB quote <= 11:00 is BBB@10:30      -> 220
+
+The join is keyed by ``symbol`` (the by-key), so AAA events never see BBB quotes
+and vice versa. Every event sits at or after its symbol's first quote, so there
+are no null matches in this example.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
+from mloda.provider import ComputeFramework, FeatureGroup, FeatureSet
+from mloda.user import Feature, FeatureName, Index, Link, Options, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+_U = timezone.utc
+
+# Expected price in effect at each event id (see module docstring for the trace).
+_ASOF_BACKWARD_EXPECTED: dict[int, int] = {0: 100, 1: 100, 2: 110, 3: 220, 4: 220}
+
+
+class AsofEventSource(FeatureGroup):
+    """LEFT side: event rows carrying the entity (``symbol``) and an event time."""
+
+    compute_framework: type[ComputeFramework] = PandasDataFrame
+
+    @classmethod
+    def get_raw_data(cls) -> dict[str, list[Any]]:
+        return {
+            "id": [0, 1, 2, 3, 4],
+            "symbol": ["AAA", "AAA", "AAA", "BBB", "BBB"],
+            "event_ts": [
+                datetime(2023, 1, 1, 10, 0, 0, tzinfo=_U),
+                datetime(2023, 1, 1, 10, 15, 0, tzinfo=_U),
+                datetime(2023, 1, 1, 10, 45, 0, tzinfo=_U),
+                datetime(2023, 1, 1, 10, 30, 0, tzinfo=_U),
+                datetime(2023, 1, 1, 11, 0, 0, tzinfo=_U),
+            ],
+        }
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("symbol",))]
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(set(cls.get_raw_data().keys()))
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame(cls.get_raw_data())
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {cls.compute_framework}
+
+
+class AsofQuoteSource(FeatureGroup):
+    """RIGHT side: a per-symbol price timeline keyed by quote time."""
+
+    compute_framework: type[ComputeFramework] = PandasDataFrame
+
+    @classmethod
+    def get_raw_data(cls) -> dict[str, list[Any]]:
+        return {
+            "symbol": ["AAA", "AAA", "BBB", "BBB"],
+            "quote_ts": [
+                datetime(2023, 1, 1, 10, 0, 0, tzinfo=_U),
+                datetime(2023, 1, 1, 10, 30, 0, tzinfo=_U),
+                datetime(2023, 1, 1, 10, 0, 0, tzinfo=_U),
+                datetime(2023, 1, 1, 10, 30, 0, tzinfo=_U),
+            ],
+            "price": [100, 110, 200, 220],
+        }
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("symbol",))]
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(set(cls.get_raw_data().keys()))
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame(cls.get_raw_data())
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {cls.compute_framework}
+
+
+class AsofEventPrice(FeatureGroup):
+    """Consumer that pulls columns from both sources, triggering the ASOF link.
+
+    Requesting features from two different feature groups that have a ``Link``
+    between them is what makes mloda apply the join: the merged frame is handed
+    to ``calculate_feature`` as ``data``. This group then exposes the event id
+    and the as-of price as two named features so the test can assert keyed by id
+    (the merge engine sorts the result by ``event_ts``, so a positional list
+    would not be in input order).
+    """
+
+    compute_framework: type[ComputeFramework] = PandasDataFrame
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"asof_event_id", "asof_event_price"}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        # id + event_ts resolve to AsofEventSource; quote_ts + price to AsofQuoteSource.
+        # symbol (the by-key) is retained automatically as the index column.
+        return {
+            Feature("id"),
+            Feature("event_ts"),
+            Feature("quote_ts"),
+            Feature("price"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"asof_event_id": data["id"], "asof_event_price": data["price"]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {cls.compute_framework}
+
+
+def _run_asof_backward() -> dict[int, int]:
+    """Run the backward ASOF join through ``run_all`` and return ``{id: price}``."""
+    link = Link.asof_on(
+        AsofEventSource,
+        AsofQuoteSource,
+        left_time_column="event_ts",
+        right_time_column="quote_ts",
+        direction="backward",
+    )
+    plugin_collector = PluginCollector.enabled_feature_groups({AsofEventSource, AsofQuoteSource, AsofEventPrice})
+
+    results = mloda.run_all(
+        [Feature("asof_event_id"), Feature("asof_event_price")],
+        compute_frameworks={PandasDataFrame},
+        links={link},
+        plugin_collector=plugin_collector,
+    )
+
+    for table in results:
+        if isinstance(table, pd.DataFrame) and "asof_event_price" in table.columns:
+            return {int(i): int(p) for i, p in zip(table["asof_event_id"], table["asof_event_price"])}
+
+    raise AssertionError("No result frame with asof_event_price found")
+
+
+class TestAsofJoinExample:
+    """Backward point-in-time join happy path on the pandas backend."""
+
+    def test_backward_asof_picks_price_in_effect(self) -> None:
+        result = _run_asof_backward()
+        assert result == _ASOF_BACKWARD_EXPECTED


### PR DESCRIPTION
## Summary

mloda 0.8.0 shipped `JoinType.ASOF` (`Link.asof` / `Link.asof_on`) with native per-backend `merge_asof`, unblocking #198. The issue's 2026-05-25 update rescoped it: there is no registry-side composer to build (the native per-backend variants landed in core, mloda#459 / #462), so the remaining work is a usage example, a guide, and a cross-link.

This closes the three revised-scope checkboxes:

- **Example test exercising `Link.asof(...)` end-to-end** -> `tests/test_end2end/test_asof_join_example.py`. Two `DataCreator`-backed source FGs (events + a per-symbol quote timeline) and a consumer FG, joined via `Link.asof_on(..., direction="backward")` through `run_all`. A tiny hand-traced dataset pins the point-in-time semantics: latest quote at-or-before each event, by-key isolation, exact-match. Modeled on the existing sessionization `test_integration.py`.
- **Guide entry** -> a new "As-of (point-in-time) joins" section in `feature-group-patterns/08-links-joins.md` (the right home: a join, not a row-preserving data op). Keyword reference, per-backend support table (SQL backends reject `direction="nearest"` and `timedelta` tolerance), the `asof` / `asof_on` link forms, the `run_all` wiring, and a link to the example test. The Join Types prose now points here instead of duplicating the keyword list.
- **Cross-link from `framework-support-matrix.md`** -> a prose note kept **outside** the generated, drift-checked block, explaining joins are a merge-engine concern (not a data-op FG) and pointing to the as-of section.

## Verification

- `python scripts/lint_docs.py` -> All docs OK (relative links + anchors resolve, no `mloda.core` imports in snippets, no orphan guide).
- `pytest tests/test_end2end/test_asof_join_example.py` -> 1 passed.
- `ruff format --check`, `ruff check`, `mypy --strict` on the new test -> clean.

Closes #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)