### PR TITLE
chore(deps): bump mloda to 0.9.0

### DIFF
--- a/config/packages.toml
+++ b/config/packages.toml
@@ -10,34 +10,34 @@
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/registry"
 
 [packages.mloda-testing]
 description = "Test utilities for mloda plugin development"
-dependencies = ["mloda>=0.9.0", "pytest>=9.0.3"]
+dependencies = ["{core_dependency}", "pytest>=9.0.3"]
 path = "mloda/testing"
 optional_dependencies = { dev = ["pytest>=9.0.3"] }
 
 [packages.mloda-community]
 description = "All community plugins for mloda"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/community"
 
 [packages.mloda-enterprise]
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/enterprise"
 
 [packages.mloda-community-example]
 description = "Example community FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/community/feature_groups/example"
 optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-example-b"] }
 
 [packages.mloda-enterprise-example]
 description = "Example enterprise FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/enterprise/feature_groups/example"
 
 [packages.mloda-community-example-a]
@@ -52,29 +52,29 @@ path = "mloda/community/feature_groups/example/example_b"
 
 [packages.mloda-community-compute-frameworks-example]
 description = "Example community ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/community/compute_frameworks/example"
 
 [packages.mloda-community-extenders-example]
 description = "Example community Extender plugin for mloda"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/community/extenders/example"
 
 [packages.mloda-enterprise-compute-frameworks-example]
 description = "Example enterprise ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/enterprise/compute_frameworks/example"
 
 [packages.mloda-enterprise-extenders-example]
 description = "Example enterprise Extender plugin for mloda"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/enterprise/extenders/example"
 
 # --- Data Operations ---
 
 [packages.mloda-community-data-operations]
 description = "Shared base classes for data operation feature groups"
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["{core_dependency}"]
 path = "mloda/community/feature_groups/data_operations"
 optional_dependencies = { all = ["mloda-community-window-aggregation", "mloda-community-aggregation", "mloda-community-rank", "mloda-community-offset", "mloda-community-frame-aggregate", "mloda-community-scalar-aggregate", "mloda-community-scalar-arithmetic", "mloda-community-point-arithmetic", "mloda-community-datetime", "mloda-community-string", "mloda-community-binning", "mloda-community-percentile", "mloda-community-time-bucketization", "mloda-community-ffill", "mloda-community-ema", "mloda-community-sessionization", "mloda-community-resample"] }
 

--- a/config/packages.toml
+++ b/config/packages.toml
@@ -10,34 +10,34 @@
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/registry"
 
 [packages.mloda-testing]
 description = "Test utilities for mloda plugin development"
-dependencies = ["mloda>=0.8.0", "pytest>=9.0.3"]
+dependencies = ["mloda>=0.9.0", "pytest>=9.0.3"]
 path = "mloda/testing"
 optional_dependencies = { dev = ["pytest>=9.0.3"] }
 
 [packages.mloda-community]
 description = "All community plugins for mloda"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/community"
 
 [packages.mloda-enterprise]
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/enterprise"
 
 [packages.mloda-community-example]
 description = "Example community FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/community/feature_groups/example"
 optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-example-b"] }
 
 [packages.mloda-enterprise-example]
 description = "Example enterprise FeatureGroup plugin for mloda"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/enterprise/feature_groups/example"
 
 [packages.mloda-community-example-a]
@@ -52,29 +52,29 @@ path = "mloda/community/feature_groups/example/example_b"
 
 [packages.mloda-community-compute-frameworks-example]
 description = "Example community ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/community/compute_frameworks/example"
 
 [packages.mloda-community-extenders-example]
 description = "Example community Extender plugin for mloda"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/community/extenders/example"
 
 [packages.mloda-enterprise-compute-frameworks-example]
 description = "Example enterprise ComputeFramework plugin for mloda"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/enterprise/compute_frameworks/example"
 
 [packages.mloda-enterprise-extenders-example]
 description = "Example enterprise Extender plugin for mloda"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/enterprise/extenders/example"
 
 # --- Data Operations ---
 
 [packages.mloda-community-data-operations]
 description = "Shared base classes for data operation feature groups"
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 path = "mloda/community/feature_groups/data_operations"
 optional_dependencies = { all = ["mloda-community-window-aggregation", "mloda-community-aggregation", "mloda-community-rank", "mloda-community-offset", "mloda-community-frame-aggregate", "mloda-community-scalar-aggregate", "mloda-community-scalar-arithmetic", "mloda-community-point-arithmetic", "mloda-community-datetime", "mloda-community-string", "mloda-community-binning", "mloda-community-percentile", "mloda-community-time-bucketization", "mloda-community-ffill", "mloda-community-ema", "mloda-community-sessionization", "mloda-community-resample"] }
 

--- a/config/shared.toml
+++ b/config/shared.toml
@@ -16,4 +16,5 @@ build-backend = "setuptools.build_meta"
 
 [defaults]
 license = "Apache-2.0"
+core_dependency = "mloda>=0.9.0"
 optional_dependencies = { dev = ["mloda-testing", "pytest>=9.0.3"] }

--- a/config/shared.toml
+++ b/config/shared.toml
@@ -2,8 +2,8 @@
 # Edit this file and run: python scripts/generate_pyproject.py
 
 [project]
-version = "0.3.2"
-requires-python = ">=3.10"
+version = "0.3.3"
+requires-python = ">=3.10,<3.15"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 
 [project.urls]

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-compute-frameworks-example"
-version = "0.3.2"
+version = "0.3.3"
 description = "Example community ComputeFramework plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example community ComputeFramework plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-extenders-example"
-version = "0.3.2"
+version = "0.3.3"
 description = "Example community Extender plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example community Extender plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-aggregation"
-version = "0.3.2"
+version = "0.3.3"
 description = "Aggregation feature group (reduce, partition_by, one row per group)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-data-operations"
-version = "0.3.2"
+version = "0.3.3"
 description = "Shared base classes for data operation feature groups"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Shared base classes for data operation feature groups"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-resample"
-version = "0.3.2"
+version = "0.3.3"
 description = "Resample feature group (collapse events onto a regular time grid: floor to bucket, group, aggregate; one row per non-empty bucket, row-changing)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-binning"
-version = "0.3.2"
+version = "0.3.3"
 description = "Binning feature group (equal-width, quantile, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-datetime"
-version = "0.3.2"
+version = "0.3.3"
 description = "Datetime extraction feature group (element-wise, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-ema"
-version = "0.3.2"
+version = "0.3.3"
 description = "EMA feature group (exponential moving average, adjust=False, null-skipping recurrence, per partition, row-preserving; pandas/polars native, pyarrow/duckdb/sqlite reject)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-ffill"
-version = "0.3.2"
+version = "0.3.3"
 description = "Forward-fill feature group (ffill a value column across time gaps, per partition, ordered by time, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-frame-aggregate"
-version = "0.3.2"
+version = "0.3.3"
 description = "Frame aggregate feature group (rolling, cumulative, expanding, time window, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-offset"
-version = "0.3.2"
+version = "0.3.3"
 description = "Offset feature group (lag, lead, diff, pct_change, first_value, last_value, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-percentile"
-version = "0.3.2"
+version = "0.3.3"
 description = "Percentile feature group (PERCENTILE_CONT, partition_by, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-point-arithmetic"
-version = "0.3.2"
+version = "0.3.3"
 description = "Point arithmetic feature group (element-wise two-column op: add, subtract, multiply, divide; PyArrow-reference null/IEEE-754 semantics on divide-by-zero; SQLite returns NULL)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.3.3"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-rank"
-version = "0.3.2"
+version = "0.3.3"
 description = "Rank feature group (row_number, rank, dense_rank, percent_rank, ntile, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-scalar-aggregate"
-version = "0.3.2"
+version = "0.3.3"
 description = "Scalar aggregate feature group (single-column global aggregate broadcast)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-scalar-arithmetic"
-version = "0.3.2"
+version = "0.3.3"
 description = "Scalar arithmetic feature group (element-wise column op constant: add, subtract, multiply, divide)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.3.3"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-sessionization"
-version = "0.3.2"
+version = "0.3.3"
 description = "Sessionization feature group (gap-threshold session id on an ordered timestamp, per partition, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-time-bucketization"
-version = "0.3.2"
+version = "0.3.3"
 description = "Time bucketization feature group (floor, ceil, round a timestamp to a bucket interval, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-window-aggregation"
-version = "0.3.2"
+version = "0.3.3"
 description = "Window aggregation feature group (broadcast, partition_by, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/data_operations/string/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/string/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-string"
-version = "0.3.2"
+version = "0.3.3"
 description = "String operation feature group (element-wise, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-data-operations>=0.2.12"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/example/example_a/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_a/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-example-a"
-version = "0.3.2"
+version = "0.3.3"
 description = "Example A FeatureGroup extending community example base"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-example>=0.2.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/example/example_b/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_b/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-example-b"
-version = "0.3.2"
+version = "0.3.3"
 description = "Example B FeatureGroup extending community example base"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda-community-example>=0.2.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example community FeatureGroup plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community-example"
-version = "0.3.2"
+version = "0.3.3"
 description = "Example community FeatureGroup plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-community"
-version = "0.3.2"
+version = "0.3.3"
 description = "All community plugins for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "All community plugins for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example enterprise ComputeFramework plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-enterprise-compute-frameworks-example"
-version = "0.3.2"
+version = "0.3.3"
 description = "Example enterprise ComputeFramework plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-enterprise-extenders-example"
-version = "0.3.2"
+version = "0.3.3"
 description = "Example enterprise Extender plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example enterprise Extender plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-enterprise-example"
-version = "0.3.2"
+version = "0.3.3"
 description = "Example enterprise FeatureGroup plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Example enterprise FeatureGroup plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.urls]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-enterprise"
-version = "0.3.2"
+version = "0.3.3"
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-registry"
-version = "0.3.2"
+version = "0.3.3"
 description = "Plugin discovery and search for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Plugin discovery and search for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/testing/pyproject.toml
+++ b/mloda/testing/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.2"
 description = "Test utilities for mloda plugin development"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.8.0", "pytest>=9.0.3"]
+dependencies = ["mloda>=0.9.0", "pytest>=9.0.3"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/mloda/testing/pyproject.toml
+++ b/mloda/testing/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mloda-testing"
-version = "0.3.2"
+version = "0.3.3"
 description = "Test utilities for mloda plugin development"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 dependencies = ["mloda>=0.9.0", "pytest>=9.0.3"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["pytest>=9.0.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Development workspace for mloda registry packages"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 dependencies = [
-    "mloda>=0.8.0",
+    "mloda>=0.9.0",
 ]
 authors = [
     { name = "Tom Kaltofen", email = "info@mloda.ai" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "mloda-registry-workspace"
 version = "0.2.0"
 description = "Development workspace for mloda registry packages"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "mloda>=0.9.0",
 ]

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -116,8 +116,10 @@ def generate_pyproject(
     author_strs = [f'{{ name = "{a["name"]}", email = "{a["email"]}" }}' for a in authors]
     lines.append(f"authors = [{', '.join(author_strs)}]")
 
-    # Dependencies
-    deps = pkg_config.get("dependencies", [])
+    # Dependencies - substitute the shared core dependency placeholder so the
+    # mloda-core pin lives in exactly one place (config/shared.toml).
+    core_dep = defaults.get("core_dependency", "")
+    deps = [dep.replace("{core_dependency}", core_dep) for dep in pkg_config.get("dependencies", [])]
     lines.append(f"dependencies = {to_toml_list(deps)}")
 
     lines.append(f'requires-python = "{shared["project"]["requires-python"]}"')
@@ -255,6 +257,47 @@ def update_workspace_members(packages: dict[str, Any], check: bool = False) -> t
     return True, "updated"
 
 
+def update_root_core_dependency(shared: dict[str, Any], check: bool = False) -> tuple[bool, str]:
+    """Update or check the mloda-core dependency in root pyproject.toml.
+
+    Rewrites the single ``[project].dependencies`` entry whose package name is
+    exactly ``mloda`` (never ``mloda-...``) to the shared ``core_dependency``
+    value, so the pin lives in one place. Idempotent and byte-stable.
+    Returns (success, message) tuple.
+    """
+    if not ROOT_PYPROJECT.exists():
+        return False, f"{ROOT_PYPROJECT}: missing"
+
+    core_dep = shared.get("defaults", {}).get("core_dependency", "")
+    if not core_dep:
+        return False, f"{ROOT_PYPROJECT}: core_dependency missing from config/shared.toml"
+
+    content = ROOT_PYPROJECT.read_text()
+
+    # Match a dependency array entry for the exact package name ``mloda``
+    # followed by a version specifier (``>=``, ``==`` ...). Requiring a version
+    # operator excludes ``mloda-...`` names and workspace paths like
+    # ``"mloda/community"``. Preserve indentation/quoting so the file is byte-stable.
+    pattern = re.compile(r'(?P<indent>[ \t]*)"mloda(?=[<>=!~])[^"]*"')
+
+    def _replace(match: re.Match[str]) -> str:
+        return f'{match.group("indent")}"{core_dep}"'
+
+    new_content, count = pattern.subn(_replace, content)
+
+    if count == 0:
+        return False, f"{ROOT_PYPROJECT}: mloda-core dependency entry not found"
+
+    if new_content == content:
+        return True, "up-to-date"
+
+    if check:
+        return False, f"{ROOT_PYPROJECT}: mloda-core dependency out of date"
+
+    ROOT_PYPROJECT.write_text(new_content)
+    return True, "updated"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Generate pyproject.toml files")
     parser.add_argument("--check", action="store_true", help="Check if files are up-to-date")
@@ -287,9 +330,14 @@ def main() -> int:
     # Handle workspace members
     workspace_ok, workspace_msg = update_workspace_members(packages, check=args.check)
 
+    # Handle root pyproject.toml mloda-core dependency (single source of truth)
+    core_ok, core_msg = update_root_core_dependency(shared, check=args.check)
+
     if args.check:
         if not workspace_ok:
             errors.append(workspace_msg)
+        if not core_ok:
+            errors.append(core_msg)
         if errors:
             print("❌ Files out of date:")
             for e in errors:
@@ -298,10 +346,14 @@ def main() -> int:
             return 1
         print(f"✅ All {len(packages)} pyproject.toml files are up-to-date")
         print("✅ Workspace members are up-to-date")
+        print("✅ Root mloda-core dependency is up-to-date")
         return 0
 
     if workspace_ok and workspace_msg == "updated":
         print(f"  ✓ {ROOT_PYPROJECT} (workspace members)")
+
+    if core_ok and core_msg == "updated":
+        print(f"  ✓ {ROOT_PYPROJECT} (mloda-core dependency)")
 
     print(f"\n✅ Generated {len(updated)} pyproject.toml files")
     return 0

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -118,8 +118,14 @@ def generate_pyproject(
 
     # Dependencies - substitute the shared core dependency placeholder so the
     # mloda-core pin lives in exactly one place (config/shared.toml).
+    raw_deps = pkg_config.get("dependencies", [])
     core_dep = defaults.get("core_dependency", "")
-    deps = [dep.replace("{core_dependency}", core_dep) for dep in pkg_config.get("dependencies", [])]
+    if not core_dep and any("{core_dependency}" in dep for dep in raw_deps):
+        raise ValueError(
+            f"{pkg_name}: dependency uses {{core_dependency}} placeholder but "
+            "[defaults].core_dependency is not set in config/shared.toml"
+        )
+    deps = [dep.replace("{core_dependency}", core_dep) for dep in raw_deps]
     lines.append(f"dependencies = {to_toml_list(deps)}")
 
     lines.append(f'requires-python = "{shared["project"]["requires-python"]}"')
@@ -348,6 +354,14 @@ def main() -> int:
         print("✅ Workspace members are up-to-date")
         print("✅ Root mloda-core dependency is up-to-date")
         return 0
+
+    if not workspace_ok or not core_ok:
+        print("❌ Failed to sync root pyproject.toml:")
+        if not workspace_ok:
+            print(f"  - {workspace_msg}")
+        if not core_ok:
+            print(f"  - {core_msg}")
+        return 1
 
     if workspace_ok and workspace_msg == "updated":
         print(f"  ✓ {ROOT_PYPROJECT} (workspace members)")

--- a/tests/test_end2end/test_core_dependency_single_source.py
+++ b/tests/test_end2end/test_core_dependency_single_source.py
@@ -34,10 +34,11 @@ _ROOT_PYPROJECT = _REPO_ROOT / "pyproject.toml"
 # followed by a floor version constraint.
 _CORE_PIN_RE = re.compile(r"^mloda\b.*>=")
 
-# Matches a literal core pin ``mloda>=`` where ``mloda`` is NOT part of a longer
-# hyphenated name like ``mloda-community-...``. This must NOT match
+# Matches a literal core pin such as ``mloda>=`` or the spaced form
+# ``mloda >= 0.9.0`` (any comparison operator), where ``mloda`` is NOT part of a
+# longer hyphenated name like ``mloda-community-...``. This must NOT match
 # ``mloda-community-data-operations>=0.2.12`` or ``mloda-testing``.
-_CORE_LITERAL_RE = re.compile(r"(?<![\w-])mloda>=")
+_CORE_LITERAL_RE = re.compile(r"(?<![\w-])mloda\s*(>=|==|~=|!=|<=|<|>)")
 
 
 def _load_toml(path: Path) -> dict[str, Any]:

--- a/tests/test_end2end/test_core_dependency_single_source.py
+++ b/tests/test_end2end/test_core_dependency_single_source.py
@@ -1,0 +1,117 @@
+"""Tests that the mloda-core version pin is declared in a single source of truth.
+
+The mloda-core dependency specifier (e.g. ``mloda>=0.9.0``) must live in exactly
+ONE place: ``config/shared.toml`` under ``[defaults].core_dependency``. Everywhere
+else it must be referenced, never re-typed:
+
+* ``config/packages.toml`` uses the placeholder token ``"{core_dependency}"`` in
+  each package's ``dependencies`` array instead of a literal ``mloda>=...`` string.
+* ``scripts/generate_pyproject.py`` substitutes that placeholder (and writes the
+  root ``pyproject.toml`` mloda entry) from the shared value.
+
+These tests encode that contract. They must fail while the pin is still duplicated
+across ``config/packages.toml`` and the root ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SHARED_CONFIG = _REPO_ROOT / "config" / "shared.toml"
+_PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
+_ROOT_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+# A pinned mloda-core specifier: the package name ``mloda`` (not ``mloda-...``)
+# followed by a floor version constraint.
+_CORE_PIN_RE = re.compile(r"^mloda\b.*>=")
+
+# Matches a literal core pin ``mloda>=`` where ``mloda`` is NOT part of a longer
+# hyphenated name like ``mloda-community-...``. This must NOT match
+# ``mloda-community-data-operations>=0.2.12`` or ``mloda-testing``.
+_CORE_LITERAL_RE = re.compile(r"(?<![\w-])mloda>=")
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _dep_name(spec: str) -> str:
+    """Extract the bare package name from a PEP 508 requirement string."""
+    return re.split(r"[<>=!~\s\[]", spec, maxsplit=1)[0].strip()
+
+
+def _core_dependency() -> str:
+    """Return the single-source core specifier, failing clearly if absent."""
+    shared = _load_toml(_SHARED_CONFIG)
+    defaults = shared.get("defaults", {})
+    assert "core_dependency" in defaults, (
+        "config/shared.toml [defaults] must define 'core_dependency' as the single "
+        "source of truth for the mloda-core version pin."
+    )
+    value = defaults["core_dependency"]
+    assert isinstance(value, str), "core_dependency must be a string"
+    return value
+
+
+def test_shared_defines_core_dependency() -> None:
+    """[defaults].core_dependency exists and is a pinned mloda specifier."""
+    value = _core_dependency()
+    assert _CORE_PIN_RE.match(value), (
+        f"core_dependency must be a pinned mloda-core specifier (e.g. 'mloda>=0.9.0'), got {value!r}."
+    )
+
+
+def test_packages_config_has_no_literal_core_pin() -> None:
+    """config/packages.toml must reference the core pin only via the placeholder."""
+    raw = _PACKAGES_CONFIG.read_text()
+    matches = _CORE_LITERAL_RE.findall(raw)
+    assert matches == [], (
+        f"config/packages.toml still contains {len(matches)} literal mloda-core pin(s); "
+        "each package must use the '{core_dependency}' placeholder instead."
+    )
+
+
+def test_root_pyproject_uses_core_dependency() -> None:
+    """Root pyproject.toml [project].dependencies contains exactly core_dependency."""
+    core = _core_dependency()
+    root = _load_toml(_ROOT_PYPROJECT)
+    deps = root.get("project", {}).get("dependencies", [])
+    assert core in deps, (
+        f"Root pyproject.toml [project].dependencies must contain the shared value {core!r}; got {deps!r}."
+    )
+    core_entries = [d for d in deps if _dep_name(d) == "mloda"]
+    assert core_entries == [core], (
+        f"Root pyproject.toml must declare the mloda-core dependency exactly as {core!r}; got {core_entries!r}."
+    )
+
+
+def test_generated_pyprojects_use_core_dependency() -> None:
+    """Every generated per-package pyproject.toml uses exactly core_dependency for mloda-core."""
+    core = _core_dependency()
+    packages = _load_toml(_PACKAGES_CONFIG).get("packages", {})
+
+    checked_core = 0
+    for pkg_name, pkg_config in packages.items():
+        pyproject_path = _REPO_ROOT / pkg_config["path"] / "pyproject.toml"
+        assert pyproject_path.exists(), f"{pyproject_path} is missing (run scripts/generate_pyproject.py)."
+        parsed = _load_toml(pyproject_path)
+        deps = parsed.get("project", {}).get("dependencies", [])
+        core_entries = [d for d in deps if _dep_name(d) == "mloda"]
+        for entry in core_entries:
+            checked_core += 1
+            assert entry == core, (
+                f"{pkg_name}: generated {pyproject_path} declares mloda-core as {entry!r}, "
+                f"but the single source of truth is {core!r}."
+            )
+
+    assert checked_core > 0, "Expected at least one generated pyproject.toml to depend on mloda-core."

--- a/tests/test_end2end/test_generate_pyproject_guards.py
+++ b/tests/test_end2end/test_generate_pyproject_guards.py
@@ -1,0 +1,113 @@
+"""Robustness guards for scripts/generate_pyproject.py.
+
+The generator is the single source of truth for every package's
+``pyproject.toml`` and for the root mloda-core pin. Two silent-failure modes
+must be turned into loud failures:
+
+Guard 1 -- a missing ``[defaults].core_dependency`` must raise, not silently
+substitute ``""`` and emit ``dependencies = [""]``.
+
+Guard 2 -- write mode must exit non-zero when the root mloda-core dependency
+entry cannot be synced, instead of returning 0 and leaving a stale pin.
+
+The generator lives at ``scripts/generate_pyproject.py`` (a script, not an
+installed package), so it is loaded here by file path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
+_ROOT_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+
+def _load_generator() -> ModuleType:
+    """Import scripts/generate_pyproject.py by file path."""
+    spec = importlib.util.spec_from_file_location("generate_pyproject", _GEN_PATH)
+    assert spec is not None and spec.loader is not None, f"could not load spec for {_GEN_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gen = _load_generator()
+
+
+def test_generate_raises_when_core_dependency_missing() -> None:
+    """generate_pyproject must fail loudly if core_dependency is absent.
+
+    Today ``defaults.get("core_dependency", "")`` turns a missing key into an
+    empty string, so ``"{core_dependency}"`` placeholders collapse to ``""``
+    and packages get an invalid ``dependencies = [""]``. This must raise
+    ``ValueError`` instead.
+    """
+    shared, packages_config = gen.load_configs()
+    packages = packages_config.get("packages", {})
+    assert "core_dependency" in shared["defaults"], "fixture assumption: shared config defines core_dependency"
+
+    # Simulate a misconfigured shared.toml with the pin removed.
+    shared["defaults"].pop("core_dependency", None)
+
+    pkg_config = packages["mloda-registry"]
+    assert "{core_dependency}" in pkg_config.get("dependencies", []), (
+        "fixture assumption: mloda-registry deps use the {core_dependency} placeholder"
+    )
+
+    with pytest.raises(ValueError):
+        content = gen.generate_pyproject("mloda-registry", pkg_config, shared, packages)
+        # Belt and suspenders: if it did NOT raise, it must at least not have
+        # emitted an empty dependency entry. This makes the current failure
+        # mode (silent "") produce a descriptive assertion rather than a bare
+        # "DID NOT RAISE".
+        assert '[""]' not in content and 'dependencies = [""]' not in content, (
+            f"generate_pyproject silently produced an empty core dependency:\n{content}"
+        )
+
+
+def test_write_mode_exits_nonzero_when_root_entry_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write mode must return non-zero when the root mloda-core entry is unsyncable.
+
+    The generator's file-path globals are CWD-relative, so an isolated
+    workspace under ``tmp_path`` (real configs copied in, a root
+    ``pyproject.toml`` with no ``mloda`` core entry) fully sandboxes the run.
+    ``update_root_core_dependency`` then returns ``(False, ...)``. Today
+    ``main()`` ignores that in write mode and returns 0; it must return 1.
+    """
+    # Snapshot the real root pyproject to prove the run never touches the repo.
+    real_root_before = _ROOT_PYPROJECT.read_text()
+
+    # Build an isolated workspace: real configs, sandboxed root pyproject.
+    (tmp_path / "config").mkdir()
+    shutil.copy(_REPO_ROOT / "config" / "shared.toml", tmp_path / "config" / "shared.toml")
+    shutil.copy(_REPO_ROOT / "config" / "packages.toml", tmp_path / "config" / "packages.toml")
+
+    # Root pyproject deliberately lacks any ``mloda`` core dependency entry,
+    # so update_root_core_dependency cannot find one to sync.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "sandbox-root"\ndependencies = ["requests>=2.0"]\n',
+    )
+
+    # CWD-relative globals now resolve inside the sandbox.
+    monkeypatch.chdir(tmp_path)
+    # Write mode: no --check flag.
+    monkeypatch.setattr(sys, "argv", ["generate_pyproject.py"])
+
+    return_code = gen.main()
+
+    assert return_code == 1, (
+        "generate_pyproject.main() in write mode must exit non-zero when the root "
+        f"mloda-core dependency entry cannot be synced, but it returned {return_code!r}."
+    )
+
+    # The real repository must be untouched by the sandboxed run.
+    assert _ROOT_PYPROJECT.read_text() == real_root_before, (
+        "the sandboxed generator run modified the real repository root pyproject.toml"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -328,10 +328,10 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/d8/b4f8beceec599fe75b4956fc8614ead1d40bc0642e6562c18c2c683f2685/mloda-0.8.0-py3-none-any.whl", hash = "sha256:521e0425169a99370b3d1cdf9fd480ebecb3f9a0ec67c62fe6a321ca8e3bcabe", size = 428976, upload-time = "2026-06-05T17:24:09.732Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/82/a7893ddd9ab26dd839671c594e9c16437364a8b8ed5dffb02e9b2de52d7f/mloda-0.9.0-py3-none-any.whl", hash = "sha256:d193b03622e6c8670ccde500c9e6d74eba9ef4ed70ca3bd6adbcb9330a370585", size = 430826, upload-time = "2026-07-07T08:48:32.032Z" },
 ]
 
 [[package]]
@@ -343,7 +343,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.8.0" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.9.0" }]
 
 [[package]]
 name = "mloda-community-aggregation"
@@ -461,7 +461,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -502,7 +502,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mloda-community-aggregation", marker = "extra == 'all'" },
     { name = "mloda-community-binning", marker = "extra == 'all'" },
     { name = "mloda-community-datetime", marker = "extra == 'all'" },
@@ -617,7 +617,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mloda-community-example-a", marker = "extra == 'all'" },
     { name = "mloda-community-example-b", marker = "extra == 'all'" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
@@ -685,7 +685,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1298,7 +1298,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.8.0" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.9.0" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
@@ -1316,7 +1316,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1338,7 +1338,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1360,7 +1360,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1382,7 +1382,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mloda-testing", marker = "extra == 'dev'", editable = "mloda/testing" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1419,7 +1419,7 @@ dev = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
     { name = "duckdb", marker = "extra == 'dev'" },
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'dev'" },
     { name = "polars", marker = "extra == 'dev'" },
@@ -1451,7 +1451,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,13 +1,10 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.15"
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
@@ -336,7 +333,7 @@ wheels = [
 
 [[package]]
 name = "mloda-community"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community" }
 dependencies = [
     { name = "mloda" },
@@ -347,7 +344,7 @@ requires-dist = [{ name = "mloda", specifier = ">=0.9.0" }]
 
 [[package]]
 name = "mloda-community-aggregation"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/aggregation" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -397,7 +394,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-binning"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/binning" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -447,7 +444,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-compute-frameworks-example"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/compute_frameworks/example" }
 dependencies = [
     { name = "mloda" },
@@ -469,7 +466,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-data-operations"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations" }
 dependencies = [
     { name = "mloda" },
@@ -527,7 +524,7 @@ provides-extras = ["dev", "all"]
 
 [[package]]
 name = "mloda-community-datetime"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/datetime" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -549,7 +546,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-ema"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/ema" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -599,7 +596,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-example"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/example" }
 dependencies = [
     { name = "mloda" },
@@ -627,7 +624,7 @@ provides-extras = ["dev", "all"]
 
 [[package]]
 name = "mloda-community-example-a"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/example/example_a" }
 dependencies = [
     { name = "mloda-community-example" },
@@ -649,7 +646,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-example-b"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/example/example_b" }
 dependencies = [
     { name = "mloda-community-example" },
@@ -671,7 +668,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-extenders-example"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/extenders/example" }
 dependencies = [
     { name = "mloda" },
@@ -693,7 +690,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-ffill"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/ffill" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -743,7 +740,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-frame-aggregate"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -787,7 +784,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-offset"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/offset" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -831,7 +828,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-percentile"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/percentile" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -875,7 +872,7 @@ provides-extras = ["dev", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-point-arithmetic"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -911,7 +908,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.2.12" },
+    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -925,7 +922,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-rank"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/rank" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -969,7 +966,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-resample"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_changing/resample" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1019,7 +1016,7 @@ provides-extras = ["dev", "pyarrow", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-scalar-aggregate"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1069,7 +1066,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-scalar-arithmetic"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1105,7 +1102,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.2.12" },
+    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1119,7 +1116,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-sessionization"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/sessionization" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1169,7 +1166,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-string"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/string" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1191,7 +1188,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-time-bucketization"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/time_bucketization" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1241,7 +1238,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-window-aggregation"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1291,7 +1288,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-enterprise"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/enterprise" }
 dependencies = [
     { name = "mloda" },
@@ -1302,7 +1299,7 @@ requires-dist = [{ name = "mloda", specifier = ">=0.9.0" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/enterprise/compute_frameworks/example" }
 dependencies = [
     { name = "mloda" },
@@ -1324,7 +1321,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-enterprise-example"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/enterprise/feature_groups/example" }
 dependencies = [
     { name = "mloda" },
@@ -1346,7 +1343,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-enterprise-extenders-example"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/enterprise/extenders/example" }
 dependencies = [
     { name = "mloda" },
@@ -1368,7 +1365,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-registry"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/registry" }
 dependencies = [
     { name = "mloda" },
@@ -1437,7 +1434,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-testing"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "mloda/testing" }
 dependencies = [
     { name = "mloda" },
@@ -1595,12 +1592,9 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
@@ -1758,12 +1752,9 @@ name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",


### PR DESCRIPTION
## What

Update mloda-registry for the mloda 0.9.0 release, plus two follow-up build-tooling fixes. Four commits:

1. **`chore(deps): bump mloda to 0.9.0`** - bump the mloda-core pin `>=0.8.0` -> `>=0.9.0`, regenerate per-package `pyproject.toml`, update `uv.lock`. The registry's full suite passes unchanged against 0.9.0 (verified on both 0.8.0 and 0.9.0), so no API breakage; this is the routine per-release floor bump.

2. **`fix(build): make the uv workspace resolvable again`** - `uv sync` / `uv lock` were failing ("No solution found ... point-arithmetic[all] incompatible"). Two causes: (a) unbounded `requires-python` made uv resolve an impossible Python 3.15+ split even though mloda caps at `<3.15` - now capped to `>=3.10,<3.15` to mirror mloda; (b) `config/shared.toml` version lagged at 0.3.2 while sibling floors pin `mloda-community-data-operations>=0.3.3`, so editable members could not satisfy their own siblings - advanced the in-development version to 0.3.3 (the value semantic-release computes next from tag 0.3.2, and its release step overwrites the field anyway). `uv lock --locked` and `uv sync --extra dev` now succeed.

3. **`refactor(build): single source of truth for the mloda-core pin`** - the pin was duplicated 12x. It now lives once as `core_dependency` in `config/shared.toml`; `config/packages.toml` uses a `{core_dependency}` placeholder and the generator (including a new root-pyproject handler) expands it. Bumping mloda is now a one-line change. Pure refactor: generated output is byte-identical. Adds a test enforcing the contract.

4. **`fix(build): harden pyproject generator against silent failures`** - review-driven: the generator now raises on a missing `core_dependency` (instead of emitting `dependencies = [""]`) and returns non-zero in write mode when the root/workspace sync fails (instead of exiting 0). Adds guard tests.

## Testing

`tox -e python314` green: 4108 passed, 141 skipped, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit` all clean. `generate_pyproject.py --check` and `uv lock --locked` clean.

## Review

Each substantive change went through two independent deep reviews (Claude Opus + codex). Opus verified the version bump is collision-free (semantic-release keys off git tags), the requires-python cap covers all supported interpreters, and the single-source refactor propagates a one-line bump everywhere. codex flagged two generator robustness gaps (silent `""` substitution; write-mode swallowing sync failures), both fixed in commit 4 via a TDD Red/Green cycle.
