### PR TITLE
docs: add tests badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![mloda](https://img.shields.io/badge/built%20with-mloda-blue.svg)](https://github.com/mloda-ai/mloda)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
+[![Tests](https://img.shields.io/badge/tests-1400%2B-green.svg)](https://github.com/mloda-ai/mloda-registry)
 
 # mloda-registry
 


### PR DESCRIPTION
Adds a Tests badge to the README (`tests-1400+`), matching the style used in the core mloda repo. Reflects the current test count (1408 test function definitions).