### PR TITLE
refactor(data_operations): consolidate aggregation-family bases (#246)

### DIFF
--- a/mloda/community/feature_groups/data_operations/aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/base.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from mloda.core.abstract_plugins.components.data_types import DataType
-from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys
 
+from mloda.community.feature_groups.data_operations.aggregation_base import (
+    AGGREGATION_TYPES,
+    AggregationFeatureGroupBase,
+)
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
 
-class AggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class AggregationFeatureGroup(AggregationFeatureGroupBase):
     """Base class for aggregation operations that reduce rows.
 
     Aggregation computes an aggregate over partitioned groups and
@@ -85,31 +85,10 @@ class AggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
-    AGGREGATION_TYPE = "aggregation_type"
     PARTITION_BY = "partition_by"
 
-    AGGREGATION_TYPES = {
-        "sum": "Sum of values",
-        "avg": "Average of values",
-        "mean": "Average of values",
-        "count": "Count of non-null values",
-        "min": "Minimum value",
-        "max": "Maximum value",
-        "std": "Population standard deviation (ddof=0)",
-        "var": "Population variance (ddof=0)",
-        "std_pop": "Population standard deviation (ddof=0, same as std)",
-        "std_samp": "Sample standard deviation (ddof=1)",
-        "var_pop": "Population variance (ddof=0, same as var)",
-        "var_samp": "Sample variance (ddof=1)",
-        "median": "Median value",
-        "mode": "Most frequent value",
-        "nunique": "Count of unique values",
-        "first": "First value in group",
-        "last": "Last value in group",
-    }
-
     PROPERTY_MAPPING = {
-        AGGREGATION_TYPE: {
+        AggregationFeatureGroupBase.AGGREGATION_TYPE: {
             **AGGREGATION_TYPES,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
@@ -131,11 +110,6 @@ class AggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             DefaultOptionKeys.default: None,
         },
     }
-
-    @classmethod
-    def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
-        """Validate that the parsed aggregation type is in AGGREGATION_TYPES."""
-        return operation_config in cls.AGGREGATION_TYPES
 
     @classmethod
     def match_feature_group_criteria(
@@ -164,39 +138,6 @@ class AggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             return False
 
         return True
-
-    @classmethod
-    def get_aggregation_type(cls, feature_name: str) -> str:
-        """Extract the aggregation type from a feature name string."""
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract aggregation type from feature name: {feature_name}")
-
-    @classmethod
-    def _extract_aggregation_type(cls, feature: Feature) -> str:
-        """Extract aggregation type from feature (string-based or config-based)."""
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        agg_type = feature.options.get(cls.AGGREGATION_TYPE)
-        if agg_type is None:
-            raise ValueError(f"Could not extract aggregation type for {feature_name}")
-        return str(agg_type)
-
-    @classmethod
-    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
-        """Declare INT64 for count/nunique (counting ops); other aggregates stay open."""
-        try:
-            agg_type = cls._extract_aggregation_type(feature)
-        except Exception:  # best-effort during planning; failure leaves the type undeclared
-            return None
-        if agg_type in {"count", "nunique"}:
-            return DataType.INT64
-        return None
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/aggregation_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation_base.py
@@ -1,0 +1,94 @@
+"""Shared skeleton for the aggregation feature-group families.
+
+The aggregation, window-aggregation, scalar-aggregate, and frame-aggregate
+families share the same aggregation-type extraction machinery: they parse the
+same aggregation names out of the feature name or options, validate them against
+a canonical aggregation-type table, and declare INT64 for counting ops. Issue
+#246 had this logic duplicated across the families' ``base.py`` files.
+
+``AggregationFeatureGroupBase`` holds the identical parts, mirroring the
+``ArithmeticFeatureGroupBase`` consolidation from issue #214. The families
+subclass it and override ``AGGREGATION_TYPES`` (so each family advertises its
+own supported set / descriptions) and ``_COUNTING_AGG_TYPES`` (which agg types
+produce an integer count), plus the family-specific bits (operand count,
+matching, PROPERTY_MAPPING). Per-backend computation lives in the backend
+modules.
+"""
+
+from __future__ import annotations
+
+from mloda.core.abstract_plugins.components.data_types import DataType
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.provider import FeatureGroup
+
+AGGREGATION_TYPES: dict[str, str] = {
+    "sum": "Sum of values",
+    "avg": "Average of values",
+    "mean": "Average of values",
+    "count": "Count of non-null values",
+    "min": "Minimum value",
+    "max": "Maximum value",
+    "std": "Population standard deviation (ddof=0)",
+    "var": "Population variance (ddof=0)",
+    "std_pop": "Population standard deviation (ddof=0, same as std)",
+    "std_samp": "Sample standard deviation (ddof=1)",
+    "var_pop": "Population variance (ddof=0, same as var)",
+    "var_samp": "Sample variance (ddof=1)",
+    "median": "Median value",
+    "mode": "Most frequent value",
+    "nunique": "Count of unique values",
+    "first": "First value in group",
+    "last": "Last value in group",
+}
+
+
+class AggregationFeatureGroupBase(FeatureChainParserMixin, FeatureGroup):
+    AGGREGATION_TYPE = "aggregation_type"
+
+    #: Canonical aggregation-type table. Subclasses override to advertise their
+    #: own supported set / descriptions.
+    AGGREGATION_TYPES: dict[str, str] = AGGREGATION_TYPES
+
+    #: Aggregation types that produce an integer count. Subclasses override which
+    #: agg types declare INT64 via ``return_data_type_rule``.
+    _COUNTING_AGG_TYPES: frozenset[str] = frozenset({"count", "nunique"})
+
+    @classmethod
+    def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
+        """Validate that the parsed aggregation type is in AGGREGATION_TYPES."""
+        return operation_config in cls.AGGREGATION_TYPES
+
+    @classmethod
+    def get_aggregation_type(cls, feature_name: str) -> str:
+        """Extract the aggregation type from a feature name string."""
+        prefix_patterns = cls._get_prefix_patterns()
+        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
+        if operation_config is not None:
+            return operation_config
+        raise ValueError(f"Could not extract aggregation type from feature name: {feature_name}")
+
+    @classmethod
+    def _extract_aggregation_type(cls, feature: Feature) -> str:
+        """Extract aggregation type from feature (string-based or config-based)."""
+        feature_name = feature.name
+        prefix_patterns = cls._get_prefix_patterns()
+        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
+        if operation_config is not None:
+            return operation_config
+        agg_type = feature.options.get(cls.AGGREGATION_TYPE)
+        if agg_type is None:
+            raise ValueError(f"Could not extract aggregation type for {feature_name}")
+        return str(agg_type)
+
+    @classmethod
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+        """Declare INT64 for counting ops; other aggregates stay open."""
+        try:
+            agg_type = cls._extract_aggregation_type(feature)
+        except Exception:  # best-effort during planning; failure leaves the type undeclared
+            return None
+        if agg_type in cls._COUNTING_AGG_TYPES:
+            return DataType.INT64
+        return None

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -13,9 +13,6 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.aggregation_base import (
-    AGGREGATION_TYPES as _CANONICAL_AGGREGATION_TYPES,
-)
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
 
@@ -29,10 +26,11 @@ _TIME_WINDOW_PATTERN = re.compile(r"^(.+)__(\w+)_(\d+)_(\w+)_window$")
 _CUMULATIVE_PATTERN = re.compile(r"^(.+)__cum(\w+)$")
 _EXPANDING_PATTERN = re.compile(r"^(.+)__expanding_(\w+)$")
 
-# Frame aggregation supports the order-independent subset of the shared
+# Frame aggregation supports the order-independent subset of the canonical
 # aggregation-type table (no mode/nunique/first/last, no ddof-variant spellings).
-_FRAME_SUPPORTED_AGG_TYPES = {"sum", "avg", "count", "min", "max", "std", "var", "median"}
-_AGGREGATION_TYPES = frozenset(_CANONICAL_AGGREGATION_TYPES.keys() & _FRAME_SUPPORTED_AGG_TYPES)
+# Frame never uses the canonical descriptions, so this is an explicit set rather
+# than a derivation from the shared table.
+_AGGREGATION_TYPES = frozenset({"sum", "avg", "count", "min", "max", "std", "var", "median"})
 _CUMULATIVE_OPS = _AGGREGATION_TYPES
 _TIME_UNITS = {"second", "minute", "hour", "day", "week", "month", "year"}
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -13,6 +13,9 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.aggregation_base import (
+    AGGREGATION_TYPES as _CANONICAL_AGGREGATION_TYPES,
+)
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
 
@@ -26,7 +29,10 @@ _TIME_WINDOW_PATTERN = re.compile(r"^(.+)__(\w+)_(\d+)_(\w+)_window$")
 _CUMULATIVE_PATTERN = re.compile(r"^(.+)__cum(\w+)$")
 _EXPANDING_PATTERN = re.compile(r"^(.+)__expanding_(\w+)$")
 
-_AGGREGATION_TYPES = {"sum", "avg", "count", "min", "max", "std", "var", "median"}
+# Frame aggregation supports the order-independent subset of the shared
+# aggregation-type table (no mode/nunique/first/last, no ddof-variant spellings).
+_FRAME_SUPPORTED_AGG_TYPES = {"sum", "avg", "count", "min", "max", "std", "var", "median"}
+_AGGREGATION_TYPES = frozenset(_CANONICAL_AGGREGATION_TYPES.keys() & _FRAME_SUPPORTED_AGG_TYPES)
 _CUMULATIVE_OPS = _AGGREGATION_TYPES
 _TIME_UNITS = {"second", "minute", "hour", "day", "week", "month", "year"}
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
@@ -14,15 +14,14 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys
 
+from mloda.community.feature_groups.data_operations.aggregation_base import AggregationFeatureGroupBase
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
 AGGREGATION_TYPES = {
@@ -42,18 +41,21 @@ AGGREGATION_TYPES = {
 }
 
 
-class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class ScalarAggregateFeatureGroup(AggregationFeatureGroupBase):
     PREFIX_PATTERN = r".*__([\w]+)_scalar$"
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
-    AGGREGATION_TYPE = "aggregation_type"
+    AGGREGATION_TYPES = AGGREGATION_TYPES
+
+    # Scalar aggregation declares INT64 only for count (not nunique, which it does not support).
+    _COUNTING_AGG_TYPES = frozenset({"count"})
 
     _SUPPORTED_AGG_TYPES: ClassVar[frozenset[str]] = frozenset(AGGREGATION_TYPES)
 
     PROPERTY_MAPPING = {
-        AGGREGATION_TYPE: {
+        AggregationFeatureGroupBase.AGGREGATION_TYPE: {
             **AGGREGATION_TYPES,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
@@ -70,41 +72,6 @@ class ScalarAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             DefaultOptionKeys.default: None,
         },
     }
-
-    @classmethod
-    def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
-        return operation_config in AGGREGATION_TYPES
-
-    @classmethod
-    def get_aggregation_type(cls, feature_name: str) -> str:
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract aggregation type from feature name: {feature_name}")
-
-    @classmethod
-    def _extract_aggregation_type(cls, feature: Feature) -> str:
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        agg_type = feature.options.get(cls.AGGREGATION_TYPE)
-        if agg_type is None:
-            raise ValueError(f"Could not extract aggregation type for {feature_name}")
-        return str(agg_type)
-
-    @classmethod
-    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
-        """Declare INT64 for count (a counting op); other aggregates stay open."""
-        try:
-            agg_type = cls._extract_aggregation_type(feature)
-        except Exception:  # best-effort during planning; failure leaves the type undeclared
-            return None
-        if agg_type == "count":
-            return DataType.INT64
-        return None
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         _feature_name = str(feature_name)

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -4,20 +4,27 @@ from __future__ import annotations
 
 from typing import Any
 
-from mloda.core.abstract_plugins.components.data_types import DataType
-from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys
 
+from mloda.community.feature_groups.data_operations.aggregation_base import (
+    AGGREGATION_TYPES as _BASE_AGGREGATION_TYPES,
+    AggregationFeatureGroupBase,
+)
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
 # Aggregation types that require an order_by column to be deterministic.
 _ORDER_DEPENDENT_AGG_TYPES = {"first", "last"}
 
+AGGREGATION_TYPES = {
+    **_BASE_AGGREGATION_TYPES,
+    "first": "First non-null value in ordered partition (requires order_by)",
+    "last": "Last non-null value in ordered partition (requires order_by)",
+}
 
-class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+
+class WindowAggregationFeatureGroup(AggregationFeatureGroupBase):
     """Base class for window aggregation operations that preserve row count.
 
     Window aggregation computes an aggregate over a partitioned group and
@@ -93,32 +100,13 @@ class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
-    AGGREGATION_TYPE = "aggregation_type"
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
 
-    AGGREGATION_TYPES = {
-        "sum": "Sum of values",
-        "avg": "Average of values",
-        "mean": "Average of values",
-        "count": "Count of non-null values",
-        "min": "Minimum value",
-        "max": "Maximum value",
-        "std": "Population standard deviation (ddof=0)",
-        "var": "Population variance (ddof=0)",
-        "std_pop": "Population standard deviation (ddof=0, same as std)",
-        "std_samp": "Sample standard deviation (ddof=1)",
-        "var_pop": "Population variance (ddof=0, same as var)",
-        "var_samp": "Sample variance (ddof=1)",
-        "median": "Median value",
-        "mode": "Most frequent value",
-        "nunique": "Count of unique values",
-        "first": "First non-null value in ordered partition (requires order_by)",
-        "last": "Last non-null value in ordered partition (requires order_by)",
-    }
+    AGGREGATION_TYPES = AGGREGATION_TYPES
 
     PROPERTY_MAPPING = {
-        AGGREGATION_TYPE: {
+        AggregationFeatureGroupBase.AGGREGATION_TYPE: {
             **AGGREGATION_TYPES,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
@@ -146,11 +134,6 @@ class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             DefaultOptionKeys.default: None,
         },
     }
-
-    @classmethod
-    def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
-        """Validate that the parsed aggregation type is in AGGREGATION_TYPES."""
-        return operation_config in cls.AGGREGATION_TYPES
 
     @classmethod
     def match_feature_group_criteria(
@@ -199,39 +182,6 @@ class WindowAggregationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         agg_type = options.get(cls.AGGREGATION_TYPE)
         if agg_type is not None:
             return str(agg_type)
-        return None
-
-    @classmethod
-    def get_aggregation_type(cls, feature_name: str) -> str:
-        """Extract the aggregation type from a feature name string."""
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract aggregation type from feature name: {feature_name}")
-
-    @classmethod
-    def _extract_aggregation_type(cls, feature: Feature) -> str:
-        """Extract aggregation type from feature (string-based or config-based)."""
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        agg_type = feature.options.get(cls.AGGREGATION_TYPE)
-        if agg_type is None:
-            raise ValueError(f"Could not extract aggregation type for {feature_name}")
-        return str(agg_type)
-
-    @classmethod
-    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
-        """Declare INT64 for count/nunique (counting ops); other aggregates stay open."""
-        try:
-            agg_type = cls._extract_aggregation_type(feature)
-        except Exception:  # best-effort during planning; failure leaves the type undeclared
-            return None
-        if agg_type in {"count", "nunique"}:
-            return DataType.INT64
         return None
 
     @classmethod


### PR DESCRIPTION
## Summary

Closes #246. Consolidates the duplicated aggregation-family base machinery into one shared `aggregation_base.py`, mirroring the `arithmetic_base.py` precedent from #214 (and the numeric-source consolidation in #237).

The three aggregation-family base classes carried byte-for-byte identical machinery (`_extract_aggregation_type`, `get_aggregation_type`, `_validate_string_match`, the `return_data_type_rule` skeleton), plus a duplicated agg-type constant table with a fourth partial copy in `frame_aggregate`.

## What changed

- **New** `data_operations/aggregation_base.py`: canonical `AGGREGATION_TYPES` table + `AggregationFeatureGroupBase(FeatureChainParserMixin, FeatureGroup)` owning the shared extraction methods and the `return_data_type_rule` skeleton. The counting set is a `_COUNTING_AGG_TYPES` class hook so the skeleton can be shared without changing which agg types declare `INT64`.
- **`aggregation/base.py`**: subclasses the shared base; drops the local table and the four shared methods (inherits canonical table + `{"count", "nunique"}` counting set, exactly the prior behavior).
- **`window_aggregation/base.py`**: subclasses the shared base; keeps its own `first`/`last` descriptions (`"(requires order_by)"`) via a spread over the canonical table.
- **`scalar_aggregate/base.py`**: subclasses the shared base; keeps its 13-key subset (still exported at module level for tests) bound as the class `AGGREGATION_TYPES`, and overrides `_COUNTING_AGG_TYPES = {"count"}` (no `nunique`).
- **`frame_aggregate/base.py`**: light touch. It fully overrides matching and uses `_extract_params` with a placeholder `PREFIX_PATTERN`, so it does **not** inherit the base and keeps its own `return_data_type_rule`. It only derives `_AGGREGATION_TYPES` from the shared canonical table, removing the fourth standalone copy.

## Behavior

No behavior change. Per-family supported subsets, naming suffixes, the `count`-vs-`count`/`nunique` INT64 distinction, and window's first/last wording are all preserved. The module-level `AGGREGATION_TYPES` (scalar) and `_AGGREGATION_TYPES` (frame) names the tests import are kept.

## Verification

- `tox` green: 3781 passed, 128 skipped; `ruff format --check`, `ruff check`, `mypy --strict`, `bandit` all clean.
- Framework-support-matrix drift check unchanged.