### PR TITLE
refactor(duckdb): drop redundant SET TimeZone='UTC' pins, consolidate floor helper

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_changing/resample/duckdb_resample.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/duckdb_resample.py
@@ -20,7 +20,7 @@ from mloda.community.feature_groups.data_operations.row_changing.resample.base i
     ResampleFeatureGroup,
 )
 from mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.duckdb_time_bucketization import (
-    _floor_expr,
+    floor_expr,
 )
 
 # Resample agg -> DuckDB aggregate function. SUM/AVG/MIN/MAX ignore nulls and
@@ -81,21 +81,17 @@ class DuckdbResample(ResampleFeatureGroup):
         quoted_source = quote_ident(source_col)
         quoted_time = quote_ident(time_column)
         quoted_feature = quote_ident(feature_name)
-        # Pin the session timezone to UTC so the DATE_TRUNC / time_bucket floor
-        # stays UTC-anchored regardless of the host/session zone, matching
-        # time_bucketization (issue #238, re-applied for resample in #265).
-        data.connection.execute("SET TimeZone='UTC'")
-        floor_expr = _floor_expr(quoted_time, n, unit)
+        floor_sql = floor_expr(quoted_time, n, unit)
 
         # Group keys: partition columns first, then the floored bucket. The
         # bucket is always a key, so the group list is never empty (whole-table
         # case has an empty partition list).
         partition_quoted = [quote_ident(col) for col in partition_by]
-        group_exprs = [*partition_quoted, floor_expr]
+        group_exprs = [*partition_quoted, floor_sql]
 
         select_parts = [
             *partition_quoted,
-            f"{floor_expr} AS {quoted_time}",
+            f"{floor_sql} AS {quoted_time}",
             f"{agg_func}({quoted_source}) AS {quoted_feature}",
         ]
 

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_duckdb.py
@@ -31,37 +31,17 @@ class TestDuckdbResample(DuckdbTestMixin, ResampleTestBase):
 
 
 class TestDuckdbResampleNonUtcSession:
-    """Resample stays UTC-anchored regardless of session TZ, via the core chokepoint.
+    """Resample stays UTC-anchored on a non-UTC session, via the core chokepoint.
 
-    ``DuckdbResample._compute_resample`` floors timestamps with ``floor_expr``
-    (which emits ``DATE_TRUNC`` for n=1) imported from ``time_bucketization``.
-    ``DATE_TRUNC`` operates in the connection's session timezone, so on a non-UTC
-    session a UTC instant would floor to local midnight instead of UTC midnight,
-    yielding a misaligned, non-UTC bucket-start label. The feature group does not
-    pin the session timezone itself; it defers to the core framework chokepoint
-    (``DuckDBFramework.set_framework_connection_object``, mloda 0.9.0) for the UTC
-    session guarantee, which pins the session to UTC on first connection assignment.
-
-    With a 1-day bucket over the whole 12-row fixture (all timestamps on
-    2023-01-01 between 08:00 and 10:30 UTC), every row belongs to the single UTC
-    day bucket ``2023-01-01 00:00:00 UTC``. On an ``America/New_York`` (UTC-5)
-    session WITHOUT the core guarantee, ``DATE_TRUNC`` would floor e.g.
-    2023-01-01 08:05 UTC (= 03:05 local) to 2023-01-01 00:00 local
-    (= 2023-01-01 05:00 UTC), a wrong non-UTC-midnight label.
-
-    The test builds its own connection (rather than the mixin's) so it can preset
-    a non-UTC session timezone, then routes that connection through the core
-    chokepoint (as production does) to reproduce the real guarantee, independent of
-    the host OS timezone.
+    Presets a non-UTC session, then relies on the core UTC guarantee (not a
+    per-FG pin) to anchor the bucket labels.
     """
 
     def test_resample_1_day_utc_anchored_on_non_utc_session(self) -> None:
         from mloda.testing.feature_groups.data_operations.mixins.duckdb import pin_connection_utc_via_core
 
         con = duckdb.connect()
-        # Preset a NON-UTC session timezone; without the core guarantee this would misfloor.
         con.execute("SET TimeZone='America/New_York'")
-        # Route through the real core chokepoint, exactly as production does.
         pin_connection_utc_via_core(con)
 
         rel = DuckdbRelation.from_arrow(con, _create_resample_arrow_table())
@@ -85,12 +65,7 @@ class TestDuckdbResampleNonUtcSession:
         assert value_col[0] == pytest.approx(230.0 / 9.0)
 
     def test_resample_15_minute_utc_anchored_on_non_utc_session(self) -> None:
-        # n>1 sub-hour bucket exercises the time_bucket floor branch. On a non-UTC
-        # session the floored bucket *label* is tagged with the session zone rather
-        # than UTC, so the bucket-start labels diverge from the PyArrow oracle even
-        # though the underlying instants line up. Keying the comparison by the ISO
-        # string (which carries the offset) makes that label drift observable, so
-        # the result must still match the UTC-anchored oracle (issue #265 / #238).
+        # n>1 sub-hour bucket exercises the time_bucket floor branch.
         from mloda.community.feature_groups.data_operations.row_changing.resample.pyarrow_resample import (
             PyArrowResample,
         )
@@ -99,7 +74,6 @@ class TestDuckdbResampleNonUtcSession:
 
         con = duckdb.connect()
         con.execute("SET TimeZone='Asia/Kolkata'")  # UTC+5:30, non-UTC session
-        # Route through the real core chokepoint, exactly as production does.
         pin_connection_utc_via_core(con)
 
         arrow_table = _create_resample_arrow_table()

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_duckdb.py
@@ -31,32 +31,38 @@ class TestDuckdbResample(DuckdbTestMixin, ResampleTestBase):
 
 
 class TestDuckdbResampleNonUtcSession:
-    """Resample must produce UTC-anchored bucket labels regardless of session TZ (issue #265).
+    """Resample stays UTC-anchored regardless of session TZ, via the core chokepoint.
 
-    This is issue #238 -- already fixed for ``time_bucketization`` -- re-appearing
-    in ``resample`` (issue #265). ``DuckdbResample._compute_resample`` floors
-    timestamps with ``_floor_expr`` (which emits ``DATE_TRUNC`` for n=1) imported
-    from ``time_bucketization``, but it never pins the DuckDB session timezone to
-    UTC. ``DATE_TRUNC`` operates in the connection's session timezone, so on a
-    non-UTC session a UTC instant gets floored to *local* midnight instead of UTC
-    midnight, yielding a misaligned, non-UTC bucket-start label.
+    ``DuckdbResample._compute_resample`` floors timestamps with ``floor_expr``
+    (which emits ``DATE_TRUNC`` for n=1) imported from ``time_bucketization``.
+    ``DATE_TRUNC`` operates in the connection's session timezone, so on a non-UTC
+    session a UTC instant would floor to local midnight instead of UTC midnight,
+    yielding a misaligned, non-UTC bucket-start label. The feature group does not
+    pin the session timezone itself; it defers to the core framework chokepoint
+    (``DuckDBFramework.set_framework_connection_object``, mloda 0.9.0) for the UTC
+    session guarantee, which pins the session to UTC on first connection assignment.
 
     With a 1-day bucket over the whole 12-row fixture (all timestamps on
     2023-01-01 between 08:00 and 10:30 UTC), every row belongs to the single UTC
     day bucket ``2023-01-01 00:00:00 UTC``. On an ``America/New_York`` (UTC-5)
-    session WITHOUT the fix, ``DATE_TRUNC`` floors e.g. 2023-01-01 08:05 UTC
-    (= 03:05 local) to 2023-01-01 00:00 local = 2023-01-01 05:00 UTC -- a WRONG,
-    non-UTC-midnight label -- so this test fails today.
+    session WITHOUT the core guarantee, ``DATE_TRUNC`` would floor e.g.
+    2023-01-01 08:05 UTC (= 03:05 local) to 2023-01-01 00:00 local
+    (= 2023-01-01 05:00 UTC), a wrong non-UTC-midnight label.
 
-    The test builds its own connection (rather than the mixin's) so it can
-    deterministically reproduce the bug by presetting a non-UTC session timezone,
-    independent of the host OS timezone.
+    The test builds its own connection (rather than the mixin's) so it can preset
+    a non-UTC session timezone, then routes that connection through the core
+    chokepoint (as production does) to reproduce the real guarantee, independent of
+    the host OS timezone.
     """
 
     def test_resample_1_day_utc_anchored_on_non_utc_session(self) -> None:
+        from mloda.testing.feature_groups.data_operations.mixins.duckdb import pin_connection_utc_via_core
+
         con = duckdb.connect()
-        # Preset a NON-UTC session timezone; this is what triggers the bug.
+        # Preset a NON-UTC session timezone; without the core guarantee this would misfloor.
         con.execute("SET TimeZone='America/New_York'")
+        # Route through the real core chokepoint, exactly as production does.
+        pin_connection_utc_via_core(con)
 
         rel = DuckdbRelation.from_arrow(con, _create_resample_arrow_table())
         feature_name = "value__resample_1_day_mean"
@@ -89,9 +95,12 @@ class TestDuckdbResampleNonUtcSession:
             PyArrowResample,
         )
         from mloda.testing.feature_groups.data_operations.helpers import extract_column
+        from mloda.testing.feature_groups.data_operations.mixins.duckdb import pin_connection_utc_via_core
 
         con = duckdb.connect()
         con.execute("SET TimeZone='Asia/Kolkata'")  # UTC+5:30, non-UTC session
+        # Route through the real core chokepoint, exactly as production does.
+        pin_connection_utc_via_core(con)
 
         arrow_table = _create_resample_arrow_table()
         rel = DuckdbRelation.from_arrow(con, arrow_table)

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
@@ -64,8 +64,16 @@ def _interval_literal(n: int, unit: str) -> str:
     raise ValueError(f"Unsupported time bucketization unit for DuckDB: {unit!r}")
 
 
-def _floor_expr(quoted_source: str, n: int, unit: str) -> str:
-    """SQL expression that floors ``quoted_source`` to the ``(n, unit)`` bucket."""
+def floor_expr(quoted_source: str, n: int, unit: str) -> str:
+    """SQL that floors a DuckDB timestamp to the ``(n, unit)`` bucket.
+
+    PRECONDITION: correct, UTC-anchored results REQUIRE the connection's
+    session timezone to be UTC. mloda's ``DuckDBFramework`` guarantees this at
+    its framework chokepoint (``set_framework_connection_object``, mloda
+    >= 0.9.0), so callers must NOT add their own ``SET TimeZone`` pin. This is
+    the single shared entry point that both the time_bucketization and resample
+    DuckDB backends use to floor timestamps.
+    """
     if n == 1:
         return f"DATE_TRUNC('{_DUCKDB_TRUNC_UNIT[unit]}', {quoted_source})"
     # ``n > 1`` is only valid for fixed-freq units (minute/hour/day).
@@ -124,18 +132,14 @@ class DuckdbTimeBucketization(TimeBucketizationFeatureGroup):
         if op not in TIME_BUCKETIZATION_OPS:
             raise ValueError(f"Unsupported bucket op {op!r} for DuckDB; supported: {sorted(TIME_BUCKETIZATION_OPS)}.")
 
-        # Pin the session timezone to UTC so DATE_TRUNC/time_bucket stay
-        # UTC-anchored regardless of the host/session zone (issue #238).
-        data.connection.execute("SET TimeZone='UTC'")
-
         quoted_source = quote_ident(source_col)
         quoted_feature = quote_ident(feature_name)
-        floor_expr = _floor_expr(quoted_source, n, unit)
+        floor_sql = floor_expr(quoted_source, n, unit)
         interval = _interval_literal(n, unit)
-        ceil_next = f"({floor_expr} + {interval})"
+        ceil_next = f"({floor_sql} + {interval})"
 
         if op == "floor":
-            result_expr = floor_expr
+            result_expr = floor_sql
         elif op == "ceil":
             if unit in _CALENDAR_CEIL_ALWAYS_ADVANCES:
                 # Calendar units always advance.
@@ -144,12 +148,12 @@ class DuckdbTimeBucketization(TimeBucketizationFeatureGroup):
                 result_expr = (
                     f"CASE "
                     f"WHEN {quoted_source} IS NULL THEN NULL "
-                    f"WHEN {quoted_source} = {floor_expr} THEN {floor_expr} "
+                    f"WHEN {quoted_source} = {floor_sql} THEN {floor_sql} "
                     f"ELSE {ceil_next} "
                     f"END"
                 )
         else:  # round
-            result_expr = cls._round_expression(quoted_source, n, unit, floor_expr, ceil_next)
+            result_expr = cls._round_expression(quoted_source, n, unit, floor_sql, ceil_next)
 
         raw_sql = f"*, {result_expr} AS {quoted_feature}"
         result: DuckdbRelation = data.project(raw_sql)
@@ -161,7 +165,7 @@ class DuckdbTimeBucketization(TimeBucketizationFeatureGroup):
         quoted_source: str,
         n: int,
         unit: str,
-        floor_expr: str,
+        floor_sql: str,
         ceil_next: str,
     ) -> str:
         """SQL expression for round-half-up bucketization.
@@ -170,17 +174,17 @@ class DuckdbTimeBucketization(TimeBucketizationFeatureGroup):
         units, and ``EPOCH(col - floored) * 2 >= EPOCH(ceil_next - floored)``
         for calendar units (whose bucket lengths vary per row).
         """
-        offset_seconds = f"EPOCH({quoted_source} - {floor_expr})"
+        offset_seconds = f"EPOCH({quoted_source} - {floor_sql})"
         if unit in {"minute", "hour", "day"}:
             half = _bucket_seconds_for_fixed_freq(n, unit) / 2.0
             return (
                 f"CASE "
                 f"WHEN {quoted_source} IS NULL THEN NULL "
                 f"WHEN {offset_seconds} >= {half} THEN {ceil_next} "
-                f"ELSE {floor_expr} "
+                f"ELSE {floor_sql} "
                 f"END"
             )
-        bucket_seconds = f"EPOCH({ceil_next} - {floor_expr})"
+        bucket_seconds = f"EPOCH({ceil_next} - {floor_sql})"
         return (
             f"CASE "
             f"WHEN {quoted_source} IS NULL THEN NULL "

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
@@ -189,6 +189,6 @@ class DuckdbTimeBucketization(TimeBucketizationFeatureGroup):
             f"CASE "
             f"WHEN {quoted_source} IS NULL THEN NULL "
             f"WHEN {offset_seconds} * 2 >= {bucket_seconds} THEN {ceil_next} "
-            f"ELSE {floor_expr} "
+            f"ELSE {floor_sql} "
             f"END"
         )

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
@@ -65,14 +65,10 @@ def _interval_literal(n: int, unit: str) -> str:
 
 
 def floor_expr(quoted_source: str, n: int, unit: str) -> str:
-    """SQL that floors a DuckDB timestamp to the ``(n, unit)`` bucket.
+    """SQL flooring a DuckDB timestamp to the ``(n, unit)`` bucket.
 
-    PRECONDITION: correct, UTC-anchored results REQUIRE the connection's
-    session timezone to be UTC. mloda's ``DuckDBFramework`` guarantees this at
-    its framework chokepoint (``set_framework_connection_object``, mloda
-    >= 0.9.0), so callers must NOT add their own ``SET TimeZone`` pin. This is
-    the single shared entry point that both the time_bucketization and resample
-    DuckDB backends use to floor timestamps.
+    Shared entry point for both DuckDB backends. Requires a UTC session tz,
+    guaranteed by ``DuckDBFramework`` (mloda >= 0.9.0); do not add a local pin.
     """
     if n == 1:
         return f"DATE_TRUNC('{_DUCKDB_TRUNC_UNIT[unit]}', {quoted_source})"

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py
@@ -54,25 +54,9 @@ class TestDuckdbDateSourceRejected:
 
 
 class TestDuckdbTimeBucketizationCalendarRound:
-    """Guards calendar-unit ROUND (week / month / year) on the DuckDB backend.
+    """Calendar-unit ROUND (week / month / year), which the shared base does not cover.
 
-    The shared ``TimeBucketizationTestBase`` only exercises ROUND at fixed-freq
-    units (minute / hour / day), which take the ``{"minute", "hour", "day"}``
-    branch of ``DuckdbTimeBucketization._round_expression``. The calendar-unit
-    branch (week / month / year, whose bucket length varies per row) is never
-    driven by the base suite, so a regression there goes unnoticed.
-
-    Concretely, the calendar branch must reference the local floored-SQL string
-    when it falls back to the floor value. A rename of the module-level ``floor``
-    helper left the branch interpolating the FUNCTION object instead of the SQL
-    string, so a request like ``timestamp__round_1_month`` emits SQL containing
-    ``<function floor_expr at 0x...>`` and DuckDB raises a ParserException. This
-    class is the standing regression guard for that calendar-round branch.
-
-    Each unit is compared against the PyArrow oracle
-    (``PyArrowTimeBucketization``) on the same arrow fixture, mirroring how the
-    resample suite compares DuckDB against ``PyArrowResample`` rather than
-    hand-computing expected literals.
+    Guards the calendar branch of ``_round_expression`` against the PyArrow oracle.
     """
 
     @pytest.mark.parametrize(
@@ -96,7 +80,6 @@ class TestDuckdbTimeBucketizationCalendarRound:
         arrow_table = _create_bucket_arrow_table()
 
         con = duckdb.connect()
-        # Route through the real core chokepoint (UTC guarantee), exactly as production does.
         pin_connection_utc_via_core(con)
         rel = DuckdbRelation.from_arrow(con, arrow_table)
 
@@ -119,21 +102,10 @@ class TestDuckdbTimeBucketizationCalendarRound:
 
 
 class TestDuckdbTimeBucketizationNonUtcSession:
-    """Bucketization stays UTC-anchored regardless of session TZ, via the core chokepoint.
+    """Flooring stays UTC-anchored on a non-UTC session, via the core chokepoint.
 
-    DuckDB's ``DATE_TRUNC`` / ``time_bucket`` operate in the connection's
-    session timezone. On a non-UTC session, a UTC input such as
-    ``2023-01-01 00:00 UTC`` would floor to local midnight (a different instant)
-    instead of UTC midnight. The feature group no longer pins the session
-    timezone itself; UTC anchoring now comes from the core framework chokepoint
-    (``DuckDBFramework.set_framework_connection_object``, mloda 0.9.0), which
-    pins the session to UTC on first connection assignment.
-
-    This test builds its own connection (rather than the mixin's) so it can
-    preset a non-UTC session timezone, then routes that connection through the
-    core chokepoint (as production does) to reproduce the real guarantee. It is
-    the standing regression guard that UTC anchoring holds via the core guarantee,
-    independent of the host OS timezone.
+    Presets a non-UTC session, then relies on the core UTC guarantee (not a
+    per-FG pin) to anchor the result.
     """
 
     def test_floor_1_day_utc_anchored_on_non_utc_session(self) -> None:
@@ -144,9 +116,7 @@ class TestDuckdbTimeBucketizationNonUtcSession:
         from mloda.testing.feature_groups.data_operations.mixins.duckdb import pin_connection_utc_via_core
 
         con = duckdb.connect()
-        # Preset a NON-UTC session timezone; without the core guarantee this would misfloor.
         con.execute("SET TimeZone='America/New_York'")
-        # Route through the real core chokepoint, exactly as production does.
         pin_connection_utc_via_core(con)
 
         rel = DuckdbRelation.from_arrow(con, _create_bucket_arrow_table())

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py
@@ -54,17 +54,20 @@ class TestDuckdbDateSourceRejected:
 
 
 class TestDuckdbTimeBucketizationNonUtcSession:
-    """Bucketization must produce UTC-anchored instants regardless of session TZ (issue #238).
+    """Bucketization stays UTC-anchored regardless of session TZ, via the core chokepoint.
 
     DuckDB's ``DATE_TRUNC`` / ``time_bucket`` operate in the connection's
     session timezone. On a non-UTC session, a UTC input such as
-    ``2023-01-01 00:00 UTC`` floors to *local* midnight (a different instant)
-    instead of UTC midnight. The feature group must pin the session timezone
-    to UTC inside ``_compute_bucket`` so the result is correct no matter what
-    the session timezone was preset to.
+    ``2023-01-01 00:00 UTC`` would floor to local midnight (a different instant)
+    instead of UTC midnight. The feature group no longer pins the session
+    timezone itself; UTC anchoring now comes from the core framework chokepoint
+    (``DuckDBFramework.set_framework_connection_object``, mloda 0.9.0), which
+    pins the session to UTC on first connection assignment.
 
     This test builds its own connection (rather than the mixin's) so it can
-    deterministically reproduce the bug by setting a non-UTC session timezone,
+    preset a non-UTC session timezone, then routes that connection through the
+    core chokepoint (as production does) to reproduce the real guarantee. It is
+    the standing regression guard that UTC anchoring holds via the core guarantee,
     independent of the host OS timezone.
     """
 
@@ -73,10 +76,13 @@ class TestDuckdbTimeBucketizationNonUtcSession:
         from datetime import datetime
         from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
         from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+        from mloda.testing.feature_groups.data_operations.mixins.duckdb import pin_connection_utc_via_core
 
         con = duckdb.connect()
-        # Preset a NON-UTC session timezone; this is what triggers the bug.
+        # Preset a NON-UTC session timezone; without the core guarantee this would misfloor.
         con.execute("SET TimeZone='America/New_York'")
+        # Route through the real core chokepoint, exactly as production does.
+        pin_connection_utc_via_core(con)
 
         rel = DuckdbRelation.from_arrow(con, _create_bucket_arrow_table())
         fs = make_feature_set("timestamp__floor_1_day")

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_duckdb.py
@@ -53,6 +53,71 @@ class TestDuckdbDateSourceRejected:
             DuckdbTimeBucketization.calculate_feature(rel, fs)
 
 
+class TestDuckdbTimeBucketizationCalendarRound:
+    """Guards calendar-unit ROUND (week / month / year) on the DuckDB backend.
+
+    The shared ``TimeBucketizationTestBase`` only exercises ROUND at fixed-freq
+    units (minute / hour / day), which take the ``{"minute", "hour", "day"}``
+    branch of ``DuckdbTimeBucketization._round_expression``. The calendar-unit
+    branch (week / month / year, whose bucket length varies per row) is never
+    driven by the base suite, so a regression there goes unnoticed.
+
+    Concretely, the calendar branch must reference the local floored-SQL string
+    when it falls back to the floor value. A rename of the module-level ``floor``
+    helper left the branch interpolating the FUNCTION object instead of the SQL
+    string, so a request like ``timestamp__round_1_month`` emits SQL containing
+    ``<function floor_expr at 0x...>`` and DuckDB raises a ParserException. This
+    class is the standing regression guard for that calendar-round branch.
+
+    Each unit is compared against the PyArrow oracle
+    (``PyArrowTimeBucketization``) on the same arrow fixture, mirroring how the
+    resample suite compares DuckDB against ``PyArrowResample`` rather than
+    hand-computing expected literals.
+    """
+
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            "timestamp__round_1_week",
+            "timestamp__round_1_month",
+            "timestamp__round_1_year",
+        ],
+    )
+    def test_calendar_round_matches_pyarrow_oracle(self, feature_name: str) -> None:
+        import duckdb
+        from datetime import datetime
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
+        from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
+        from mloda.testing.feature_groups.data_operations.mixins.duckdb import pin_connection_utc_via_core
+        from mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.pyarrow_time_bucketization import (  # noqa: E501
+            PyArrowTimeBucketization,
+        )
+
+        arrow_table = _create_bucket_arrow_table()
+
+        con = duckdb.connect()
+        # Route through the real core chokepoint (UTC guarantee), exactly as production does.
+        pin_connection_utc_via_core(con)
+        rel = DuckdbRelation.from_arrow(con, arrow_table)
+
+        fs = make_feature_set(feature_name)
+        result = DuckdbTimeBucketization.calculate_feature(rel, fs)
+        oracle = PyArrowTimeBucketization.calculate_feature(arrow_table, fs)
+
+        actual = list(result.to_arrow_table().column(feature_name).to_pylist())
+        expected = list(oracle.column(feature_name).to_pylist())
+
+        assert len(actual) == len(expected), f"row count {len(actual)} != oracle {len(expected)}"
+        for i, (a, e) in enumerate(zip(actual, expected)):
+            if e is None:
+                assert a is None, f"row {i}: expected None, got {a!r}"
+            else:
+                # Both are tz-aware UTC datetimes; ``==`` compares instants.
+                if isinstance(a, str):
+                    a = datetime.fromisoformat(a)
+                assert a == e, f"row {i}: {a!r} != oracle {e!r}"
+
+
 class TestDuckdbTimeBucketizationNonUtcSession:
     """Bucketization stays UTC-anchored regardless of session TZ, via the core chokepoint.
 

--- a/mloda/testing/feature_groups/data_operations/mixins/duckdb.py
+++ b/mloda/testing/feature_groups/data_operations/mixins/duckdb.py
@@ -7,6 +7,27 @@ from typing import Any
 import pyarrow as pa
 
 
+def pin_connection_utc_via_core(con: Any) -> None:
+    """Pin a DuckDB connection's session timezone to UTC via the real core chokepoint.
+
+    Routes ``con`` through ``DuckDBFramework.set_framework_connection_object``, which
+    applies the same UTC-session guarantee that mloda's DuckDBFramework applies in
+    production (mloda 0.9.0). Using this helper means tests rely on the core guarantee
+    instead of the host default timezone (or a per-feature-group pin).
+
+    Imports are done inside the function body to keep module import light and to match
+    the lazy-import style used elsewhere in this file (where ``duckdb`` is imported
+    inside methods).
+    """
+    import uuid
+
+    from mloda.user import ParallelizationMode
+    from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+
+    framework = DuckDBFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset({uuid.uuid4()}))
+    framework.set_framework_connection_object(con)
+
+
 class DuckdbTestMixin:
     """Mixin implementing adapter methods for DuckDB.
 
@@ -20,6 +41,7 @@ class DuckdbTestMixin:
         import duckdb
 
         self.conn = duckdb.connect()
+        pin_connection_utc_via_core(self.conn)
         super().setup_method()  # type: ignore[misc]
 
     def create_test_data(self, arrow_table: pa.Table) -> Any:

--- a/mloda/testing/feature_groups/data_operations/mixins/duckdb.py
+++ b/mloda/testing/feature_groups/data_operations/mixins/duckdb.py
@@ -8,17 +8,7 @@ import pyarrow as pa
 
 
 def pin_connection_utc_via_core(con: Any) -> None:
-    """Pin a DuckDB connection's session timezone to UTC via the real core chokepoint.
-
-    Routes ``con`` through ``DuckDBFramework.set_framework_connection_object``, which
-    applies the same UTC-session guarantee that mloda's DuckDBFramework applies in
-    production (mloda 0.9.0). Using this helper means tests rely on the core guarantee
-    instead of the host default timezone (or a per-feature-group pin).
-
-    Imports are done inside the function body to keep module import light and to match
-    the lazy-import style used elsewhere in this file (where ``duckdb`` is imported
-    inside methods).
-    """
+    """Pin ``con`` to UTC via the core chokepoint, as production does (mloda >= 0.9.0)."""
     import uuid
 
     from mloda.user import ParallelizationMode


### PR DESCRIPTION
Closes #269.

## What

mloda 0.9.0 pins the DuckDB session timezone to UTC at the framework chokepoint (`DuckDBFramework.set_framework_connection_object`, closes mloda#522). The per-feature-group `SET TimeZone='UTC'` workarounds in the DuckDB `time_bucketization` and `resample` backends are now redundant, so this removes both and consolidates the floor helper.

## Changes

- **Remove both `SET TimeZone='UTC'` pins** from `duckdb_time_bucketization.py` and `duckdb_resample.py`. Flooring now relies on the framework's UTC guarantee.
- **Consolidate the floor helper** into a single public entry point: `_floor_expr` becomes `floor_expr`, and its docstring encapsulates the UTC session-timezone precondition (guaranteed by the framework chokepoint, mloda >= 0.9.0), so a future caller cannot silently reintroduce the split-precondition gap that caused #265. The local variable holding the SQL string is renamed to `floor_sql` to avoid shadowing the helper.
- **Tests now rely on the core guarantee.** A new `pin_connection_utc_via_core` helper routes a DuckDB connection through the real core chokepoint. The shared DuckDB test mixin and the two bespoke non-UTC regression tests use it, so the suite proves the core guarantee (not a per-FG pin, and not the host timezone) is what anchors flooring to UTC.

## Review-found fix (included)

An independent review caught that the helper rename left the calendar-unit branch of `_round_expression` interpolating the `floor_expr` function object instead of the `floor_sql` string, so `round_1_week/month/year` on DuckDB raised a `ParserException`. This branch was untested (the shared base only covers fixed-freq round). Fixed, plus a new DuckDB calendar-round regression test comparing against the PyArrow oracle.

## Definition of done

- [x] `SET TimeZone='UTC'` calls removed from both DuckDB backends
- [x] Non-UTC regression tests pass, relying on the core guarantee
- [x] Floor helper consolidated so the tz precondition is encapsulated
- [x] tox passes (4112 passed, 141 skipped; ruff format + check, mypy --strict, bandit all green)
