### PR TITLE
docs(join): re-enable PyArrow as-of join now that core does it natively (mloda 0.9.0)

### DIFF
--- a/docs/guides/feature-group-patterns/08-links-joins.md
+++ b/docs/guides/feature-group-patterns/08-links-joins.md
@@ -87,8 +87,9 @@ Two matches happen at once:
 | `left_time_column` | required | Time column on the left side. |
 | `right_time_column` | required | Time column on the right side. |
 | `direction` | `"backward"` | `"backward"`: latest right row at or before the left time. `"forward"`: earliest right row at or after it. `"nearest"`: whichever is closest in time. |
-| `tolerance` | `None` | Maximum allowed time gap; a left row with no right match inside the gap gets nulls. Accepts a number or a `timedelta`. |
+| `tolerance` | `None` | Maximum allowed time gap; a left row with no right match inside the gap gets nulls. Accepts a number or a `timedelta` (backend restrictions apply, see below). |
 | `allow_exact_matches` | `True` | Whether an exactly-equal timestamp counts as a match. |
+| `coerce_time_columns` | `False` | When `True`, ISO-8601 string time columns are coerced to native timestamps per backend instead of raising. The default keeps the strict ordered-dtype check. |
 
 These follow pandas `merge_asof` semantics. The keyword arguments are keyword-only on
 both factories (`Link.asof(left_spec, right_spec, *, left_time_column=..., ...)` and
@@ -98,17 +99,29 @@ both factories (`Link.asof(left_spec, right_spec, *, left_time_column=..., ...)`
 
 | Backend | As-of | Notes |
 |---|---|---|
-| PyArrow | not supported (needs fix) | The current core implementation falls back to pandas (`to_pandas` then `pd.merge_asof` then `from_pandas`): it requires pandas to be installed and is not a native Arrow join. Treated as unsupported pending a native/reject fix, tracked in [mloda#488](https://github.com/mloda-ai/mloda/issues/488). Use Pandas or Polars instead. |
-| Pandas | yes | Native `pd.merge_asof`. |
-| Polars (lazy) | yes | Native `join_asof`. |
+| Pandas | yes | Native `pd.merge_asof`. Supports `direction="nearest"` and `timedelta` tolerances. |
+| Polars (lazy) | yes | Native `join_asof`. Supports `direction="nearest"` and `timedelta` tolerances. |
+| PyArrow | yes | Native Acero `Table.join_asof` (mloda 0.9.0, [mloda#489](https://github.com/mloda-ai/mloda/pull/489): no more pandas round-trip). Like the SQL backends it rejects `direction="nearest"` and `allow_exact_matches=False` with a `ValueError`, and requires an integer tolerance (a `timedelta` or non-integer tolerance is rejected). |
 | DuckDB | yes | SQL `ASOF JOIN`. Rejects `direction="nearest"` and a `timedelta` tolerance with a `ValueError`; pass a numeric tolerance instead. |
 | SQLite | yes | SQL window functions. Same restriction as DuckDB: no `nearest`, numeric tolerance only. |
 
 `direction="nearest"` and `timedelta` tolerances work on the Pandas and Polars
-backends but are rejected up front on the SQL backends rather than emulated in Python.
-PyArrow is not a supported target for as-of joins yet (see the note above and
-[mloda#488](https://github.com/mloda-ai/mloda/issues/488)). Pick a backend that
-supports the knobs your join needs.
+backends but are rejected up front (with a `ValueError`) on the PyArrow, DuckDB, and
+SQLite backends rather than emulated in Python: PyArrow's native Acero join has no
+symmetric "nearest" mode and takes an integer tolerance, and the SQL backends want a
+numeric tolerance. Pick a backend that supports the knobs your join needs.
+
+Two guards apply uniformly across every backend (mloda 0.9.0):
+
+- **Ordered time columns ([mloda#529](https://github.com/mloda-ai/mloda/pull/529)).**
+  As-of time columns must be ordered (datetime, numeric, or timedelta). A non-ordered
+  column (for example ISO-8601 date *strings* / object dtype) raises a clear
+  `ValueError` naming the column instead of silently producing wrong matches. Cast it
+  to a real datetime or numeric before joining.
+- **Opt-in string coercion ([mloda#548](https://github.com/mloda-ai/mloda/pull/548)).**
+  Passing `coerce_time_columns=True` to `Link.asof(...)` / `Link.asof_on(...)` opts in
+  to coercing ISO-8601 string time columns to native timestamps per backend; the
+  default (`False`) keeps the strict error above.
 
 ### Defining the link
 

--- a/docs/guides/feature-group-patterns/08-links-joins.md
+++ b/docs/guides/feature-group-patterns/08-links-joins.md
@@ -101,7 +101,7 @@ both factories (`Link.asof(left_spec, right_spec, *, left_time_column=..., ...)`
 |---|---|---|
 | Pandas | yes | Native `pd.merge_asof`. Supports `direction="nearest"` and `timedelta` tolerances. |
 | Polars (lazy) | yes | Native `join_asof`. Supports `direction="nearest"` and `timedelta` tolerances. |
-| PyArrow | yes | Native Acero `Table.join_asof` (mloda 0.9.0, [mloda#489](https://github.com/mloda-ai/mloda/pull/489): no more pandas round-trip). Like the SQL backends it rejects `direction="nearest"` and `allow_exact_matches=False` with a `ValueError`, and requires an integer tolerance (a `timedelta` or non-integer tolerance is rejected). |
+| PyArrow | yes | Native Acero `Table.join_asof` (mloda 0.9.0, [mloda#489](https://github.com/mloda-ai/mloda/pull/489): no more pandas round-trip). Like the SQL backends it rejects `direction="nearest"` with a `ValueError`; it is stricter than they are in two ways, also rejecting `allow_exact_matches=False` (Acero's match range always includes exact matches) and requiring an integer tolerance (a `timedelta` or non-integer tolerance is rejected). |
 | DuckDB | yes | SQL `ASOF JOIN`. Rejects `direction="nearest"` and a `timedelta` tolerance with a `ValueError`; pass a numeric tolerance instead. |
 | SQLite | yes | SQL window functions. Same restriction as DuckDB: no `nearest`, numeric tolerance only. |
 

--- a/docs/guides/feature-group-patterns/08-links-joins.md
+++ b/docs/guides/feature-group-patterns/08-links-joins.md
@@ -101,27 +101,17 @@ both factories (`Link.asof(left_spec, right_spec, *, left_time_column=..., ...)`
 |---|---|---|
 | Pandas | yes | Native `pd.merge_asof`. Supports `direction="nearest"` and `timedelta` tolerances. |
 | Polars (lazy) | yes | Native `join_asof`. Supports `direction="nearest"` and `timedelta` tolerances. |
-| PyArrow | yes | Native Acero `Table.join_asof` (mloda 0.9.0, [mloda#489](https://github.com/mloda-ai/mloda/pull/489): no more pandas round-trip). Like the SQL backends it rejects `direction="nearest"` with a `ValueError`; it is stricter than they are in two ways, also rejecting `allow_exact_matches=False` (Acero's match range always includes exact matches) and requiring an integer tolerance (a `timedelta` or non-integer tolerance is rejected). |
+| PyArrow | yes | Native Acero `Table.join_asof` ([mloda#489](https://github.com/mloda-ai/mloda/pull/489), 0.9.0). Rejects `direction="nearest"`, `allow_exact_matches=False`, and non-integer tolerances (integer only). |
 | DuckDB | yes | SQL `ASOF JOIN`. Rejects `direction="nearest"` and a `timedelta` tolerance with a `ValueError`; pass a numeric tolerance instead. |
 | SQLite | yes | SQL window functions. Same restriction as DuckDB: no `nearest`, numeric tolerance only. |
 
-`direction="nearest"` and `timedelta` tolerances work on the Pandas and Polars
-backends but are rejected up front (with a `ValueError`) on the PyArrow, DuckDB, and
-SQLite backends rather than emulated in Python: PyArrow's native Acero join has no
-symmetric "nearest" mode and takes an integer tolerance, and the SQL backends want a
-numeric tolerance. Pick a backend that supports the knobs your join needs.
-
-Two guards apply uniformly across every backend (mloda 0.9.0):
-
-- **Ordered time columns ([mloda#529](https://github.com/mloda-ai/mloda/pull/529)).**
-  As-of time columns must be ordered (datetime, numeric, or timedelta). A non-ordered
-  column (for example ISO-8601 date *strings* / object dtype) raises a clear
-  `ValueError` naming the column instead of silently producing wrong matches. Cast it
-  to a real datetime or numeric before joining.
-- **Opt-in string coercion ([mloda#548](https://github.com/mloda-ai/mloda/pull/548)).**
-  Passing `coerce_time_columns=True` to `Link.asof(...)` / `Link.asof_on(...)` opts in
-  to coercing ISO-8601 string time columns to native timestamps per backend; the
-  default (`False`) keeps the strict error above.
+`direction="nearest"` and `timedelta` tolerances work only on the Pandas and Polars
+backends; PyArrow and the SQL backends reject them (see the table). Two guards apply to
+every backend (mloda 0.9.0): as-of time columns must be ordered, so a non-ordered
+(e.g. string) column raises a clear `ValueError` naming it
+([mloda#529](https://github.com/mloda-ai/mloda/pull/529)); and `coerce_time_columns=True`
+opts in to coercing ISO-8601 string columns per backend
+([mloda#548](https://github.com/mloda-ai/mloda/pull/548)).
 
 ### Defining the link
 

--- a/tests/test_end2end/test_asof_join_example.py
+++ b/tests/test_end2end/test_asof_join_example.py
@@ -11,8 +11,8 @@ Scenario (tiny and hand-traceable)
 ----------------------------------
 Two source feature groups, both backed by ``DataCreator``:
 
-* ``AsofEventSource`` (LEFT / events): columns ``id``, ``symbol``, ``event_ts``.
-* ``AsofQuoteSource`` (RIGHT / quotes): columns ``symbol``, ``quote_ts``, ``price``.
+* the event source (LEFT / events): columns ``id``, ``symbol``, ``event_ts``.
+* the quote source (RIGHT / quotes): columns ``symbol``, ``quote_ts``, ``price``.
 
 Both declare ``index_columns() -> [Index(("symbol",))]`` so the ASOF link can
 derive the equi by-key (``symbol``) automatically. ``Link.asof_on(...)`` then
@@ -48,14 +48,23 @@ from typing import Any, Optional
 import pytest
 
 pd = pytest.importorskip("pandas")
-pa = pytest.importorskip("pyarrow")
+
+# pandas is the baseline (always required); pyarrow is optional. Guard both the
+# module and the compute-framework import so the pandas parametrization still
+# runs when pyarrow is absent (only the pyarrow param is skipped, see below).
+try:
+    import pyarrow as pa
+
+    from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+except ImportError:  # pragma: no cover - exercised only without pyarrow installed
+    pa = None  # type: ignore[assignment]
+    PyArrowTable = None  # type: ignore[assignment,misc]
 
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
 from mloda.provider import ComputeFramework, FeatureGroup, FeatureSet
 from mloda.user import Feature, FeatureName, Index, Link, Options, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
 _U = timezone.utc
 
@@ -214,17 +223,26 @@ class AsofEventPricePyArrow(_AsofEventPrice):
     compute_framework: type[ComputeFramework] = PyArrowTable
 
 
-def _extract_asof_prices(results: list[Any]) -> dict[int, int]:
-    """Read the ``{id: price}`` mapping from the pandas or PyArrow result frame."""
+def _extract_asof_prices(results: list[Any], framework: type[ComputeFramework]) -> dict[int, int]:
+    """Read the ``{id: price}`` mapping, asserting the result is the native frame type.
+
+    The type check is framework-aware: a pandas result is only accepted for the
+    pandas backend and a PyArrow result only for the PyArrow backend. This guards
+    the native compute path, so a regression where ``run_all`` satisfied a
+    PyArrow request with a pandas frame (or vice versa) fails loudly instead of
+    silently passing.
+    """
     for table in results:
         if isinstance(table, pd.DataFrame) and "asof_event_price" in table.columns:
+            assert framework is PandasDataFrame, f"Expected a {framework.__name__} result frame, got pandas.DataFrame"
             return {int(i): int(p) for i, p in zip(table["asof_event_id"], table["asof_event_price"])}
-        if isinstance(table, pa.Table) and "asof_event_price" in table.column_names:
+        if pa is not None and isinstance(table, pa.Table) and "asof_event_price" in table.column_names:
+            assert framework is PyArrowTable, f"Expected a {framework.__name__} result frame, got pyarrow.Table"
             ids = table.column("asof_event_id").to_pylist()
             prices = table.column("asof_event_price").to_pylist()
             return {int(i): int(p) for i, p in zip(ids, prices)}
 
-    raise AssertionError("No result frame with asof_event_price found")
+    raise AssertionError(f"No native {framework.__name__} result frame with asof_event_price found")
 
 
 def _run_asof_backward(
@@ -250,7 +268,7 @@ def _run_asof_backward(
         plugin_collector=plugin_collector,
     )
 
-    return _extract_asof_prices(results)
+    return _extract_asof_prices(results, framework)
 
 
 class TestAsofJoinExample:
@@ -272,6 +290,7 @@ class TestAsofJoinExample:
                 AsofQuoteSourcePyArrow,
                 AsofEventPricePyArrow,
                 id="pyarrow",
+                marks=pytest.mark.skipif(pa is None or PyArrowTable is None, reason="pyarrow not installed"),
             ),
         ],
     )

--- a/tests/test_end2end/test_asof_join_example.py
+++ b/tests/test_end2end/test_asof_join_example.py
@@ -1,43 +1,12 @@
-"""End-to-end worked example of mloda's ASOF (point-in-time) join.
+"""Runnable example of mloda's ASOF (point-in-time) join, linked from the as-of
+join guide. It passes on first run and is exercised on both the pandas and
+PyArrow backends (mloda 0.9.0 does PyArrow ASOF natively via Acero).
 
-This module is a *readable* example, not a red-phase failing test: mloda already
-implements the ASOF join in core, so the test PASSES on first run. It is kept as
-a regression/example that pins the point-in-time semantics, and the ASOF join
-guide links to it. The same scenario is exercised on two compute frameworks,
-pandas and PyArrow, via a single parametrized test; mloda 0.9.0 implements the
-PyArrow ASOF join natively (Acero), so both backends pass.
+Backward join keyed by ``symbol``: each event picks the latest quote with
+``quote_ts <= event_ts`` (exact match allowed). Expected price per event id::
 
-Scenario (tiny and hand-traceable)
-----------------------------------
-Two source feature groups, both backed by ``DataCreator``:
-
-* the event source (LEFT / events): columns ``id``, ``symbol``, ``event_ts``.
-* the quote source (RIGHT / quotes): columns ``symbol``, ``quote_ts``, ``price``.
-
-Both declare ``index_columns() -> [Index(("symbol",))]`` so the ASOF link can
-derive the equi by-key (``symbol``) automatically. ``Link.asof_on(...)`` then
-performs a *backward* as-of join: for each event row it picks the quote with the
-same ``symbol`` whose ``quote_ts`` is the latest value ``<= event_ts``.
-``allow_exact_matches=True`` (the default) means an event whose timestamp equals
-a quote timestamp matches that quote.
-
-Quote price timelines (per symbol)::
-
-    AAA:  10:00 -> 100      BBB:  10:00 -> 200
-          10:30 -> 110            10:30 -> 220
-
-Hand-traced expected price in effect at each event (backward, exact allowed)::
-
-    id  symbol  event_ts   reasoning                                  -> price
-    0   AAA     10:00      exact match on AAA@10:00                    -> 100
-    1   AAA     10:15      latest AAA quote <= 10:15 is AAA@10:00      -> 100
-    2   AAA     10:45      latest AAA quote <= 10:45 is AAA@10:30      -> 110
-    3   BBB     10:30      exact match on BBB@10:30                    -> 220
-    4   BBB     11:00      latest BBB quote <= 11:00 is BBB@10:30      -> 220
-
-The join is keyed by ``symbol`` (the by-key), so AAA events never see BBB quotes
-and vice versa. Every event sits at or after its symbol's first quote, so there
-are no null matches in this example.
+    0 AAA@10:00 -> 100   1 AAA@10:15 -> 100   2 AAA@10:45 -> 110
+    3 BBB@10:30 -> 220   4 BBB@11:00 -> 220
 """
 
 from __future__ import annotations
@@ -73,26 +42,14 @@ _ASOF_BACKWARD_EXPECTED: dict[int, int] = {0: 100, 1: 100, 2: 110, 3: 220, 4: 22
 
 
 def _to_frame(framework: type[ComputeFramework], columns: dict[str, Any]) -> Any:
-    """Materialize a column dict into the native frame of ``framework``.
-
-    Both source and consumer feature groups produce their output this way so the
-    per-backend difference is confined to a single place: pandas builds a
-    ``DataFrame`` and PyArrow builds a ``Table``. ``columns`` may hold plain
-    Python lists (from the sources) or already-native columns such as a PyArrow
-    ``ChunkedArray`` (from the merged frame in the consumer).
-    """
+    """Build the native frame for ``framework`` (pandas ``DataFrame`` / PyArrow ``Table``)."""
     if framework is PandasDataFrame:
         return pd.DataFrame(columns)
     return pa.table(columns)
 
 
 class _AsofEventSource(FeatureGroup):
-    """LEFT side base: event rows carrying the entity (``symbol``) and event time.
-
-    All backend-agnostic wiring lives here; concrete subclasses only pin the
-    ``compute_framework`` so ``calculate_feature`` materializes the matching
-    native frame via :func:`_to_frame`.
-    """
+    """LEFT side (events); subclasses only pin ``compute_framework``."""
 
     compute_framework: type[ComputeFramework]
 
@@ -128,7 +85,7 @@ class _AsofEventSource(FeatureGroup):
 
 
 class _AsofQuoteSource(FeatureGroup):
-    """RIGHT side base: a per-symbol price timeline keyed by quote time."""
+    """RIGHT side (per-symbol price timeline); subclasses only pin ``compute_framework``."""
 
     compute_framework: type[ComputeFramework]
 
@@ -163,16 +120,8 @@ class _AsofQuoteSource(FeatureGroup):
 
 
 class _AsofEventPrice(FeatureGroup):
-    """Consumer base that pulls columns from both sources, triggering the ASOF link.
-
-    Requesting features from two different feature groups that have a ``Link``
-    between them is what makes mloda apply the join: the merged frame is handed
-    to ``calculate_feature`` as ``data``. This group then exposes the event id
-    and the as-of price as two named features so the test can assert keyed by id
-    (the merge engine sorts the result by ``event_ts``, so a positional list
-    would not be in input order). The output frame is materialized in the
-    subclass's ``compute_framework`` so the result matches the requested backend.
-    """
+    """Consumer that pulls from both sources (triggering the ASOF link) and exposes
+    ``asof_event_id`` / ``asof_event_price`` so the test can assert keyed by id."""
 
     compute_framework: type[ComputeFramework]
 
@@ -224,14 +173,8 @@ class AsofEventPricePyArrow(_AsofEventPrice):
 
 
 def _extract_asof_prices(results: list[Any], framework: type[ComputeFramework]) -> dict[int, int]:
-    """Read the ``{id: price}`` mapping, asserting the result is the native frame type.
-
-    The type check is framework-aware: a pandas result is only accepted for the
-    pandas backend and a PyArrow result only for the PyArrow backend. This guards
-    the native compute path, so a regression where ``run_all`` satisfied a
-    PyArrow request with a pandas frame (or vice versa) fails loudly instead of
-    silently passing.
-    """
+    """Read ``{id: price}`` from the result, asserting it is ``framework``'s native
+    frame type so a wrong-backend result (e.g. a pandas fallback) fails loudly."""
     for table in results:
         if isinstance(table, pd.DataFrame) and "asof_event_price" in table.columns:
             assert framework is PandasDataFrame, f"Expected a {framework.__name__} result frame, got pandas.DataFrame"

--- a/tests/test_end2end/test_asof_join_example.py
+++ b/tests/test_end2end/test_asof_join_example.py
@@ -1,13 +1,15 @@
-"""End-to-end worked example of mloda 0.8.0's ASOF (point-in-time) join.
+"""End-to-end worked example of mloda's ASOF (point-in-time) join.
 
-This module is a *readable* example, not a red-phase failing test: mloda 0.8.0
-already implements the ASOF join in core, so the test PASSES on first run. It is
-kept as a regression/example that pins the point-in-time semantics, and the ASOF
-join guide links to it.
+This module is a *readable* example, not a red-phase failing test: mloda already
+implements the ASOF join in core, so the test PASSES on first run. It is kept as
+a regression/example that pins the point-in-time semantics, and the ASOF join
+guide links to it. The same scenario is exercised on two compute frameworks,
+pandas and PyArrow, via a single parametrized test; mloda 0.9.0 implements the
+PyArrow ASOF join natively (Acero), so both backends pass.
 
 Scenario (tiny and hand-traceable)
 ----------------------------------
-Two source feature groups, both pandas data sources backed by ``DataCreator``:
+Two source feature groups, both backed by ``DataCreator``:
 
 * ``AsofEventSource`` (LEFT / events): columns ``id``, ``symbol``, ``event_ts``.
 * ``AsofQuoteSource`` (RIGHT / quotes): columns ``symbol``, ``quote_ts``, ``price``.
@@ -46,12 +48,14 @@ from typing import Any, Optional
 import pytest
 
 pd = pytest.importorskip("pandas")
+pa = pytest.importorskip("pyarrow")
 
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
 from mloda.provider import ComputeFramework, FeatureGroup, FeatureSet
 from mloda.user import Feature, FeatureName, Index, Link, Options, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
 _U = timezone.utc
 
@@ -59,10 +63,29 @@ _U = timezone.utc
 _ASOF_BACKWARD_EXPECTED: dict[int, int] = {0: 100, 1: 100, 2: 110, 3: 220, 4: 220}
 
 
-class AsofEventSource(FeatureGroup):
-    """LEFT side: event rows carrying the entity (``symbol``) and an event time."""
+def _to_frame(framework: type[ComputeFramework], columns: dict[str, Any]) -> Any:
+    """Materialize a column dict into the native frame of ``framework``.
 
-    compute_framework: type[ComputeFramework] = PandasDataFrame
+    Both source and consumer feature groups produce their output this way so the
+    per-backend difference is confined to a single place: pandas builds a
+    ``DataFrame`` and PyArrow builds a ``Table``. ``columns`` may hold plain
+    Python lists (from the sources) or already-native columns such as a PyArrow
+    ``ChunkedArray`` (from the merged frame in the consumer).
+    """
+    if framework is PandasDataFrame:
+        return pd.DataFrame(columns)
+    return pa.table(columns)
+
+
+class _AsofEventSource(FeatureGroup):
+    """LEFT side base: event rows carrying the entity (``symbol``) and event time.
+
+    All backend-agnostic wiring lives here; concrete subclasses only pin the
+    ``compute_framework`` so ``calculate_feature`` materializes the matching
+    native frame via :func:`_to_frame`.
+    """
+
+    compute_framework: type[ComputeFramework]
 
     @classmethod
     def get_raw_data(cls) -> dict[str, list[Any]]:
@@ -88,17 +111,17 @@ class AsofEventSource(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return pd.DataFrame(cls.get_raw_data())
+        return _to_frame(cls.compute_framework, cls.get_raw_data())
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {cls.compute_framework}
 
 
-class AsofQuoteSource(FeatureGroup):
-    """RIGHT side: a per-symbol price timeline keyed by quote time."""
+class _AsofQuoteSource(FeatureGroup):
+    """RIGHT side base: a per-symbol price timeline keyed by quote time."""
 
-    compute_framework: type[ComputeFramework] = PandasDataFrame
+    compute_framework: type[ComputeFramework]
 
     @classmethod
     def get_raw_data(cls) -> dict[str, list[Any]]:
@@ -123,32 +146,33 @@ class AsofQuoteSource(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return pd.DataFrame(cls.get_raw_data())
+        return _to_frame(cls.compute_framework, cls.get_raw_data())
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {cls.compute_framework}
 
 
-class AsofEventPrice(FeatureGroup):
-    """Consumer that pulls columns from both sources, triggering the ASOF link.
+class _AsofEventPrice(FeatureGroup):
+    """Consumer base that pulls columns from both sources, triggering the ASOF link.
 
     Requesting features from two different feature groups that have a ``Link``
     between them is what makes mloda apply the join: the merged frame is handed
     to ``calculate_feature`` as ``data``. This group then exposes the event id
     and the as-of price as two named features so the test can assert keyed by id
     (the merge engine sorts the result by ``event_ts``, so a positional list
-    would not be in input order).
+    would not be in input order). The output frame is materialized in the
+    subclass's ``compute_framework`` so the result matches the requested backend.
     """
 
-    compute_framework: type[ComputeFramework] = PandasDataFrame
+    compute_framework: type[ComputeFramework]
 
     @classmethod
     def feature_names_supported(cls) -> set[str]:
         return {"asof_event_id", "asof_event_price"}
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        # id + event_ts resolve to AsofEventSource; quote_ts + price to AsofQuoteSource.
+        # id + event_ts resolve to the event source; quote_ts + price to the quote source.
         # symbol (the by-key) is retained automatically as the index column.
         return {
             Feature("id"),
@@ -159,41 +183,104 @@ class AsofEventPrice(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return pd.DataFrame({"asof_event_id": data["id"], "asof_event_price": data["price"]})
+        return _to_frame(cls.compute_framework, {"asof_event_id": data["id"], "asof_event_price": data["price"]})
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {cls.compute_framework}
 
 
-def _run_asof_backward() -> dict[int, int]:
-    """Run the backward ASOF join through ``run_all`` and return ``{id: price}``."""
-    link = Link.asof_on(
-        AsofEventSource,
-        AsofQuoteSource,
-        left_time_column="event_ts",
-        right_time_column="quote_ts",
-        direction="backward",
-    )
-    plugin_collector = PluginCollector.enabled_feature_groups({AsofEventSource, AsofQuoteSource, AsofEventPrice})
+class AsofEventSourcePandas(_AsofEventSource):
+    compute_framework: type[ComputeFramework] = PandasDataFrame
 
-    results = mloda.run_all(
-        [Feature("asof_event_id"), Feature("asof_event_price")],
-        compute_frameworks={PandasDataFrame},
-        links={link},
-        plugin_collector=plugin_collector,
-    )
 
+class AsofQuoteSourcePandas(_AsofQuoteSource):
+    compute_framework: type[ComputeFramework] = PandasDataFrame
+
+
+class AsofEventPricePandas(_AsofEventPrice):
+    compute_framework: type[ComputeFramework] = PandasDataFrame
+
+
+class AsofEventSourcePyArrow(_AsofEventSource):
+    compute_framework: type[ComputeFramework] = PyArrowTable
+
+
+class AsofQuoteSourcePyArrow(_AsofQuoteSource):
+    compute_framework: type[ComputeFramework] = PyArrowTable
+
+
+class AsofEventPricePyArrow(_AsofEventPrice):
+    compute_framework: type[ComputeFramework] = PyArrowTable
+
+
+def _extract_asof_prices(results: list[Any]) -> dict[int, int]:
+    """Read the ``{id: price}`` mapping from the pandas or PyArrow result frame."""
     for table in results:
         if isinstance(table, pd.DataFrame) and "asof_event_price" in table.columns:
             return {int(i): int(p) for i, p in zip(table["asof_event_id"], table["asof_event_price"])}
+        if isinstance(table, pa.Table) and "asof_event_price" in table.column_names:
+            ids = table.column("asof_event_id").to_pylist()
+            prices = table.column("asof_event_price").to_pylist()
+            return {int(i): int(p) for i, p in zip(ids, prices)}
 
     raise AssertionError("No result frame with asof_event_price found")
 
 
-class TestAsofJoinExample:
-    """Backward point-in-time join happy path on the pandas backend."""
+def _run_asof_backward(
+    framework: type[ComputeFramework],
+    event_source: type[FeatureGroup],
+    quote_source: type[FeatureGroup],
+    event_price: type[FeatureGroup],
+) -> dict[int, int]:
+    """Run the backward ASOF join through ``run_all`` and return ``{id: price}``."""
+    link = Link.asof_on(
+        event_source,
+        quote_source,
+        left_time_column="event_ts",
+        right_time_column="quote_ts",
+        direction="backward",
+    )
+    plugin_collector = PluginCollector.enabled_feature_groups({event_source, quote_source, event_price})
 
-    def test_backward_asof_picks_price_in_effect(self) -> None:
-        result = _run_asof_backward()
+    results = mloda.run_all(
+        [Feature("asof_event_id"), Feature("asof_event_price")],
+        compute_frameworks={framework},
+        links={link},
+        plugin_collector=plugin_collector,
+    )
+
+    return _extract_asof_prices(results)
+
+
+class TestAsofJoinExample:
+    """Backward point-in-time join happy path on the pandas and PyArrow backends."""
+
+    @pytest.mark.parametrize(
+        "framework, event_source, quote_source, event_price",
+        [
+            pytest.param(
+                PandasDataFrame,
+                AsofEventSourcePandas,
+                AsofQuoteSourcePandas,
+                AsofEventPricePandas,
+                id="pandas",
+            ),
+            pytest.param(
+                PyArrowTable,
+                AsofEventSourcePyArrow,
+                AsofQuoteSourcePyArrow,
+                AsofEventPricePyArrow,
+                id="pyarrow",
+            ),
+        ],
+    )
+    def test_backward_asof_picks_price_in_effect(
+        self,
+        framework: type[ComputeFramework],
+        event_source: type[FeatureGroup],
+        quote_source: type[FeatureGroup],
+        event_price: type[FeatureGroup],
+    ) -> None:
+        result = _run_asof_backward(framework, event_source, quote_source, event_price)
         assert result == _ASOF_BACKWARD_EXPECTED


### PR DESCRIPTION
Closes #255. mloda 0.9.0 (mloda#489) made the PyArrow merge engine do as-of joins natively via Acero instead of round-tripping through pandas, and the registry now pins `mloda>=0.9.0` (#282). This updates the guide to the real status and exercises the native path.

## Changes

`docs/guides/feature-group-patterns/08-links-joins.md`:
- PyArrow backend row: "not supported (needs fix)" -> "yes" (native Acero `Table.join_asof`). Notes it rejects `direction="nearest"` (like the SQL backends) and is stricter still: also rejects `allow_exact_matches=False` and requires an integer tolerance.
- Documents the two related 0.9.0 guards (ordered-column `ValueError`, mloda#529; opt-in `coerce_time_columns`, mloda#548) and drops the stale mloda#488 pointers.

`tests/test_end2end/test_asof_join_example.py`:
- Runs the backward as-of example on both pandas and PyArrow (parametrized), asserting the result is the native frame type so a pandas-fallback regression fails loudly. Pyarrow case skips when pyarrow is absent.

## Verification

`tox` green (4109 passed, 141 skipped; ruff/mypy/bandit clean). Gated by two independent reviews (Claude Opus + codex); all doc claims verified against the mloda 0.9.0 source.
