### PR TITLE
refactor(testing): remove verified dead code

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/conftest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/conftest.py
@@ -1,24 +1,7 @@
-"""Shared fixtures for offset tests."""
+"""Shared test re-exports for offset tests."""
 
 from __future__ import annotations
 
-from typing import Any
-
-import pyarrow as pa
-import pytest
-
-from mloda.testing.data_creator.base import DataOperationsTestDataCreator
-from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.testing.feature_groups.data_operations.row_preserving.offset.offset import make_feature_set
 
 __all__ = ["make_feature_set"]
-
-
-@pytest.fixture
-def raw_data() -> dict[str, list[Any]]:
-    return DataOperationsTestDataCreator.get_raw_data()
-
-
-@pytest.fixture
-def sample_data() -> pa.Table:
-    return PyArrowDataOpsTestDataCreator.create()

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/conftest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/conftest.py
@@ -1,29 +1,10 @@
-"""Shared fixtures and helpers for window_aggregation tests."""
+"""Shared test re-exports for window_aggregation tests."""
 
 from __future__ import annotations
 
-from typing import Any
-
-import pyarrow as pa
-import pytest
-
-from mloda.testing.data_creator.base import DataOperationsTestDataCreator
-from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.testing.feature_groups.data_operations.helpers import (
     make_feature_set,
 )
 
 # Re-export make_feature_set so existing imports from conftest still work.
 __all__ = ["make_feature_set"]
-
-
-@pytest.fixture
-def raw_data() -> dict[str, list[Any]]:
-    """Return the shared 12-row test dataset as a plain dict."""
-    return DataOperationsTestDataCreator.get_raw_data()
-
-
-@pytest.fixture
-def sample_data() -> pa.Table:
-    """Return the shared 12-row test dataset as a PyArrow Table."""
-    return PyArrowDataOpsTestDataCreator.create()

--- a/mloda/testing/data_creator/base.py
+++ b/mloda/testing/data_creator/base.py
@@ -28,19 +28,6 @@ class DataOperationsTestDataCreator(FeatureGroup):
 
     compute_framework: type[ComputeFramework] = PyArrowTable
 
-    NULL_POSITIONS: dict[str, set[int]] = {
-        "region": {11},
-        "category": {6},
-        "timestamp": {10},
-        "event_date": {2},
-        "value_int": {4},
-        "value_float": {2, 11},
-        "amount": {1, 7},
-        "name": {2, 11},
-        "is_active": {3, 9},
-        "score": set(range(12)),
-    }
-
     @classmethod
     def input_data(cls) -> BaseInputData | None:
         return DataCreator(set(cls.get_raw_data().keys()))

--- a/mloda/testing/feature_groups/data_operations/row_preserving/datetime/datetime.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/datetime/datetime.py
@@ -89,18 +89,6 @@ VARIED_EXPECTED_IS_WEEKEND: list[Any] = [0, 0, 1, None]
 # Q2, Q3, Q4, None
 VARIED_EXPECTED_QUARTER: list[Any] = [2, 3, 4, None]
 
-VARIED_EXPECTED: dict[str, list[Any]] = {
-    "year": VARIED_EXPECTED_YEAR,
-    "month": VARIED_EXPECTED_MONTH,
-    "day": VARIED_EXPECTED_DAY,
-    "hour": VARIED_EXPECTED_HOUR,
-    "minute": VARIED_EXPECTED_MINUTE,
-    "second": VARIED_EXPECTED_SECOND,
-    "dayofweek": VARIED_EXPECTED_DAYOFWEEK,
-    "is_weekend": VARIED_EXPECTED_IS_WEEKEND,
-    "quarter": VARIED_EXPECTED_QUARTER,
-}
-
 
 def _create_varied_times_arrow_table() -> pa.Table:
     """Create a 4-row PyArrow table with non-midnight UTC timestamps."""


### PR DESCRIPTION
Removes the verified-dead symbols from #259. Every symbol was re-grepped repo-wide immediately before deletion to confirm zero references.

### Removed
| Symbol | File | Why dead |
|---|---|---|
| `DataOperationsTestDataCreator.NULL_POSITIONS` | `mloda/testing/data_creator/base.py` | class dict never read anywhere |
| `VARIED_EXPECTED` (composite dict) | `mloda/testing/feature_groups/data_operations/row_preserving/datetime/datetime.py` | never consumed; callers use the individual `VARIED_EXPECTED_*` constants, which remain |
| `raw_data`, `sample_data` fixtures | `.../row_preserving/offset/tests/conftest.py` | defined but never requested by any test; orphaned imports removed too |
| `raw_data`, `sample_data` fixtures | `.../row_preserving/window_aggregation/tests/conftest.py` | same |

Each conftest now keeps only its `make_feature_set` re-export. Net: -63/+2 lines.

### Deliberately NOT removed
The `NullPolicy` enum (`base.py`) is runtime-dead but its own docstring calls it a "documentation and configuration anchor," and ~14 docstrings/comments reference `NullPolicy.SKIP` etc. by name. Removing it would orphan that prose. Left in place pending a maintainer decision (flagged in #259).

### Validation
Full `tox` passes: 3833 passed / 141 skipped, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit` all clean.

Closes the dead-code portion of #259.