### PR TITLE
refactor(data_operations): remove dead code and consolidate duplicated logic

### DIFF
--- a/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/duckdb_aggregation.py
@@ -13,25 +13,12 @@ from mloda.community.feature_groups.data_operations.aggregation.base import (
     AggregationFeatureGroup,
 )
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
+from mloda.community.feature_groups.data_operations.duckdb_agg_constants import DUCKDB_AGG_FUNCS
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 
-# All aggregation types natively supported by DuckDB.
+# Group aggregation uses FIRST/LAST (window functions need FIRST_VALUE/LAST_VALUE).
 _DUCKDB_AGG_FUNCS: dict[str, str] = {
-    "sum": "SUM",
-    "avg": "AVG",
-    "mean": "AVG",
-    "count": "COUNT",
-    "min": "MIN",
-    "max": "MAX",
-    "std": "STDDEV_POP",
-    "var": "VAR_POP",
-    "std_pop": "STDDEV_POP",
-    "std_samp": "STDDEV_SAMP",
-    "var_pop": "VAR_POP",
-    "var_samp": "VAR_SAMP",
-    "median": "MEDIAN",
-    "mode": "MODE",
-    "nunique": "COUNT_DISTINCT",  # handled specially: COUNT(DISTINCT col) syntax
+    **DUCKDB_AGG_FUNCS,
     "first": "FIRST",
     "last": "LAST",
 }

--- a/mloda/community/feature_groups/data_operations/aggregation/polars_lazy_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/polars_lazy_aggregation.py
@@ -14,28 +14,16 @@ from mloda.community.feature_groups.data_operations.aggregation.base import (
 )
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import _POLARS_MASK_TMP, apply_polars_mask
+from mloda.community.feature_groups.data_operations.polars_agg_constants import POLARS_AGG_EXPRS
 from mloda.community.feature_groups.data_operations.polars_mode_helpers import (
     ModeHelperCols,
     add_mode_helper_cols,
     mode_agg_expr,
 )
 
-# Mapping from aggregation type to a Polars expression builder.
+# Aggregation extends the shared builders with first/last.
 _POLARS_AGG_EXPRS: dict[str, Any] = {
-    "sum": lambda col: pl.col(col).sum(),
-    "avg": lambda col: pl.col(col).mean(),
-    "mean": lambda col: pl.col(col).mean(),
-    "count": lambda col: pl.col(col).count(),
-    "min": lambda col: pl.col(col).min(),
-    "max": lambda col: pl.col(col).max(),
-    "std": lambda col: pl.col(col).std(ddof=0),
-    "var": lambda col: pl.col(col).var(ddof=0),
-    "std_pop": lambda col: pl.col(col).std(ddof=0),
-    "std_samp": lambda col: pl.col(col).std(ddof=1),
-    "var_pop": lambda col: pl.col(col).var(ddof=0),
-    "var_samp": lambda col: pl.col(col).var(ddof=1),
-    "median": lambda col: pl.col(col).median(),
-    "nunique": lambda col: pl.col(col).drop_nulls().n_unique(),
+    **POLARS_AGG_EXPRS,
     "first": lambda col: pl.col(col).drop_nulls().first(),
     "last": lambda col: pl.col(col).drop_nulls().last(),
 }

--- a/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
@@ -19,35 +19,12 @@ from mloda.community.feature_groups.data_operations.aggregation.base import (
 )
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import apply_pyarrow_mask
-
-# Aggregation types with direct PyArrow group_by support.
-_PA_AGG_FUNCS: dict[str, str] = {
-    "sum": "sum",
-    "avg": "mean",
-    "mean": "mean",
-    "count": "count",
-    "min": "min",
-    "max": "max",
-    "nunique": "count_distinct",
-}
-
-# Variance/stddev operations mapped to (PyArrow func name, ddof).
-_VARIANCE_FUNCS: dict[str, tuple[str, int]] = {
-    "std": ("stddev", 0),
-    "var": ("variance", 0),
-    "std_pop": ("stddev", 0),
-    "std_samp": ("stddev", 1),
-    "var_pop": ("variance", 0),
-    "var_samp": ("variance", 1),
-}
-
-# Ordered aggregates need use_threads=False in PyArrow.
-_ORDERED_FUNCS: dict[str, str] = {
-    "first": "first",
-    "last": "last",
-}
-
-_SUPPORTED_AGG_TYPES = {*_PA_AGG_FUNCS, *_VARIANCE_FUNCS, *_ORDERED_FUNCS}
+from mloda.community.feature_groups.data_operations.pyarrow_agg_constants import (
+    PA_AGG_FUNCS as _PA_AGG_FUNCS,
+    PA_ORDERED_FUNCS as _ORDERED_FUNCS,
+    PA_SUPPORTED_AGG_TYPES as _SUPPORTED_AGG_TYPES,
+    PA_VARIANCE_FUNCS as _VARIANCE_FUNCS,
+)
 
 
 class PyArrowAggregation(AggregationFeatureGroup):

--- a/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
@@ -14,16 +14,7 @@ from mloda.community.feature_groups.data_operations.aggregation.base import (
 )
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
-
-# Aggregation types that SQLite supports natively.
-_SQLITE_AGG_FUNCS: dict[str, str] = {
-    "sum": "SUM",
-    "avg": "AVG",
-    "mean": "AVG",
-    "count": "COUNT",
-    "min": "MIN",
-    "max": "MAX",
-}
+from mloda.community.feature_groups.data_operations.sqlite_agg_constants import SQLITE_AGG_FUNCS as _SQLITE_AGG_FUNCS
 
 
 class SqliteAggregation(AggregationFeatureGroup):

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_security.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_security.py
@@ -81,13 +81,11 @@ class TestAllowlistCompleteness:
             assert agg_type in _DUCKDB_AGG_FUNCS, f"DuckDB backend missing aggregation type: {agg_type}"
 
     def test_sqlite_covers_supported_types(self) -> None:
-        from mloda.community.feature_groups.data_operations.aggregation.sqlite_aggregation import (
-            _SQLITE_AGG_FUNCS,
-        )
+        from mloda.community.feature_groups.data_operations.sqlite_agg_constants import SQLITE_AGG_FUNCS
 
         basic_types = {"sum", "min", "max", "avg", "count"}
         for agg_type in basic_types:
-            assert agg_type in _SQLITE_AGG_FUNCS, f"SQLite backend missing basic aggregation type: {agg_type}"
+            assert agg_type in SQLITE_AGG_FUNCS, f"SQLite backend missing basic aggregation type: {agg_type}"
 
 
 class TestPartitionByInjection:

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from mloda.core.abstract_plugins.components.feature import Feature
 
 
 # ---------------------------------------------------------------------------
@@ -40,53 +40,24 @@ Valid values: second, minute, hour, day, week, month, year.
 
 
 # ---------------------------------------------------------------------------
-# Null handling policy constants
+# Shared mixins
 # ---------------------------------------------------------------------------
-# These document the data operations null handling contract.
-# Implementations must match these defaults. PyArrow behavior is the reference.
 
 
-class NullPolicy(str, Enum):
-    """Null handling behavior constants for data operations.
+class PartitionByMixin:
+    """Shared ``_extract_partition_by`` for partition-aware row operations.
 
-    Each value describes a null handling rule. Implementations must match
-    PyArrow's behavior as the reference. Where a framework diverges from
-    these defaults, add explicit convergence code (e.g. pandas groupby
-    needs ``dropna=False``; SQLite rank needs an explicit null-last clause).
-
-    These constants are documentation and configuration anchors, not
-    runtime enforcement. Each package's ``calculate_feature`` is responsible
-    for honoring the policy.
+    Mixed into the ffill/ema/sessionization/resample bases, which each define
+    a ``PARTITION_BY`` options key. Reads that key from the feature options,
+    returning ``[]`` when absent.
     """
 
-    PROPAGATE = "propagate"
-    """Element-wise operations return null for null input (null in, null out).
+    PARTITION_BY: str
 
-    Applies to: datetime, string, binning.
-    """
-
-    SKIP = "skip"
-    """Aggregations skip null values (e.g. SUM ignores nulls).
-
-    Applies to: window_aggregation, aggregation, frame_aggregate.
-    """
-
-    NULL_IS_GROUP = "null_is_group"
-    """Null is a valid group key in partitioned operations.
-
-    Applies to: window_aggregation, aggregation, rank, offset, frame_aggregate.
-    Pandas divergence: pass ``dropna=False`` to ``groupby()``.
-    """
-
-    NULLS_LAST = "nulls_last"
-    """Nulls rank last in ordered operations.
-
-    Applies to: rank.
-    SQLite divergence: add ``CASE WHEN col IS NULL THEN 1 ELSE 0 END`` to ORDER BY.
-    """
-
-    EDGE_NULL = "edge_null"
-    """Out-of-range positions produce null (e.g. lag/lead at table edges).
-
-    Applies to: offset.
-    """
+    @classmethod
+    def _extract_partition_by(cls, feature: Feature) -> list[str]:
+        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
+        partition_by = feature.options.get(cls.PARTITION_BY)
+        if partition_by is None:
+            return []
+        return list(partition_by)

--- a/mloda/community/feature_groups/data_operations/duckdb_agg_constants.py
+++ b/mloda/community/feature_groups/data_operations/duckdb_agg_constants.py
@@ -1,0 +1,30 @@
+"""Shared DuckDB aggregation-function table.
+
+The aggregation and window-aggregation families share 15 native DuckDB
+function mappings. They deliberately diverge on ``first``/``last``: group
+aggregation uses ``FIRST``/``LAST`` while window functions need
+``FIRST_VALUE``/``LAST_VALUE``. Each backend module adds those two entries
+itself, so only the shared 15 live here.
+"""
+
+from __future__ import annotations
+
+# Aggregation types natively supported by DuckDB (excluding first/last, which
+# differ between group and window contexts).
+DUCKDB_AGG_FUNCS: dict[str, str] = {
+    "sum": "SUM",
+    "avg": "AVG",
+    "mean": "AVG",
+    "count": "COUNT",
+    "min": "MIN",
+    "max": "MAX",
+    "std": "STDDEV_POP",
+    "var": "VAR_POP",
+    "std_pop": "STDDEV_POP",
+    "std_samp": "STDDEV_SAMP",
+    "var_pop": "VAR_POP",
+    "var_samp": "VAR_SAMP",
+    "median": "MEDIAN",
+    "mode": "MODE",
+    "nunique": "COUNT_DISTINCT",  # handled specially: COUNT(DISTINCT col) syntax
+}

--- a/mloda/community/feature_groups/data_operations/duckdb_helpers.py
+++ b/mloda/community/feature_groups/data_operations/duckdb_helpers.py
@@ -1,0 +1,26 @@
+"""Shared DuckDB helper utilities for row-preserving data operations."""
+
+from __future__ import annotations
+
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
+from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
+
+
+def assert_duckdb_source_col_present(data: DuckdbRelation, source_col: str) -> None:
+    """Reject a missing source column on a DuckDB relation with a clear ``ValueError``."""
+    if source_col not in data.columns:
+        raise ValueError(
+            f"Source column {source_col!r} is not present in the DuckDB relation; available: {data.columns}."
+        )
+
+
+def duckdb_drop_rn_restore(rel: DuckdbRelation, rn: str) -> DuckdbRelation:
+    """Restore original row order via the ``rn`` helper column, then drop it.
+
+    Orders the relation by the row-number helper column *rn* (recreating the
+    original input order after a window/aggregate reshuffle), projects every
+    remaining column, and drops *rn*.
+    """
+    rel = rel.order(quote_ident(rn))
+    keep = ", ".join(quote_ident(c) for c in rel.columns if c != rn)
+    return rel.project(keep)

--- a/mloda/community/feature_groups/data_operations/pandas_helpers.py
+++ b/mloda/community/feature_groups/data_operations/pandas_helpers.py
@@ -94,6 +94,14 @@ def coerce_count_dtype(data: Any, feature_name: str, agg_type: str) -> None:
         data[feature_name] = data[feature_name].astype("int64")
 
 
+def assert_pandas_source_col_present(data: Any, source_col: str) -> None:
+    """Reject a missing source column on a pandas DataFrame with a clear ``ValueError``."""
+    if source_col not in data.columns:
+        raise ValueError(
+            f"Source column {source_col!r} is not present in the pandas DataFrame; available: {list(data.columns)}."
+        )
+
+
 _MODE_IDX_COL = "__mloda_mode_row_idx__"
 _MODE_COUNT_COL = "__mloda_mode_count__"
 _MODE_FIRST_IDX_COL = "__mloda_mode_first_idx__"

--- a/mloda/community/feature_groups/data_operations/polars_agg_constants.py
+++ b/mloda/community/feature_groups/data_operations/polars_agg_constants.py
@@ -1,0 +1,32 @@
+"""Shared Polars aggregation-expression builders.
+
+The aggregation and window-aggregation families share the same 14 Polars
+expression builders. ``POLARS_AGG_EXPRS`` holds the shared set; the
+aggregation family extends it with ``first``/``last`` (window-aggregation
+implements those with deterministic ordering of its own).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+
+# Mapping from aggregation type to a Polars expression builder.
+# Each callable takes a column name and returns a Polars Expr.
+POLARS_AGG_EXPRS: dict[str, Any] = {
+    "sum": lambda col: pl.col(col).sum(),
+    "avg": lambda col: pl.col(col).mean(),
+    "mean": lambda col: pl.col(col).mean(),
+    "count": lambda col: pl.col(col).count(),
+    "min": lambda col: pl.col(col).min(),
+    "max": lambda col: pl.col(col).max(),
+    "std": lambda col: pl.col(col).std(ddof=0),
+    "var": lambda col: pl.col(col).var(ddof=0),
+    "std_pop": lambda col: pl.col(col).std(ddof=0),
+    "std_samp": lambda col: pl.col(col).std(ddof=1),
+    "var_pop": lambda col: pl.col(col).var(ddof=0),
+    "var_samp": lambda col: pl.col(col).var(ddof=1),
+    "median": lambda col: pl.col(col).median(),
+    "nunique": lambda col: pl.col(col).drop_nulls().n_unique(),
+}

--- a/mloda/community/feature_groups/data_operations/polars_helpers.py
+++ b/mloda/community/feature_groups/data_operations/polars_helpers.py
@@ -1,0 +1,12 @@
+"""Shared Polars helper utilities for row-preserving data operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def assert_polars_source_col_present(data: Any, source_col: str) -> None:
+    """Reject a missing source column on a Polars LazyFrame with a clear ``ValueError``."""
+    names = data.collect_schema().names()
+    if source_col not in names:
+        raise ValueError(f"Source column {source_col!r} is not present in the polars frame; available: {names}.")

--- a/mloda/community/feature_groups/data_operations/pyarrow_agg_constants.py
+++ b/mloda/community/feature_groups/data_operations/pyarrow_agg_constants.py
@@ -1,0 +1,38 @@
+"""Shared PyArrow aggregation-function tables.
+
+The aggregation and window-aggregation families map the same aggregation
+names to the same PyArrow ``group_by().aggregate()`` function names. These
+tables were byte-for-byte duplicated across both backend modules; they live
+here so a per-function change is made once.
+"""
+
+from __future__ import annotations
+
+# Aggregation types with direct PyArrow group_by support.
+PA_AGG_FUNCS: dict[str, str] = {
+    "sum": "sum",
+    "avg": "mean",
+    "mean": "mean",
+    "count": "count",
+    "min": "min",
+    "max": "max",
+    "nunique": "count_distinct",
+}
+
+# Variance/stddev operations mapped to (PyArrow func name, ddof).
+PA_VARIANCE_FUNCS: dict[str, tuple[str, int]] = {
+    "std": ("stddev", 0),
+    "var": ("variance", 0),
+    "std_pop": ("stddev", 0),
+    "std_samp": ("stddev", 1),
+    "var_pop": ("variance", 0),
+    "var_samp": ("variance", 1),
+}
+
+# Ordered aggregates need use_threads=False in PyArrow.
+PA_ORDERED_FUNCS: dict[str, str] = {
+    "first": "first",
+    "last": "last",
+}
+
+PA_SUPPORTED_AGG_TYPES = {*PA_AGG_FUNCS, *PA_VARIANCE_FUNCS, *PA_ORDERED_FUNCS}

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -46,6 +46,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import PartitionByMixin
+
 # Order-independent aggregations supported in v1. Order-dependent aggregations
 # (e.g. ``first`` / ``last``) and ``median`` are deliberately excluded.
 RESAMPLE_AGGS: dict[str, str] = {
@@ -99,7 +101,7 @@ def _parse_resample_op(token: str) -> tuple[int, str, str]:
     return n, unit, agg
 
 
-class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class ResampleFeatureGroup(PartitionByMixin, FeatureChainParserMixin, FeatureGroup):
     """Base class for resample operations that CHANGE the row count.
 
     Subclasses must implement ``_compute_resample`` (the backend-specific
@@ -206,14 +208,6 @@ class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if op is None:
             raise ValueError(f"Could not extract resample op for {feature.name}")
         return str(op)
-
-    @classmethod
-    def _extract_partition_by(cls, feature: Feature) -> list[str]:
-        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
 
     @classmethod
     def _extract_time_column(cls, feature: Feature) -> str:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
@@ -50,8 +50,10 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import PartitionByMixin
 
-class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+
+class EmaFeatureGroup(PartitionByMixin, FeatureChainParserMixin, FeatureGroup):
     """Base class for exponential-moving-average operations that preserve row count."""
 
     PREFIX_PATTERN = r".*__ema_\d+$"
@@ -135,14 +137,6 @@ class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if span <= 0:
             raise ValueError(f"ema span must be a positive integer (span > 0), got {span} in {name!r}.")
         return span
-
-    @classmethod
-    def _extract_partition_by(cls, feature: Feature) -> list[str]:
-        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
 
     @classmethod
     def _extract_order_by(cls, feature: Feature) -> str:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/pandas_ema.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/pandas_ema.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.pandas_helpers import assert_pandas_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.ema.base import EmaFeatureGroup
 
 
@@ -18,10 +19,7 @@ class PandasEma(EmaFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pd.DataFrame, source_col: str) -> None:
-        if source_col not in data.columns:
-            raise ValueError(
-                f"Source column {source_col!r} is not present in the pandas DataFrame; available: {list(data.columns)}."
-            )
+        assert_pandas_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ema(

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/polars_lazy_ema.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/polars_lazy_ema.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.polars_helpers import assert_polars_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.ema.base import EmaFeatureGroup
 
 
@@ -18,9 +19,7 @@ class PolarsLazyEma(EmaFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pl.LazyFrame, source_col: str) -> None:
-        names = data.collect_schema().names()
-        if source_col not in names:
-            raise ValueError(f"Source column {source_col!r} is not present in the polars frame; available: {names}.")
+        assert_polars_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ema(

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
@@ -41,8 +41,10 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import PartitionByMixin
 
-class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+
+class FfillFeatureGroup(PartitionByMixin, FeatureChainParserMixin, FeatureGroup):
     """Base class for forward-fill-by-time operations that preserve row count.
 
     ffill is a single-op operation (no op/unit matrix). All backends support it
@@ -118,14 +120,6 @@ class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             )
 
         return source_names
-
-    @classmethod
-    def _extract_partition_by(cls, feature: Feature) -> list[str]:
-        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
 
     @classmethod
     def _extract_order_by(cls, feature: Feature) -> str:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/duckdb_ffill.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/duckdb_ffill.py
@@ -13,6 +13,10 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_window import 
     WindowFrame,
 )
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import (
+    assert_duckdb_source_col_present,
+    duckdb_drop_rn_restore,
+)
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
 
 
@@ -23,10 +27,7 @@ class DuckdbFfill(FfillFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: DuckdbRelation, source_col: str) -> None:
-        if source_col not in data.columns:
-            raise ValueError(
-                f"Source column {source_col!r} is not present in the DuckDB relation; available: {data.columns}."
-            )
+        assert_duckdb_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ffill(
@@ -37,7 +38,6 @@ class DuckdbFfill(FfillFeatureGroup):
         partition_by: list[str],
         order_by: str,
     ) -> DuckdbRelation:
-        original_cols = list(data.columns)
         rn = pick_helper_column_name(taken=set(data.columns) | {feature_name})
 
         quoted_source = quote_ident(source_col)
@@ -61,6 +61,4 @@ class DuckdbFfill(FfillFeatureGroup):
             order_by=order_spec,
             frame=frame,
         )
-        rel = rel.order(quote_ident(rn))
-        keep = ", ".join(quote_ident(c) for c in (*original_cols, feature_name))
-        return rel.project(keep)
+        return duckdb_drop_rn_restore(rel, rn)

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/pandas_ffill.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/pandas_ffill.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.pandas_helpers import assert_pandas_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
 
 
@@ -18,10 +19,7 @@ class PandasFfill(FfillFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pd.DataFrame, source_col: str) -> None:
-        if source_col not in data.columns:
-            raise ValueError(
-                f"Source column {source_col!r} is not present in the pandas DataFrame; available: {list(data.columns)}."
-            )
+        assert_pandas_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ffill(

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/polars_lazy_ffill.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/polars_lazy_ffill.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.polars_helpers import assert_polars_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
 
 
@@ -18,9 +19,7 @@ class PolarsLazyFfill(FfillFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pl.LazyFrame, source_col: str) -> None:
-        names = data.collect_schema().names()
-        if source_col not in names:
-            raise ValueError(f"Source column {source_col!r} is not present in the polars frame; available: {names}.")
+        assert_polars_source_col_present(data, source_col)
 
     @classmethod
     def _compute_ffill(

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/duckdb_frame_aggregate.py
@@ -16,6 +16,7 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_window import 
     WindowFrame,
 )
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import duckdb_drop_rn_restore
 from mloda.community.feature_groups.data_operations.errors import (
     unsupported_agg_type_error,
     unsupported_frame_type_error,
@@ -131,11 +132,7 @@ class DuckdbFrameAggregate(FrameAggregateFeatureGroup):
         )
 
         # Step 3: restore original order, drop helper
-        rel = rel.order(quote_ident(rn))
-        keep = ", ".join(quote_ident(c) for c in rel.columns if c != rn)
-        rel = rel.project(keep)
-
-        return rel
+        return duckdb_drop_rn_restore(rel, rn)
 
     @classmethod
     def _compute_time_frame(

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/sqlite_frame_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/sqlite_frame_aggregate.py
@@ -115,7 +115,7 @@ class SqliteFrameAggregate(FrameAggregateFeatureGroup):
                 framework="SQLite",
             )
 
-        # NullPolicy.NULLS_LAST: ``OrderBy(order_by, nulls="last")`` renders
+        # Nulls-last: ``OrderBy(order_by, nulls="last")`` renders
         # ``ORDER BY ... NULLS LAST``, equivalent to the old
         # ``CASE WHEN order IS NULL THEN 1 ELSE 0 END, order`` sort key.
         original_cols = list(data.columns)

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/sqlite_offset.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/sqlite_offset.py
@@ -33,7 +33,7 @@ class SqliteOffset(OffsetFeatureGroup):
 
         quoted_source = quote_ident(source_col)
 
-        # NullPolicy.NULLS_LAST: ``OrderBy(order_by, nulls="last")`` renders
+        # Nulls-last: ``OrderBy(order_by, nulls="last")`` renders
         # ``ORDER BY ... NULLS LAST``, equivalent to the old
         # ``CASE WHEN order IS NULL THEN 1 ELSE 0 END, order`` sort key.
         order_spec = [OrderBy(order_by, nulls="last")]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/conftest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/conftest.py
@@ -1,24 +1,8 @@
-"""Shared fixtures for offset tests."""
+"""Shared helpers for offset tests."""
 
 from __future__ import annotations
 
-from typing import Any
-
-import pyarrow as pa
-import pytest
-
-from mloda.testing.data_creator.base import DataOperationsTestDataCreator
-from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.testing.feature_groups.data_operations.row_preserving.offset.offset import make_feature_set
 
+# Re-export make_feature_set so existing imports from conftest still work.
 __all__ = ["make_feature_set"]
-
-
-@pytest.fixture
-def raw_data() -> dict[str, list[Any]]:
-    return DataOperationsTestDataCreator.get_raw_data()
-
-
-@pytest.fixture
-def sample_data() -> pa.Table:
-    return PyArrowDataOpsTestDataCreator.create()

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/duckdb_rank.py
@@ -10,6 +10,7 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name, quote_ident
 from mloda_plugins.compute_framework.base_implementations.sql.sql_window import OrderBy
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import duckdb_drop_rn_restore
 from mloda.community.feature_groups.data_operations.row_preserving.rank.base import (
     RankFeatureGroup,
 )
@@ -83,6 +84,4 @@ class DuckdbRank(RankFeatureGroup):
             partition_by=partition_by,
             order_by=order_spec,
         )
-        rel = rel.order(quote_ident(rn))
-        keep = ", ".join(quote_ident(c) for c in rel.columns if c != rn)
-        return rel.project(keep)
+        return duckdb_drop_rn_restore(rel, rn)

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/sqlite_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/sqlite_rank.py
@@ -63,7 +63,7 @@ class SqliteRank(RankFeatureGroup):
         order_by: str,
         rank_type: str,
     ) -> SqliteRelation:
-        # NullPolicy.NULLS_LAST: ``OrderBy(order_by, nulls="last")`` renders
+        # Nulls-last: ``OrderBy(order_by, nulls="last")`` renders
         # ``ORDER BY ... NULLS LAST``, equivalent to the old
         # ``CASE WHEN order IS NULL THEN 1 ELSE 0 END, order`` sort key.
         original_cols = list(data.columns)

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/sqlite_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/sqlite_scalar_aggregate.py
@@ -14,15 +14,7 @@ from mloda.community.feature_groups.data_operations.mask_utils import build_sql_
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.base import (
     ScalarAggregateFeatureGroup,
 )
-
-_SQLITE_AGG_FUNCS: dict[str, str] = {
-    "sum": "SUM",
-    "min": "MIN",
-    "max": "MAX",
-    "avg": "AVG",
-    "mean": "AVG",
-    "count": "COUNT",
-}
+from mloda.community.feature_groups.data_operations.sqlite_agg_constants import SQLITE_AGG_FUNCS as _SQLITE_AGG_FUNCS
 
 
 class SqliteScalarAggregate(ScalarAggregateFeatureGroup):

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_security.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_security.py
@@ -82,13 +82,11 @@ class TestAllowlistCompleteness:
             assert f"test_{agg_type}" in collected.columns
 
     def test_sqlite_covers_supported_types(self) -> None:
-        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.sqlite_scalar_aggregate import (
-            _SQLITE_AGG_FUNCS,
-        )
+        from mloda.community.feature_groups.data_operations.sqlite_agg_constants import SQLITE_AGG_FUNCS
 
         basic_types = {"sum", "min", "max", "avg", "mean", "count"}
         for agg_type in basic_types:
-            assert agg_type in _SQLITE_AGG_FUNCS, f"SQLite backend missing basic aggregation type: {agg_type}"
+            assert agg_type in SQLITE_AGG_FUNCS, f"SQLite backend missing basic aggregation type: {agg_type}"
 
 
 class TestSqlUtilities:

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
@@ -54,6 +54,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import PartitionByMixin
+
 # Supported sessionization units mapped to their length in seconds. The four
 # keys also define the units accepted by the feature-name regex.
 SESSIONIZATION_UNITS: dict[str, int] = {
@@ -102,7 +104,7 @@ def _sessionize_threshold_seconds(n: int, unit: str) -> int:
     return n * SESSIONIZATION_UNITS[unit]
 
 
-class SessionizationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class SessionizationFeatureGroup(PartitionByMixin, FeatureChainParserMixin, FeatureGroup):
     """Base class for gap-threshold sessionization operations that preserve row count."""
 
     PREFIX_PATTERN = r".*__sessionize_\d+_(?:minute|hour|day|week)$"
@@ -191,14 +193,6 @@ class SessionizationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         except IndexError as exc:
             raise ValueError(f"Could not extract a sessionize token from feature name {name!r}.") from exc
         return f"sessionize_{token}"
-
-    @classmethod
-    def _extract_partition_by(cls, feature: Feature) -> list[str]:
-        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
 
     @classmethod
     def _extract_order_by(cls, feature: Feature, source_col: str) -> str:

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/duckdb_sessionization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/duckdb_sessionization.py
@@ -15,6 +15,7 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framewor
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name, quote_ident
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import assert_duckdb_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.base import (
     SessionizationFeatureGroup,
 )
@@ -27,10 +28,7 @@ class DuckdbSessionization(SessionizationFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: DuckdbRelation, order_col: str) -> None:
-        if order_col not in data.columns:
-            raise ValueError(
-                f"Source column {order_col!r} is not present in the DuckDB relation; available: {data.columns}."
-            )
+        assert_duckdb_source_col_present(data, order_col)
 
     @classmethod
     def _compute_session(

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pandas_sessionization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pandas_sessionization.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.pandas_helpers import assert_pandas_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.base import (
     SessionizationFeatureGroup,
 )
@@ -20,10 +21,7 @@ class PandasSessionization(SessionizationFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pd.DataFrame, order_col: str) -> None:
-        if order_col not in data.columns:
-            raise ValueError(
-                f"Source column {order_col!r} is not present in the pandas DataFrame; available: {list(data.columns)}."
-            )
+        assert_pandas_source_col_present(data, order_col)
 
     @classmethod
     def _compute_session(

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/polars_lazy_sessionization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/polars_lazy_sessionization.py
@@ -10,6 +10,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
+from mloda.community.feature_groups.data_operations.polars_helpers import assert_polars_source_col_present
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.base import (
     SessionizationFeatureGroup,
 )
@@ -22,9 +23,7 @@ class PolarsLazySessionization(SessionizationFeatureGroup):
 
     @classmethod
     def _assert_source_column_present(cls, data: pl.LazyFrame, order_col: str) -> None:
-        names = data.collect_schema().names()
-        if order_col not in names:
-            raise ValueError(f"Source column {order_col!r} is not present in the polars frame; available: {names}.")
+        assert_polars_source_col_present(data, order_col)
 
     @classmethod
     def _compute_session(

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/duckdb_window_aggregation.py
@@ -10,29 +10,17 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name, quote_ident
 from mloda_plugins.compute_framework.base_implementations.sql.sql_window import Unbounded, WindowFrame
 
+from mloda.community.feature_groups.data_operations.duckdb_agg_constants import DUCKDB_AGG_FUNCS
+from mloda.community.feature_groups.data_operations.duckdb_helpers import duckdb_drop_rn_restore
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import build_sql_case_when
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
 )
 
-# All aggregation types are natively supported by DuckDB window functions.
+# Window functions use FIRST_VALUE/LAST_VALUE (group aggregation uses FIRST/LAST).
 _DUCKDB_AGG_FUNCS: dict[str, str] = {
-    "sum": "SUM",
-    "avg": "AVG",
-    "mean": "AVG",
-    "count": "COUNT",
-    "min": "MIN",
-    "max": "MAX",
-    "std": "STDDEV_POP",
-    "var": "VAR_POP",
-    "std_pop": "STDDEV_POP",
-    "std_samp": "STDDEV_SAMP",
-    "var_pop": "VAR_POP",
-    "var_samp": "VAR_SAMP",
-    "median": "MEDIAN",
-    "mode": "MODE",
-    "nunique": "COUNT_DISTINCT",  # handled specially: COUNT(DISTINCT col) syntax
+    **DUCKDB_AGG_FUNCS,
     "first": "FIRST_VALUE",
     "last": "LAST_VALUE",
 }
@@ -94,7 +82,6 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
         last. Explicit UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING restores
         full-partition visibility to match PyArrow group_by().aggregate()."""
         rn = pick_helper_column_name(taken=set(data.columns) | {feature_name})
-        qrn = quote_ident(rn)
         agg_func = _DUCKDB_AGG_FUNCS[agg_type]
 
         # Step 1: tag rows with their original position
@@ -110,8 +97,4 @@ class DuckdbWindowAggregation(WindowAggregationFeatureGroup):
         )
 
         # Step 3: restore original row order, drop helper column
-        rel = rel.order(qrn)
-        keep = ", ".join(quote_ident(c) for c in rel.columns if c != rn)
-        rel = rel.project(keep)
-
-        return rel
+        return duckdb_drop_rn_restore(rel, rn)

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/polars_lazy_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/polars_lazy_window_aggregation.py
@@ -11,6 +11,7 @@ from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe 
 
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.mask_utils import _POLARS_MASK_TMP, apply_polars_mask
+from mloda.community.feature_groups.data_operations.polars_agg_constants import POLARS_AGG_EXPRS as _POLARS_AGG_EXPRS
 from mloda.community.feature_groups.data_operations.polars_mode_helpers import (
     ModeHelperCols,
     add_mode_helper_cols,
@@ -20,25 +21,6 @@ from mloda.community.feature_groups.data_operations.polars_mode_helpers import (
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
 )
-
-# Mapping from aggregation type to a Polars expression builder.
-# Each callable takes a column name and returns a Polars Expr.
-_POLARS_AGG_EXPRS: dict[str, Any] = {
-    "sum": lambda col: pl.col(col).sum(),
-    "avg": lambda col: pl.col(col).mean(),
-    "mean": lambda col: pl.col(col).mean(),
-    "count": lambda col: pl.col(col).count(),
-    "min": lambda col: pl.col(col).min(),
-    "max": lambda col: pl.col(col).max(),
-    "std": lambda col: pl.col(col).std(ddof=0),
-    "var": lambda col: pl.col(col).var(ddof=0),
-    "std_pop": lambda col: pl.col(col).std(ddof=0),
-    "std_samp": lambda col: pl.col(col).std(ddof=1),
-    "var_pop": lambda col: pl.col(col).var(ddof=0),
-    "var_samp": lambda col: pl.col(col).var(ddof=1),
-    "median": lambda col: pl.col(col).median(),
-    "nunique": lambda col: pl.col(col).drop_nulls().n_unique(),
-}
 
 _SUPPORTED_AGG_TYPES = {*_POLARS_AGG_EXPRS.keys(), "mode", "first", "last"}
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
@@ -19,35 +19,15 @@ from mloda_plugins.compute_framework.base_implementations.pyarrow.table import P
 from mloda.community.feature_groups.data_operations.errors import unsupported_agg_type_error
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
 from mloda.community.feature_groups.data_operations.mask_utils import apply_pyarrow_mask
+from mloda.community.feature_groups.data_operations.pyarrow_agg_constants import (
+    PA_AGG_FUNCS as _PA_AGG_FUNCS,
+    PA_ORDERED_FUNCS as _ORDERED_FUNCS,
+    PA_SUPPORTED_AGG_TYPES as _SUPPORTED_AGG_TYPES,
+    PA_VARIANCE_FUNCS as _VARIANCE_FUNCS,
+)
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
 )
-
-_PA_AGG_FUNCS: dict[str, str] = {
-    "sum": "sum",
-    "avg": "mean",
-    "mean": "mean",
-    "count": "count",
-    "min": "min",
-    "max": "max",
-    "nunique": "count_distinct",
-}
-
-_VARIANCE_FUNCS: dict[str, tuple[str, int]] = {
-    "std": ("stddev", 0),
-    "var": ("variance", 0),
-    "std_pop": ("stddev", 0),
-    "std_samp": ("stddev", 1),
-    "var_pop": ("variance", 0),
-    "var_samp": ("variance", 1),
-}
-
-_ORDERED_FUNCS: dict[str, str] = {
-    "first": "first",
-    "last": "last",
-}
-
-_SUPPORTED_AGG_TYPES = {*_PA_AGG_FUNCS, *_VARIANCE_FUNCS, *_ORDERED_FUNCS}
 
 
 class PyArrowWindowAggregation(WindowAggregationFeatureGroup):

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
@@ -14,16 +14,7 @@ from mloda.community.feature_groups.data_operations.mask_utils import build_sql_
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
     WindowAggregationFeatureGroup,
 )
-
-# Aggregation types that SQLite supports natively in window functions.
-_SQLITE_AGG_FUNCS: dict[str, str] = {
-    "sum": "SUM",
-    "avg": "AVG",
-    "mean": "AVG",
-    "count": "COUNT",
-    "min": "MIN",
-    "max": "MAX",
-}
+from mloda.community.feature_groups.data_operations.sqlite_agg_constants import SQLITE_AGG_FUNCS as _SQLITE_AGG_FUNCS
 
 
 class SqliteWindowAggregation(WindowAggregationFeatureGroup):

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/conftest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/conftest.py
@@ -1,29 +1,10 @@
-"""Shared fixtures and helpers for window_aggregation tests."""
+"""Shared helpers for window_aggregation tests."""
 
 from __future__ import annotations
 
-from typing import Any
-
-import pyarrow as pa
-import pytest
-
-from mloda.testing.data_creator.base import DataOperationsTestDataCreator
-from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.testing.feature_groups.data_operations.helpers import (
     make_feature_set,
 )
 
 # Re-export make_feature_set so existing imports from conftest still work.
 __all__ = ["make_feature_set"]
-
-
-@pytest.fixture
-def raw_data() -> dict[str, list[Any]]:
-    """Return the shared 12-row test dataset as a plain dict."""
-    return DataOperationsTestDataCreator.get_raw_data()
-
-
-@pytest.fixture
-def sample_data() -> pa.Table:
-    """Return the shared 12-row test dataset as a PyArrow Table."""
-    return PyArrowDataOpsTestDataCreator.create()

--- a/mloda/community/feature_groups/data_operations/sqlite_agg_constants.py
+++ b/mloda/community/feature_groups/data_operations/sqlite_agg_constants.py
@@ -1,0 +1,18 @@
+"""Shared SQLite aggregation-function table.
+
+The aggregation, window-aggregation, and scalar-aggregate families map the
+same aggregation names to the same native SQLite functions. (frame-aggregate
+intentionally omits ``mean`` and keeps its own subset.)
+"""
+
+from __future__ import annotations
+
+# Aggregation types that SQLite supports natively.
+SQLITE_AGG_FUNCS: dict[str, str] = {
+    "sum": "SUM",
+    "avg": "AVG",
+    "mean": "AVG",
+    "count": "COUNT",
+    "min": "MIN",
+    "max": "MAX",
+}

--- a/mloda/testing/data_creator/base.py
+++ b/mloda/testing/data_creator/base.py
@@ -28,19 +28,6 @@ class DataOperationsTestDataCreator(FeatureGroup):
 
     compute_framework: type[ComputeFramework] = PyArrowTable
 
-    NULL_POSITIONS: dict[str, set[int]] = {
-        "region": {11},
-        "category": {6},
-        "timestamp": {10},
-        "event_date": {2},
-        "value_int": {4},
-        "value_float": {2, 11},
-        "amount": {1, 7},
-        "name": {2, 11},
-        "is_active": {3, 9},
-        "score": set(range(12)),
-    }
-
     @classmethod
     def input_data(cls) -> BaseInputData | None:
         return DataCreator(set(cls.get_raw_data().keys()))

--- a/mloda/testing/feature_groups/data_operations/aggregation/aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/aggregation/aggregation.py
@@ -218,7 +218,7 @@ class AggregationTestBase(MaskTestMixin, DataOpsTestBase):
             assert result_map[region] == expected, f"region={region}"
 
     def test_null_policy_skip_avg_with_null_values(self) -> None:
-        """NullPolicy.SKIP: Group B has a null value_int at row 4. Avg should skip it."""
+        """Null-skip: Group B has a null value_int at row 4. Avg should skip it."""
         fs = make_feature_set("value_int__avg_agg", ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -229,7 +229,7 @@ class AggregationTestBase(MaskTestMixin, DataOpsTestBase):
         assert result_map["B"] == pytest.approx(140.0 / 3.0, rel=1e-6)
 
     def test_null_policy_null_is_group(self) -> None:
-        """NullPolicy.NULL_IS_GROUP: Row 11 has region=None. It should form its own group."""
+        """Null-as-group: Row 11 has region=None. It should form its own group."""
         fs = make_feature_set("value_int__sum_agg", ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -535,7 +535,7 @@ class AggregationTestBase(MaskTestMixin, DataOpsTestBase):
     # -- Null edge case tests ------------------------------------------------
 
     def test_null_policy_skip_all_null_column(self) -> None:
-        """NullPolicy.SKIP: score column is all null. Aggregation should produce all nulls."""
+        """Null-skip: score column is all null. Aggregation should produce all nulls."""
         fs = make_feature_set("score__sum_agg", ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 

--- a/mloda/testing/feature_groups/data_operations/base.py
+++ b/mloda/testing/feature_groups/data_operations/base.py
@@ -103,6 +103,16 @@ class DataOpsTestBase(ABC):
                 return
         pytest.skip(f"{op} not supported by this framework")
 
+    def _assert_float_list_with_nulls(self, actual: list[Any], expected: list[Any]) -> None:
+        """Assert two float lists match elementwise: ``None`` stays ``None``, others compared via approx."""
+        assert len(actual) == len(expected), f"row count {len(actual)} != expected {len(expected)}"
+        for i, (a, e) in enumerate(zip(actual, expected)):
+            if e is None:
+                assert a is None, f"row {i}: expected None, got {a!r}"
+            else:
+                assert a is not None, f"row {i}: expected {e!r}, got None"
+                assert float(a) == pytest.approx(e), f"row {i}: {a!r} != {e!r}"
+
     # -- Cross-framework comparison --------------------------------------------
 
     def _compare_with_reference(

--- a/mloda/testing/feature_groups/data_operations/row_preserving/datetime/datetime.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/datetime/datetime.py
@@ -89,18 +89,6 @@ VARIED_EXPECTED_IS_WEEKEND: list[Any] = [0, 0, 1, None]
 # Q2, Q3, Q4, None
 VARIED_EXPECTED_QUARTER: list[Any] = [2, 3, 4, None]
 
-VARIED_EXPECTED: dict[str, list[Any]] = {
-    "year": VARIED_EXPECTED_YEAR,
-    "month": VARIED_EXPECTED_MONTH,
-    "day": VARIED_EXPECTED_DAY,
-    "hour": VARIED_EXPECTED_HOUR,
-    "minute": VARIED_EXPECTED_MINUTE,
-    "second": VARIED_EXPECTED_SECOND,
-    "dayofweek": VARIED_EXPECTED_DAYOFWEEK,
-    "is_weekend": VARIED_EXPECTED_IS_WEEKEND,
-    "quarter": VARIED_EXPECTED_QUARTER,
-}
-
 
 def _create_varied_times_arrow_table() -> pa.Table:
     """Create a 4-row PyArrow table with non-midnight UTC timestamps."""

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ema/ema.py
@@ -250,15 +250,6 @@ class EmaTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
 
     # -- Helpers ------------------------------------------------------------
 
-    def _assert_float_list_with_nulls(self, actual: list[Any], expected: list[Any]) -> None:
-        assert len(actual) == len(expected), f"row count {len(actual)} != expected {len(expected)}"
-        for i, (a, e) in enumerate(zip(actual, expected)):
-            if e is None:
-                assert a is None, f"row {i}: expected None, got {a!r}"
-            else:
-                assert a is not None, f"row {i}: expected {e!r}, got None"
-                assert float(a) == pytest.approx(e), f"row {i}: {a!r} != {e!r}"
-
     def _ema_feature_set(self, span: int) -> FeatureSet:
         return make_feature_set(f"value__ema_{span}", partition_by=["region"], order_by="ts")
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/ffill/ffill.py
@@ -205,15 +205,6 @@ class FfillTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
 
     # -- Helpers ------------------------------------------------------------
 
-    def _assert_float_list_with_nulls(self, actual: list[Any], expected: list[Any]) -> None:
-        assert len(actual) == len(expected), f"row count {len(actual)} != expected {len(expected)}"
-        for i, (a, e) in enumerate(zip(actual, expected)):
-            if e is None:
-                assert a is None, f"row {i}: expected None, got {a!r}"
-            else:
-                assert a is not None, f"row {i}: expected {e!r}, got None"
-                assert float(a) == pytest.approx(e), f"row {i}: {a!r} != {e!r}"
-
     def _ffill_feature_set(self) -> FeatureSet:
         return make_feature_set("value__ffill", partition_by=["region"], order_by="ts")
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -187,7 +187,7 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         assert result_col[11] is None
 
     def test_null_policy_edge_null(self) -> None:
-        """NullPolicy.EDGE_NULL: lag at start of partition produces null."""
+        """Edge-null: lag at start of partition produces null."""
         fs = make_feature_set("value_int__lag_1_offset", ["region"], "value_int")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/percentile/percentile.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/percentile/percentile.py
@@ -153,7 +153,7 @@ class PercentileTestBase(MaskTestMixin, DataOpsTestBase):
         assert result_col == pytest.approx(EXPECTED_P100_BY_REGION, rel=1e-6)
 
     def test_null_policy_skip_p50_with_null_values(self) -> None:
-        """NullPolicy.SKIP: Group B has a null value_int at row 4. P50 should skip it."""
+        """Null-skip: Group B has a null value_int at row 4. P50 should skip it."""
         fs = make_feature_set("value_int__p50_percentile", ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -164,7 +164,7 @@ class PercentileTestBase(MaskTestMixin, DataOpsTestBase):
         assert result_col[7] == pytest.approx(50.0, rel=1e-6)
 
     def test_null_policy_null_is_group(self) -> None:
-        """NullPolicy.NULL_IS_GROUP: Row 11 has region=None. It should form its own group."""
+        """Null-as-group: Row 11 has region=None. It should form its own group."""
         fs = make_feature_set("value_int__p50_percentile", ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -194,7 +194,7 @@ class PercentileTestBase(MaskTestMixin, DataOpsTestBase):
         assert isinstance(result, self.get_expected_type())
 
     def test_null_policy_skip_all_null_column(self) -> None:
-        """NullPolicy.SKIP: score column is all null. Percentile should produce all nulls."""
+        """Null-skip: score column is all null. Percentile should produce all nulls."""
         fs = make_feature_set("score__p50_percentile", ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
@@ -192,7 +192,7 @@ class RankTestBase(DataOpsTestBase):
         assert result_col == EXPECTED_BOTTOM_2
 
     def test_null_policy_nulls_last(self) -> None:
-        """NullPolicy.NULLS_LAST: null values in order_by column rank last."""
+        """Nulls-last: null values in order_by column rank last."""
         fs = make_feature_set("value_int__row_number_ranked", ["region"], "value_int")
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -208,7 +208,7 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
         assert result_col == EXPECTED_MAX_BY_REGION
 
     def test_null_policy_skip_avg_with_null_values(self) -> None:
-        """NullPolicy.SKIP: Group B has a null value_int at row 4. Avg should skip it."""
+        """Null-skip: Group B has a null value_int at row 4. Avg should skip it."""
         fs = make_feature_set("value_int__avg_window", ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -219,7 +219,7 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
         assert result_col[7] == pytest.approx(GROUP_B_AVG_EXPECTED, rel=1e-6)
 
     def test_null_policy_null_is_group(self) -> None:
-        """NullPolicy.NULL_IS_GROUP: Row 11 has region=None. It should form its own group."""
+        """Null-as-group: Row 11 has region=None. It should form its own group."""
         fs = make_feature_set("value_int__sum_window", ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
@@ -463,7 +463,7 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
     # -- Null edge case tests ------------------------------------------------
 
     def test_null_policy_skip_all_null_column(self) -> None:
-        """NullPolicy.SKIP: score column is all null. Aggregation should produce all nulls or zeros.
+        """Null-skip: score column is all null. Aggregation should produce all nulls or zeros.
 
         PyArrow/Polars/DuckDB/SQLite return null for sum of all-null group.
         Pandas returns 0 (groupby.transform("sum") treats all-null as 0).


### PR DESCRIPTION
Addresses #259 (delivers the issue's recommended **safe, high-confidence first-PR scope**; does not fully close it, see deferred work below).

## Dead code removed (verified runtime-unreachable)
- `NullPolicy` enum (`base.py`) deleted; the ~14 `NullPolicy.*` docstring/comment anchors that named it reworded to neutral prose (`Null-skip`, `Null-as-group`, `Nulls-last`, `Edge-null`) per the decision recorded on the issue.
- `DataOperationsTestDataCreator.NULL_POSITIONS` class var (never read).
- Composite `VARIED_EXPECTED` dict in the datetime test fixtures (callers use the individual `VARIED_EXPECTED_*` constants).
- Unused `raw_data` / `sample_data` pytest fixtures (and orphaned imports) in the offset and window_aggregation test conftests.

## Duplication consolidated (behavior-preserving)
- **Backend agg tables** → shared `pyarrow_agg_constants`, `polars_agg_constants`, `sqlite_agg_constants`, `duckdb_agg_constants`. Per-context divergences preserved: DuckDB group `FIRST`/`LAST` vs window `FIRST_VALUE`/`LAST_VALUE`; Polars aggregation extends the shared 14 with `first`/`last`; SQLite `frame_aggregate`'s `mean`-omitting subset left untouched.
- **`_extract_partition_by`** → `PartitionByMixin` shared by the ffill/ema/sessionization/resample bases.
- **Source-column guards** → `assert_pandas_source_col_present` (added to `pandas_helpers`), plus new `polars_helpers` / `duckdb_helpers`.
- **DuckDB row-order restore** → `duckdb_drop_rn_restore` (ffill/window_aggregation/frame_aggregate/rank). rank's two-helper-column path is intentionally left as-is; only the single-`rn` path is migrated.
- **Test helper** `_assert_float_list_with_nulls` moved onto `DataOpsTestBase`.

## Deferred (tracked under #259, higher-risk / flagged follow-up in the issue)
- `_extract_source_features` / `input_features` / `_extract_order_by` `SingleSourceOrderedOpMixin` consolidation.
- pandas/polars sort-restore boilerplate extraction.
- resample-variant `_assert_source_column_present` message normalization.

## Notes
- Behavior-preserving consolidation done directly (no red phase), guarded by the existing data-operations suite.
- 48 files changed, net -107 lines; 6 new shared modules.

## Verification
`tox` passes: 3833 passed / 141 skipped (pytest), `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`.