### PR TITLE
test(credentials): guard against HashableDict in credential/BaseInputData path (#270)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,3 +55,14 @@ jobs:
         python-version: "3.12"
     - name: Lint docs
       run: python scripts/lint_docs.py
+
+  lint-credentials:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Run credentials lint
+      run: python scripts/lint_credentials.py

--- a/scripts/lint_credentials.py
+++ b/scripts/lint_credentials.py
@@ -1,15 +1,38 @@
-"""Lint for HashableDict reappearing near credential / BaseInputData data-access construction.
+"""Lint for HashableDict reappearing inside credential / BaseInputData data-access construction.
 
 Regression guard for GitHub issue #270: mloda 0.9.0 rejects HashableDict in
-credential / BaseInputData data-access construction. This flags any HashableDict
-token that appears on or within a few lines of a credential marker, while leaving
-legitimate HashableDict usage (Options group values, ApiInputDataCollection,
-provider export/import) untouched.
+credential / BaseInputData data-access construction. Detection is marker-anchored
+and bracket-span based:
+
+- A construction-shaped credential marker is one of ``credentials=``,
+  ``add_credentials(``, or a quoted ``"BaseInputData"`` group key.
+- From each marker match, walk forward character by character tracking bracket
+  depth. The marker's construct span ends when depth goes negative (the enclosing
+  construct was exited) or when a newline is seen at depth 0 (the statement ended),
+  with a safety cap so an unclosed snippet cannot run away.
+- Any ``HashableDict`` token whose offset falls inside such a span is flagged, at
+  the token's 1-based line, deduped to one error per line.
+
+Legitimate HashableDict usage (Options group values, ApiInputDataCollection,
+provider export/import) is left untouched because it is not inside a marker span.
+
+Known limitations (accepted trade-offs, matched against the literal source text):
+- Aliased imports evade detection. ``from mloda.provider import HashableDict as HD``
+  followed by ``HD(...)`` is not caught: the guard matches the literal
+  ``HashableDict`` token only.
+- No dataflow / variable-indirection analysis. ``credentials=creds`` where
+  ``creds = HashableDict(...)`` is assigned elsewhere is not caught: detection is
+  limited to ``HashableDict`` appearing inside the credential construct's own
+  brackets.
+- Only the quoted ``"BaseInputData"`` group-key form is matched (the documented
+  reader-tuple form). An unquoted ``BaseInputData`` class reference is intentionally
+  not treated as a marker, to avoid false positives on that ubiquitous token.
 
 Run: python scripts/lint_credentials.py
 Exit code: 1 if any issues found, 0 otherwise.
 """
 
+import os
 import re
 import sys
 from pathlib import Path
@@ -27,29 +50,55 @@ SELF_FILES: frozenset[str] = frozenset({"scripts/lint_credentials.py", "tests/te
 
 HASHABLE_DICT_RE = re.compile(r"\bHashableDict\b")
 
-CREDENTIAL_MARKER_RE = re.compile(
-    r"\bcredentials\b|\badd_credentials\b|\bDataAccessCollection\b|[\"']BaseInputData[\"']"
-)
+CREDENTIAL_MARKER_RE = re.compile(r"\bcredentials\s*=|\badd_credentials\s*\(|[\"']BaseInputData[\"']")
+
+# Safety cap: stop scanning a single marker's span after this many lines so a
+# malformed / unclosed snippet cannot run away.
+_MAX_SPAN_LINES = 50
 
 
-def scan_content(rel_path: str, content: str, window: int = 2) -> list[str]:
-    """Flag each HashableDict line that has a credential marker within +/- window lines.
+def _marker_span_end(content: str, start: int) -> int:
+    """Return the exclusive end offset of the bracket-balanced span from ``start``.
+
+    Walk forward tracking bracket depth. Stop when depth goes negative (the
+    enclosing construct was exited), when a newline is seen at depth 0 (the
+    statement ended), or when the safety cap of scanned lines is reached.
+    """
+    depth = 0
+    newlines = 0
+    for i in range(start, len(content)):
+        ch = content[i]
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+            if depth < 0:
+                return i
+        elif ch == "\n":
+            newlines += 1
+            if depth == 0 or newlines >= _MAX_SPAN_LINES:
+                return i
+    return len(content)
+
+
+def scan_content(rel_path: str, content: str) -> list[str]:
+    """Flag each HashableDict token that falls inside a credential-marker span.
 
     Pure: takes text, returns violation strings. Each violation contains the
     substrings ``HashableDict`` and ``credential`` plus a ``{rel_path}:{lineno}:``
-    locator, where lineno is the 1-based line of the HashableDict token.
+    locator, where lineno is the 1-based line of the HashableDict token. Lines are
+    deduped, so a token inside multiple overlapping spans yields a single error.
     """
-    lines = content.splitlines()
-    errors: list[str] = []
-    for index, line in enumerate(lines):
-        if not HASHABLE_DICT_RE.search(line):
-            continue
-        lo = max(0, index - window)
-        hi = min(len(lines), index + window + 1)
-        if any(CREDENTIAL_MARKER_RE.search(lines[near]) for near in range(lo, hi)):
-            lineno = index + 1
-            errors.append(f"{rel_path}:{lineno}: HashableDict used in credential / data-access construction")
-    return errors
+    spans = [(m.end(), _marker_span_end(content, m.end())) for m in CREDENTIAL_MARKER_RE.finditer(content)]
+    flagged_lines: set[int] = set()
+    for match in HASHABLE_DICT_RE.finditer(content):
+        offset = match.start()
+        if any(start <= offset < end for start, end in spans):
+            flagged_lines.add(content.count("\n", 0, offset) + 1)
+    return [
+        f"{rel_path}:{lineno}: HashableDict used in credential / data-access construction"
+        for lineno in sorted(flagged_lines)
+    ]
 
 
 def _is_excluded_dir(part: str) -> bool:
@@ -59,20 +108,20 @@ def _is_excluded_dir(part: str) -> bool:
 def find_credential_hashable_dict(root: Path) -> list[str]:
     """Walk root for .py/.md files and return sorted credential-context HashableDict violations."""
     errors: list[str] = []
-    for path in root.rglob("*"):
-        if path.suffix not in SCAN_SUFFIXES or not path.is_file():
-            continue
-        rel = path.relative_to(root)
-        if any(_is_excluded_dir(part) for part in rel.parts[:-1]):
-            continue
-        rel_posix = rel.as_posix()
-        if rel_posix in SELF_FILES:
-            continue
-        try:
-            content = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
-        errors.extend(scan_content(rel_posix, content))
+    for dirpath, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if not _is_excluded_dir(d)]
+        for name in files:
+            path = Path(dirpath) / name
+            if path.suffix not in SCAN_SUFFIXES:
+                continue
+            rel_posix = path.relative_to(root).as_posix()
+            if rel_posix in SELF_FILES:
+                continue
+            try:
+                content = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            errors.extend(scan_content(rel_posix, content))
     return sorted(errors)
 
 

--- a/scripts/lint_credentials.py
+++ b/scripts/lint_credentials.py
@@ -1,0 +1,92 @@
+"""Lint for HashableDict reappearing near credential / BaseInputData data-access construction.
+
+Regression guard for GitHub issue #270: mloda 0.9.0 rejects HashableDict in
+credential / BaseInputData data-access construction. This flags any HashableDict
+token that appears on or within a few lines of a credential marker, while leaving
+legitimate HashableDict usage (Options group values, ApiInputDataCollection,
+provider export/import) untouched.
+
+Run: python scripts/lint_credentials.py
+Exit code: 1 if any issues found, 0 otherwise.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+SCAN_ROOT: Path = REPO_ROOT
+
+SCAN_SUFFIXES: tuple[str, ...] = (".py", ".md")
+
+EXCLUDE_DIRS: frozenset[str] = frozenset(
+    {".git", ".tox", ".venv", "venv", "__pycache__", "node_modules", "build", "dist"}
+)
+
+SELF_FILES: frozenset[str] = frozenset({"scripts/lint_credentials.py", "tests/test_end2end/test_lint_credentials.py"})
+
+HASHABLE_DICT_RE = re.compile(r"\bHashableDict\b")
+
+CREDENTIAL_MARKER_RE = re.compile(
+    r"\bcredentials\b|\badd_credentials\b|\bDataAccessCollection\b|[\"']BaseInputData[\"']"
+)
+
+
+def scan_content(rel_path: str, content: str, window: int = 2) -> list[str]:
+    """Flag each HashableDict line that has a credential marker within +/- window lines.
+
+    Pure: takes text, returns violation strings. Each violation contains the
+    substrings ``HashableDict`` and ``credential`` plus a ``{rel_path}:{lineno}:``
+    locator, where lineno is the 1-based line of the HashableDict token.
+    """
+    lines = content.splitlines()
+    errors: list[str] = []
+    for index, line in enumerate(lines):
+        if not HASHABLE_DICT_RE.search(line):
+            continue
+        lo = max(0, index - window)
+        hi = min(len(lines), index + window + 1)
+        if any(CREDENTIAL_MARKER_RE.search(lines[near]) for near in range(lo, hi)):
+            lineno = index + 1
+            errors.append(f"{rel_path}:{lineno}: HashableDict used in credential / data-access construction")
+    return errors
+
+
+def _is_excluded_dir(part: str) -> bool:
+    return part in EXCLUDE_DIRS or part.endswith(".egg-info")
+
+
+def find_credential_hashable_dict(root: Path) -> list[str]:
+    """Walk root for .py/.md files and return sorted credential-context HashableDict violations."""
+    errors: list[str] = []
+    for path in root.rglob("*"):
+        if path.suffix not in SCAN_SUFFIXES or not path.is_file():
+            continue
+        rel = path.relative_to(root)
+        if any(_is_excluded_dir(part) for part in rel.parts[:-1]):
+            continue
+        rel_posix = rel.as_posix()
+        if rel_posix in SELF_FILES:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        errors.extend(scan_content(rel_posix, content))
+    return sorted(errors)
+
+
+def main() -> int:
+    errors = find_credential_hashable_dict(SCAN_ROOT)
+    if errors:
+        print(f"Found {len(errors)} credential-context HashableDict issue(s):\n")
+        for error in errors:
+            print(f"  {error}")
+        return 1
+
+    print("No credential-context HashableDict usage found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_end2end/test_lint_credentials.py
+++ b/tests/test_end2end/test_lint_credentials.py
@@ -1,0 +1,187 @@
+"""Tests for scripts/lint_credentials.py (regression guard for GitHub issue #270).
+
+The guard fails if ``HashableDict`` reappears near credential /
+``BaseInputData`` data-access construction (which mloda 0.9.0 rejects), while
+NOT flagging legitimate ``HashableDict`` usage (Options group values,
+ApiInputDataCollection, provider export/import).
+
+Like ``test_lint_docs.py``, the lint script is not a packaged module, so it's
+loaded via a sys.path insert. ``tests/**`` has ``E402`` ignored in ruff config
+so the post-path import does not trip the linter.
+
+Contract notes for the Green agent implementing scripts/lint_credentials.py:
+- Stable assertion phrase pinned below: every violation string must contain the
+  substring ``"HashableDict"`` AND the substring ``"credential"`` (lowercase),
+  plus the ``{rel_path}:{lineno}:`` locator.
+- ``main()`` must scan a module-level, rebindable root named ``SCAN_ROOT``
+  (defaulting to ``REPO_ROOT``); these tests monkeypatch
+  ``lint_credentials.SCAN_ROOT`` to point at a tmp tree.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import lint_credentials
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+# --------------------------------------------------------------------------
+# scan_content — positive cases (MUST be flagged), one per issue example form
+# --------------------------------------------------------------------------
+
+
+def test_scan_flags_credentials_list_form() -> None:
+    content = 'credentials=[HashableDict({"user": "x"})]\n'
+    errors = lint_credentials.scan_content("mod.py", content)
+    assert len(errors) == 1
+    assert "mod.py:1:" in errors[0]
+    assert "HashableDict" in errors[0]
+    assert "credential" in errors[0]
+
+
+def test_scan_flags_credentials_dict_value_form() -> None:
+    content = 'credentials={"db": HashableDict({"user": "x"})}\n'
+    errors = lint_credentials.scan_content("mod.py", content)
+    assert len(errors) == 1
+    assert "mod.py:1:" in errors[0]
+    assert "HashableDict" in errors[0]
+    assert "credential" in errors[0]
+
+
+def test_scan_flags_add_credentials_call_form() -> None:
+    content = 'add_credentials(HashableDict({"user": "x"}))\n'
+    errors = lint_credentials.scan_content("mod.py", content)
+    assert len(errors) == 1
+    assert "mod.py:1:" in errors[0]
+    assert "HashableDict" in errors[0]
+    assert "credential" in errors[0]
+
+
+def test_scan_flags_base_input_data_group_key_form() -> None:
+    content = 'Options(group={"BaseInputData": (Reader, HashableDict({"user": "x"}))})\n'
+    errors = lint_credentials.scan_content("mod.py", content)
+    assert len(errors) == 1
+    assert "mod.py:1:" in errors[0]
+    assert "HashableDict" in errors[0]
+    assert "credential" in errors[0]
+
+
+def test_scan_flags_marker_within_window_across_blank_line() -> None:
+    """Proves the ±window scan works: DataAccessCollection marker, a blank line,
+    then the HashableDict line (2 lines apart, within default window=2)."""
+    content = "DataAccessCollection(\n\n    credentials=[HashableDict({})]\n)\n"
+    errors = lint_credentials.scan_content("mod.py", content)
+    assert len(errors) == 1
+    # The HashableDict token is on line 3.
+    assert "mod.py:3:" in errors[0]
+    assert "HashableDict" in errors[0]
+    assert "credential" in errors[0]
+
+
+# --------------------------------------------------------------------------
+# scan_content — negative cases (MUST NOT be flagged)
+# --------------------------------------------------------------------------
+
+
+def test_scan_ignores_legit_options_group_value() -> None:
+    content = 'Options(group={"MyReader": HashableDict({"path": "/x"})})\n'
+    assert lint_credentials.scan_content("mod.py", content) == []
+
+
+def test_scan_ignores_hashable_dict_far_from_marker() -> None:
+    """HashableDict more than `window` lines from any credential marker is clean."""
+    lines = [
+        "credentials = load_credentials()",  # marker on line 1
+        "a = 1",
+        "b = 2",
+        "c = 3",
+        "d = 4",
+        'value = HashableDict({"path": "/x"})',  # line 6, > window from marker
+    ]
+    content = "\n".join(lines) + "\n"
+    assert lint_credentials.scan_content("mod.py", content) == []
+
+
+def test_scan_ignores_typed_credential_without_hashable_dict() -> None:
+    content = 'credentials=[Credential(user="x")]\n'
+    assert lint_credentials.scan_content("mod.py", content) == []
+
+
+def test_scan_ignores_plain_dict_credential_without_hashable_dict() -> None:
+    content = 'credentials={"db": {"user": "x"}}\n'
+    assert lint_credentials.scan_content("mod.py", content) == []
+
+
+# --------------------------------------------------------------------------
+# find_credential_hashable_dict — tree-level
+# --------------------------------------------------------------------------
+
+
+def test_real_repo_tree_is_clean() -> None:
+    """The actual audit: the repo currently has zero credential-context usages."""
+    assert lint_credentials.find_credential_hashable_dict(lint_credentials.REPO_ROOT) == []
+
+
+def test_find_excludes_junk_dirs(tmp_path: Path) -> None:
+    _write(tmp_path / ".venv" / "mod.py", "credentials=[HashableDict({})]\n")
+    _write(tmp_path / "build" / "mod.py", "credentials=[HashableDict({})]\n")
+    _write(tmp_path / "pkg.egg-info" / "mod.py", "credentials=[HashableDict({})]\n")
+    assert lint_credentials.find_credential_hashable_dict(tmp_path) == []
+
+
+def test_find_flags_planted_violation(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "mod.py", 'credentials=[HashableDict({"user": "x"})]\n')
+    errors = lint_credentials.find_credential_hashable_dict(tmp_path)
+    assert len(errors) == 1
+    assert "src/mod.py:1:" in errors[0]
+
+
+def test_guard_excludes_own_files(tmp_path: Path) -> None:
+    """A planted violation inside the guard's own two files must NOT be returned,
+    since those files legitimately carry the literal token as fixtures."""
+    _write(tmp_path / "scripts" / "lint_credentials.py", "credentials=[HashableDict({})]\n")
+    _write(
+        tmp_path / "tests" / "test_end2end" / "test_lint_credentials.py",
+        "credentials=[HashableDict({})]\n",
+    )
+    assert lint_credentials.find_credential_hashable_dict(tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# main() — return-code contract (monkeypatch module-level SCAN_ROOT)
+# --------------------------------------------------------------------------
+
+
+def test_main_clean_tree_returns_zero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write(tmp_path / "src" / "mod.py", 'credentials=[Credential(user="x")]\n')
+    monkeypatch.setattr(lint_credentials, "SCAN_ROOT", tmp_path)
+    rc = lint_credentials.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out != ""
+
+
+def test_main_flags_planted_violation_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write(tmp_path / "src" / "mod.py", 'credentials=[HashableDict({"user": "x"})]\n')
+    monkeypatch.setattr(lint_credentials, "SCAN_ROOT", tmp_path)
+    rc = lint_credentials.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "src/mod.py" in out

--- a/tests/test_end2end/test_lint_credentials.py
+++ b/tests/test_end2end/test_lint_credentials.py
@@ -13,6 +13,12 @@ Contract notes for the Green agent implementing scripts/lint_credentials.py:
 - Stable assertion phrase pinned below: every violation string must contain the
   substring ``"HashableDict"`` AND the substring ``"credential"`` (lowercase),
   plus the ``{rel_path}:{lineno}:`` locator.
+- Detection is marker-anchored and bracket-span based (there is NO ``window``
+  parameter): from each construction-shaped credential marker
+  (``credentials=``, ``add_credentials(``, or a quoted ``BaseInputData`` group
+  key), walk forward tracking bracket depth and flag any ``HashableDict`` token
+  that falls inside that enclosing construct, reported at the token's 1-based
+  line (deduped, one error per HashableDict line).
 - ``main()`` must scan a module-level, rebindable root named ``SCAN_ROOT``
   (defaulting to ``REPO_ROOT``); these tests monkeypatch
   ``lint_credentials.SCAN_ROOT`` to point at a tmp tree.
@@ -75,14 +81,28 @@ def test_scan_flags_base_input_data_group_key_form() -> None:
     assert "credential" in errors[0]
 
 
-def test_scan_flags_marker_within_window_across_blank_line() -> None:
-    """Proves the ±window scan works: DataAccessCollection marker, a blank line,
-    then the HashableDict line (2 lines apart, within default window=2)."""
-    content = "DataAccessCollection(\n\n    credentials=[HashableDict({})]\n)\n"
+def test_scan_flags_hashable_dict_on_later_line_of_same_construct() -> None:
+    """Cross-line: marker and HashableDict on DIFFERENT lines, both inside the
+    same bracket construct. Pins forward bracket-span detection (a per-line-only
+    impl would miss it)."""
+    content = "    credentials=[\n        HashableDict({}),\n    ]\n"
     errors = lint_credentials.scan_content("mod.py", content)
     assert len(errors) == 1
-    # The HashableDict token is on line 3.
-    assert "mod.py:3:" in errors[0]
+    # The HashableDict token is on line 2, inside the credentials=[...] span.
+    assert "mod.py:2:" in errors[0]
+    assert "HashableDict" in errors[0]
+    assert "credential" in errors[0]
+
+
+def test_scan_flags_wrapped_credential_construction() -> None:
+    """Deeply wrapped: the HashableDict token sits several lines below the marker,
+    still inside the enclosing brackets. Proves wrapping beyond 2 lines no longer
+    slips through a fixed proximity window."""
+    content = "credentials=[\n    some_factory(\n        extra_arg,\n        HashableDict({}),\n    ),\n]\n"
+    errors = lint_credentials.scan_content("mod.py", content)
+    assert len(errors) == 1
+    # The HashableDict token is on line 4.
+    assert "mod.py:4:" in errors[0]
     assert "HashableDict" in errors[0]
     assert "credential" in errors[0]
 
@@ -97,15 +117,27 @@ def test_scan_ignores_legit_options_group_value() -> None:
     assert lint_credentials.scan_content("mod.py", content) == []
 
 
+def test_scan_ignores_hashable_dict_near_unrelated_marker_mention() -> None:
+    """Bare prose ``credentials`` and a bare ``DataAccessCollection`` mention are
+    NOT markers; a legit Options-group HashableDict nearby must NOT be flagged."""
+    content = (
+        "You can also pass credentials to the reader.\n"
+        "from mloda.user import DataAccessCollection\n"
+        'opts = Options(group={"MyReader": HashableDict({"path": "/x"})})\n'
+    )
+    assert lint_credentials.scan_content("mod.py", content) == []
+
+
 def test_scan_ignores_hashable_dict_far_from_marker() -> None:
-    """HashableDict more than `window` lines from any credential marker is clean."""
+    """HashableDict outside the ``credentials = load_credentials()`` statement's
+    span (the marker's construct already ended) is clean."""
     lines = [
-        "credentials = load_credentials()",  # marker on line 1
+        "credentials = load_credentials()",  # marker's statement ends on line 1
         "a = 1",
         "b = 2",
         "c = 3",
         "d = 4",
-        'value = HashableDict({"path": "/x"})',  # line 6, > window from marker
+        'value = HashableDict({"path": "/x"})',  # line 6, outside the marker span
     ]
     content = "\n".join(lines) + "\n"
     assert lint_credentials.scan_content("mod.py", content) == []
@@ -171,7 +203,7 @@ def test_main_clean_tree_returns_zero(
     rc = lint_credentials.main()
     out = capsys.readouterr().out
     assert rc == 0
-    assert out != ""
+    assert "No credential-context" in out
 
 
 def test_main_flags_planted_violation_returns_one(

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,12 @@ skip_install = true
 commands =
     python scripts/lint_docs.py
 
+[testenv:lint-credentials]
+description = Check for HashableDict near credential / BaseInputData data-access construction
+skip_install = true
+commands =
+    python scripts/lint_credentials.py
+
 [testenv:verify-builds]
 description = Verify all packages build with correct versions
 usedevelop = true


### PR DESCRIPTION
## Summary

Closes the remaining Definition of Done for #270. mloda 0.9.0 (mloda-ai/mloda#524) dropped `HashableDict` acceptance from the credentials / `BaseInputData` data-access path. The audit already found zero registry usages, so this adds the regression guard the issue asks for and confirms the guides are clean.

## What this does

- **`scripts/lint_credentials.py`**: a lint that fails if `HashableDict` reappears inside credential / `BaseInputData` data-access construction, while leaving legitimate `HashableDict` usage (Options group values, `ApiInputDataCollection`, provider export) untouched. Detection is marker-anchored and bracket-span based: from each construction-shaped marker (`credentials=`, `add_credentials(`, or a quoted `"BaseInputData"` group key) it walks the enclosing bracket construct and flags only `HashableDict` tokens inside it.
- **`tests/test_end2end/test_lint_credentials.py`**: pins the four issue example forms as flagged, cross-line and deeply-wrapped constructs as flagged, and legitimate `HashableDict` / typed-`Credential` / plain-dict / unrelated-mention cases as not flagged, plus `test_real_repo_tree_is_clean` (the live audit assertion).
- Wired into **`tox.ini`** (`[testenv:lint-credentials]`) and **CI** (`lint-credentials` job), mirroring the existing `lint-docs` guard.

## DoD status

- Guides `14-feature-matching.md` and `17-data-connection-matching.md` verified to show only `Credential(...)` / plain-dict usage (neither mentions `HashableDict`).
- Regression guard added (script + tox env + CI job + tests).
- Audit assertion encoded as `test_real_repo_tree_is_clean`.

## Review

Passed two independent deep reviews (Claude Opus + codex). Both flagged the initial line-window heuristic as too narrow and too broad; the follow-up commit replaces it with the bracket-span detection above and documents the accepted heuristic limitations (aliased imports, no dataflow, quoted-`BaseInputData`-only).

## Testing

Full `tox` gate green: 4125 passed, 141 skipped; `ruff format --check`, `ruff check`, `mypy --strict`, and `bandit` all pass. `tox -e lint-credentials` passes on the clean tree.
