### PR TITLE
refactor(data_operations): share backend aggregation-function tables

### DIFF
--- a/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
@@ -17,37 +17,14 @@ from mloda_plugins.compute_framework.base_implementations.pyarrow.table import P
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
+from mloda.community.feature_groups.data_operations.backend_agg_tables import (
+    PYARROW_AGG_FUNCS as _PA_AGG_FUNCS,
+    PYARROW_ORDERED_FUNCS as _ORDERED_FUNCS,
+    PYARROW_SUPPORTED_AGG_TYPES as _SUPPORTED_AGG_TYPES,
+    PYARROW_VARIANCE_FUNCS as _VARIANCE_FUNCS,
+)
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import apply_pyarrow_mask
-
-# Aggregation types with direct PyArrow group_by support.
-_PA_AGG_FUNCS: dict[str, str] = {
-    "sum": "sum",
-    "avg": "mean",
-    "mean": "mean",
-    "count": "count",
-    "min": "min",
-    "max": "max",
-    "nunique": "count_distinct",
-}
-
-# Variance/stddev operations mapped to (PyArrow func name, ddof).
-_VARIANCE_FUNCS: dict[str, tuple[str, int]] = {
-    "std": ("stddev", 0),
-    "var": ("variance", 0),
-    "std_pop": ("stddev", 0),
-    "std_samp": ("stddev", 1),
-    "var_pop": ("variance", 0),
-    "var_samp": ("variance", 1),
-}
-
-# Ordered aggregates need use_threads=False in PyArrow.
-_ORDERED_FUNCS: dict[str, str] = {
-    "first": "first",
-    "last": "last",
-}
-
-_SUPPORTED_AGG_TYPES = {*_PA_AGG_FUNCS, *_VARIANCE_FUNCS, *_ORDERED_FUNCS}
 
 
 class PyArrowAggregation(AggregationFeatureGroup):

--- a/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
@@ -12,18 +12,9 @@ from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation
 from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
+from mloda.community.feature_groups.data_operations.backend_agg_tables import SQLITE_AGG_FUNCS as _SQLITE_AGG_FUNCS
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
-
-# Aggregation types that SQLite supports natively.
-_SQLITE_AGG_FUNCS: dict[str, str] = {
-    "sum": "SUM",
-    "avg": "AVG",
-    "mean": "AVG",
-    "count": "COUNT",
-    "min": "MIN",
-    "max": "MAX",
-}
 
 
 class SqliteAggregation(AggregationFeatureGroup):

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_security.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_security.py
@@ -81,8 +81,8 @@ class TestAllowlistCompleteness:
             assert agg_type in _DUCKDB_AGG_FUNCS, f"DuckDB backend missing aggregation type: {agg_type}"
 
     def test_sqlite_covers_supported_types(self) -> None:
-        from mloda.community.feature_groups.data_operations.aggregation.sqlite_aggregation import (
-            _SQLITE_AGG_FUNCS,
+        from mloda.community.feature_groups.data_operations.backend_agg_tables import (
+            SQLITE_AGG_FUNCS as _SQLITE_AGG_FUNCS,
         )
 
         basic_types = {"sum", "min", "max", "avg", "count"}

--- a/mloda/community/feature_groups/data_operations/backend_agg_tables.py
+++ b/mloda/community/feature_groups/data_operations/backend_agg_tables.py
@@ -1,0 +1,46 @@
+"""Backend aggregation-function tables shared between the aggregation and window-aggregation families.
+
+Removes the duplication that previously existed between each family's per-backend modules,
+following the same consolidation precedent as ``aggregation_base.py`` (cf. issue #246).
+"""
+
+from __future__ import annotations
+
+# Aggregation types with direct PyArrow group_by support.
+PYARROW_AGG_FUNCS: dict[str, str] = {
+    "sum": "sum",
+    "avg": "mean",
+    "mean": "mean",
+    "count": "count",
+    "min": "min",
+    "max": "max",
+    "nunique": "count_distinct",
+}
+
+# Variance/stddev operations mapped to (PyArrow func name, ddof).
+PYARROW_VARIANCE_FUNCS: dict[str, tuple[str, int]] = {
+    "std": ("stddev", 0),
+    "var": ("variance", 0),
+    "std_pop": ("stddev", 0),
+    "std_samp": ("stddev", 1),
+    "var_pop": ("variance", 0),
+    "var_samp": ("variance", 1),
+}
+
+# Ordered aggregates need use_threads=False in PyArrow.
+PYARROW_ORDERED_FUNCS: dict[str, str] = {
+    "first": "first",
+    "last": "last",
+}
+
+PYARROW_SUPPORTED_AGG_TYPES = {*PYARROW_AGG_FUNCS, *PYARROW_VARIANCE_FUNCS, *PYARROW_ORDERED_FUNCS}
+
+# Aggregation types that SQLite supports natively.
+SQLITE_AGG_FUNCS: dict[str, str] = {
+    "sum": "SUM",
+    "avg": "AVG",
+    "mean": "AVG",
+    "count": "COUNT",
+    "min": "MIN",
+    "max": "MAX",
+}

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from enum import Enum
 
+from mloda.core.abstract_plugins.components.feature import Feature
+
 
 # ---------------------------------------------------------------------------
 # Shared config key constants
@@ -18,6 +20,15 @@ PARTITION_BY = "partition_by"
 
 Used by: window_aggregation, aggregation, rank, offset, frame_aggregate.
 """
+
+
+def extract_partition_by(feature: Feature, partition_by_key: str = PARTITION_BY) -> list[str]:
+    """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
+    partition_by = feature.options.get(partition_by_key)
+    if partition_by is None:
+        return []
+    return list(partition_by)
+
 
 FRAME_TYPE = "frame_type"
 """Config key for frame type in frame_aggregate operations.

--- a/mloda/community/feature_groups/data_operations/duckdb_helpers.py
+++ b/mloda/community/feature_groups/data_operations/duckdb_helpers.py
@@ -1,0 +1,11 @@
+"""Shared DuckDB helper utilities for the data-operations backends."""
+
+from __future__ import annotations
+
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
+
+
+def assert_source_col_present(data: DuckdbRelation, col: str) -> None:
+    """Reject a missing source column on a DuckDB relation with a clear ``ValueError``."""
+    if col not in data.columns:
+        raise ValueError(f"Source column {col!r} is not present in the DuckDB relation; available: {data.columns}.")

--- a/mloda/community/feature_groups/data_operations/pandas_helpers.py
+++ b/mloda/community/feature_groups/data_operations/pandas_helpers.py
@@ -33,6 +33,14 @@ PANDAS_AGG_FUNCS: dict[str, str] = {
 }
 
 
+def assert_source_col_present(data: pd.DataFrame, col: str) -> None:
+    """Reject a missing source column on a pandas DataFrame with a clear ``ValueError``."""
+    if col not in data.columns:
+        raise ValueError(
+            f"Source column {col!r} is not present in the pandas DataFrame; available: {list(data.columns)}."
+        )
+
+
 def null_safe_groupby(df: Any, partition_by: list[str], col: str) -> Any:
     """Group *df* by *partition_by* keeping null keys, then select *col*.
 

--- a/mloda/community/feature_groups/data_operations/polars_helpers.py
+++ b/mloda/community/feature_groups/data_operations/polars_helpers.py
@@ -1,0 +1,12 @@
+"""Shared polars helper utilities for the data-operations backends."""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def assert_source_col_present(data: pl.LazyFrame, col: str) -> None:
+    """Reject a missing source column on a polars LazyFrame with a clear ``ValueError``."""
+    names = data.collect_schema().names()
+    if col not in names:
+        raise ValueError(f"Source column {col!r} is not present in the polars frame; available: {names}.")

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -46,6 +46,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import extract_partition_by
+
 # Order-independent aggregations supported in v1. Order-dependent aggregations
 # (e.g. ``first`` / ``last``) and ``median`` are deliberately excluded.
 RESAMPLE_AGGS: dict[str, str] = {
@@ -210,10 +212,7 @@ class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def _extract_partition_by(cls, feature: Feature) -> list[str]:
         """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
+        return extract_partition_by(feature, cls.PARTITION_BY)
 
     @classmethod
     def _extract_time_column(cls, feature: Feature) -> str:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
@@ -50,6 +50,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import extract_partition_by
+
 
 class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """Base class for exponential-moving-average operations that preserve row count."""
@@ -139,10 +141,7 @@ class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def _extract_partition_by(cls, feature: Feature) -> list[str]:
         """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
+        return extract_partition_by(feature, cls.PARTITION_BY)
 
     @classmethod
     def _extract_order_by(cls, feature: Feature) -> str:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/pandas_ema.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/pandas_ema.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.pandas_helpers import assert_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.ema.base import EmaFeatureGroup
 
 
@@ -18,10 +19,7 @@ class PandasEma(EmaFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pd.DataFrame, source_col: str) -> None:
-        if source_col not in data.columns:
-            raise ValueError(
-                f"Source column {source_col!r} is not present in the pandas DataFrame; available: {list(data.columns)}."
-            )
+        assert_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ema(

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/polars_lazy_ema.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/polars_lazy_ema.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.polars_helpers import assert_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.ema.base import EmaFeatureGroup
 
 
@@ -18,9 +19,7 @@ class PolarsLazyEma(EmaFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pl.LazyFrame, source_col: str) -> None:
-        names = data.collect_schema().names()
-        if source_col not in names:
-            raise ValueError(f"Source column {source_col!r} is not present in the polars frame; available: {names}.")
+        assert_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ema(

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
@@ -41,6 +41,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import extract_partition_by
+
 
 class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """Base class for forward-fill-by-time operations that preserve row count.
@@ -122,10 +124,7 @@ class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def _extract_partition_by(cls, feature: Feature) -> list[str]:
         """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
+        return extract_partition_by(feature, cls.PARTITION_BY)
 
     @classmethod
     def _extract_order_by(cls, feature: Feature) -> str:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/duckdb_ffill.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/duckdb_ffill.py
@@ -13,6 +13,7 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_window import 
     WindowFrame,
 )
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import assert_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
 
 
@@ -23,10 +24,7 @@ class DuckdbFfill(FfillFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: DuckdbRelation, source_col: str) -> None:
-        if source_col not in data.columns:
-            raise ValueError(
-                f"Source column {source_col!r} is not present in the DuckDB relation; available: {data.columns}."
-            )
+        assert_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ffill(

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/pandas_ffill.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/pandas_ffill.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.pandas_helpers import assert_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
 
 
@@ -18,10 +19,7 @@ class PandasFfill(FfillFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pd.DataFrame, source_col: str) -> None:
-        if source_col not in data.columns:
-            raise ValueError(
-                f"Source column {source_col!r} is not present in the pandas DataFrame; available: {list(data.columns)}."
-            )
+        assert_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ffill(

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/polars_lazy_ffill.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/polars_lazy_ffill.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.polars_helpers import assert_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
 
 
@@ -18,9 +19,7 @@ class PolarsLazyFfill(FfillFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pl.LazyFrame, source_col: str) -> None:
-        names = data.collect_schema().names()
-        if source_col not in names:
-            raise ValueError(f"Source column {source_col!r} is not present in the polars frame; available: {names}.")
+        assert_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ffill(

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
@@ -54,6 +54,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import extract_partition_by
+
 # Supported sessionization units mapped to their length in seconds. The four
 # keys also define the units accepted by the feature-name regex.
 SESSIONIZATION_UNITS: dict[str, int] = {
@@ -195,10 +197,7 @@ class SessionizationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def _extract_partition_by(cls, feature: Feature) -> list[str]:
         """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
+        return extract_partition_by(feature, cls.PARTITION_BY)
 
     @classmethod
     def _extract_order_by(cls, feature: Feature, source_col: str) -> str:

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/duckdb_sessionization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/duckdb_sessionization.py
@@ -15,6 +15,7 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framewor
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name, quote_ident
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import assert_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.base import (
     SessionizationFeatureGroup,
 )
@@ -27,10 +28,7 @@ class DuckdbSessionization(SessionizationFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: DuckdbRelation, order_col: str) -> None:
-        if order_col not in data.columns:
-            raise ValueError(
-                f"Source column {order_col!r} is not present in the DuckDB relation; available: {data.columns}."
-            )
+        assert_source_col_present(data, order_col)
 
     @classmethod
     def _compute_session(

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pandas_sessionization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pandas_sessionization.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.pandas_helpers import assert_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.base import (
     SessionizationFeatureGroup,
 )
@@ -20,10 +21,7 @@ class PandasSessionization(SessionizationFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pd.DataFrame, order_col: str) -> None:
-        if order_col not in data.columns:
-            raise ValueError(
-                f"Source column {order_col!r} is not present in the pandas DataFrame; available: {list(data.columns)}."
-            )
+        assert_source_col_present(data, order_col)
 
     @classmethod
     def _compute_session(

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/polars_lazy_sessionization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/polars_lazy_sessionization.py
@@ -10,6 +10,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.polars_helpers import assert_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.base import (
     SessionizationFeatureGroup,
 )
@@ -22,9 +23,7 @@ class PolarsLazySessionization(SessionizationFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pl.LazyFrame, order_col: str) -> None:
-        names = data.collect_schema().names()
-        if order_col not in names:
-            raise ValueError(f"Source column {order_col!r} is not present in the polars frame; available: {names}.")
+        assert_source_col_present(data, order_col)
 
     @classmethod
     def _compute_session(

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
@@ -16,38 +16,18 @@ import pyarrow.compute as pc
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
+from mloda.community.feature_groups.data_operations.backend_agg_tables import (
+    PYARROW_AGG_FUNCS as _PA_AGG_FUNCS,
+    PYARROW_ORDERED_FUNCS as _ORDERED_FUNCS,
+    PYARROW_SUPPORTED_AGG_TYPES as _SUPPORTED_AGG_TYPES,
+    PYARROW_VARIANCE_FUNCS as _VARIANCE_FUNCS,
+)
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
 from mloda.community.feature_groups.data_operations.mask_utils import apply_pyarrow_mask
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
 )
-
-_PA_AGG_FUNCS: dict[str, str] = {
-    "sum": "sum",
-    "avg": "mean",
-    "mean": "mean",
-    "count": "count",
-    "min": "min",
-    "max": "max",
-    "nunique": "count_distinct",
-}
-
-_VARIANCE_FUNCS: dict[str, tuple[str, int]] = {
-    "std": ("stddev", 0),
-    "var": ("variance", 0),
-    "std_pop": ("stddev", 0),
-    "std_samp": ("stddev", 1),
-    "var_pop": ("variance", 0),
-    "var_samp": ("variance", 1),
-}
-
-_ORDERED_FUNCS: dict[str, str] = {
-    "first": "first",
-    "last": "last",
-}
-
-_SUPPORTED_AGG_TYPES = {*_PA_AGG_FUNCS, *_VARIANCE_FUNCS, *_ORDERED_FUNCS}
 
 
 class PyArrowWindowAggregation(WindowAggregationFeatureGroup):

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
@@ -9,21 +9,12 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import p
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation
 
+from mloda.community.feature_groups.data_operations.backend_agg_tables import SQLITE_AGG_FUNCS as _SQLITE_AGG_FUNCS
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
 )
-
-# Aggregation types that SQLite supports natively in window functions.
-_SQLITE_AGG_FUNCS: dict[str, str] = {
-    "sum": "SUM",
-    "avg": "AVG",
-    "mean": "AVG",
-    "count": "COUNT",
-    "min": "MIN",
-    "max": "MAX",
-}
 
 
 class SqliteWindowAggregation(WindowAggregationFeatureGroup):

--- a/mloda/testing/feature_groups/data_operations/base.py
+++ b/mloda/testing/feature_groups/data_operations/base.py
@@ -133,3 +133,12 @@ class DataOpsTestBase(ABC):
                     assert fw_val == pytest.approx(ref_val, rel=rel), f"row {i}: {fw_val} != reference {ref_val}"
         else:
             assert result_col == ref_col
+
+    def _assert_float_list_with_nulls(self, actual: list[Any], expected: list[Any]) -> None:
+        assert len(actual) == len(expected), f"row count {len(actual)} != expected {len(expected)}"
+        for i, (a, e) in enumerate(zip(actual, expected)):
+            if e is None:
+                assert a is None, f"row {i}: expected None, got {a!r}"
+            else:
+                assert a is not None, f"row {i}: expected {e!r}, got None"
+                assert float(a) == pytest.approx(e), f"row {i}: {a!r} != {e!r}"

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
@@ -250,15 +250,6 @@ class EmaTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
 
     # -- Helpers ------------------------------------------------------------
 
-    def _assert_float_list_with_nulls(self, actual: list[Any], expected: list[Any]) -> None:
-        assert len(actual) == len(expected), f"row count {len(actual)} != expected {len(expected)}"
-        for i, (a, e) in enumerate(zip(actual, expected)):
-            if e is None:
-                assert a is None, f"row {i}: expected None, got {a!r}"
-            else:
-                assert a is not None, f"row {i}: expected {e!r}, got None"
-                assert float(a) == pytest.approx(e), f"row {i}: {a!r} != {e!r}"
-
     def _ema_feature_set(self, span: int) -> FeatureSet:
         return make_feature_set(f"value__ema_{span}", partition_by=["region"], order_by="ts")
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
@@ -205,15 +205,6 @@ class FfillTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
 
     # -- Helpers ------------------------------------------------------------
 
-    def _assert_float_list_with_nulls(self, actual: list[Any], expected: list[Any]) -> None:
-        assert len(actual) == len(expected), f"row count {len(actual)} != expected {len(expected)}"
-        for i, (a, e) in enumerate(zip(actual, expected)):
-            if e is None:
-                assert a is None, f"row {i}: expected None, got {a!r}"
-            else:
-                assert a is not None, f"row {i}: expected {e!r}, got None"
-                assert float(a) == pytest.approx(e), f"row {i}: {a!r} != {e!r}"
-
     def _ffill_feature_set(self) -> FeatureSet:
         return make_feature_set("value__ffill", partition_by=["region"], order_by="ts")
 


### PR DESCRIPTION
Consolidates duplicated data-operations logic flagged in #259. Two commits, all byte-identical / safe clusters, no behavior change.

### Commit 1 — backend aggregation-function tables
`_PA_AGG_FUNCS` / `_VARIANCE_FUNCS` / `_ORDERED_FUNCS` / `_SUPPORTED_AGG_TYPES` (PyArrow) and `_SQLITE_AGG_FUNCS` (SQLite) were copy-pasted byte-for-byte between the `aggregation` and `window_aggregation` families. Moved into `backend_agg_tables.py`, re-imported under the existing local names (import aliases) so each module body is otherwise untouched.

### Commit 2 — partition_by, source-column guards, test helper
- `extract_partition_by()`: one free function in `data_operations/base.py`, replacing the four identical `_extract_partition_by` copies (ffill, ema, sessionization, resample bases).
- `assert_source_col_present()`: one guard per backend, each in a **backend-specific** helper module (`pandas_helpers`, new `polars_helpers`, new `duckdb_helpers`) so pandas/polars/duckdb stay import-isolated (a single shared module would force every backend to import all three frameworks). The per-op `_assert_source_column_present` overrides now delegate.
- `_assert_float_list_with_nulls()`: moved into `DataOpsTestBase`, removing the identical copies from the ffill and ema test bases.

Mirrors the existing `aggregation_base.py` consolidation precedent.

### Out of scope (documented as follow-ups in #259)
- **DuckDB agg table**: `first`/`last` map to `FIRST`/`LAST` in aggregation but `FIRST_VALUE`/`LAST_VALUE` in window aggregation; merging would silently break one backend.
- **scalar_aggregate / frame_aggregate**: hold intentional subsets of the agg tables.
- Polars agg-expr table (subset nuance), the DuckDB row-restore idiom helper, and the larger `_extract_source_features` mixin (guard-style variations) — higher-risk, deferred.

### Validation
Full `tox` passes after each commit: 3833 passed / 141 skipped, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit` all clean.

Closes the duplicated-code portion of #259.
