### PR TITLE
docs(guides): document allowed_values field and property_spec builder

### DIFF
--- a/docs/guides/09-create-feature-group.md
+++ b/docs/guides/09-create-feature-group.md
@@ -35,6 +35,7 @@ Q8: Framework-specific API needed?
 
 Q9: Does the feature name come from configuration vs naming pattern?
     Configuration → Pattern 3 with PROPERTY_MAPPING
+                    (declare the value space via allowed_values / property_spec; see Pattern 11)
 
 Q10: Does it need custom matching logic beyond class name?
     YES → See 14-feature-matching

--- a/docs/guides/feature-group-patterns/03-chained-features.md
+++ b/docs/guides/feature-group-patterns/03-chained-features.md
@@ -37,7 +37,9 @@ class MeanImputedFeature(FeatureChainParserMixin, FeatureGroup):
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
-    # Optional: enables configuration-based creation
+    # Optional: enables configuration-based creation.
+    # Flattened form shown here; the recommended allowed_values / property_spec
+    # shape is below. See 11-options.md for the full value-space reference.
     PROPERTY_MAPPING = {
         "imputation_method": {
             "mean": "Impute with mean",
@@ -96,6 +98,7 @@ Use specific keys (not generic `operation_type`) to avoid collisions between fea
 
 PROPERTY_MAPPING supports additional capabilities that reduce boilerplate in `match_feature_group_criteria` overrides:
 
+- **`allowed_values`**: Declare the accepted value space in its own key instead of flattening it among the flags. Recommended shape; build it with `property_spec` for construction-time validation. See [Options: PROPERTY_MAPPING value space](11-options.md#property_mapping-value-space).
 - **`required_when`**: Declare options that are only required under certain conditions via a predicate callable.
 - **`type_validator`**: Validate raw option values with a callable (e.g., check that a value is a list of strings). Does not require `strict_validation`.
 - **`validation_function`**: Validate individual parsed values when `strict_validation` is enabled (e.g., check that a value is a positive integer).

--- a/docs/guides/feature-group-patterns/11-options.md
+++ b/docs/guides/feature-group-patterns/11-options.md
@@ -58,6 +58,67 @@ feature = Feature("price__scaled", Options(
 
 Use propagation sparingly—most context should remain local. Common use cases include trace IDs for debugging, tenant identifiers, or configuration that genuinely needs to flow through the entire pipeline.
 
+## PROPERTY_MAPPING value space
+
+A `PROPERTY_MAPPING` entry declares a parameter's accepted values plus metadata flags. Historically the values were flattened in among the flags:
+
+```python
+from mloda.provider import DefaultOptionKeys
+
+# Flattened form (still fully supported)
+PROPERTY_MAPPING = {
+    "operation_type": {
+        "add": "Addition",
+        "sub": "Subtraction",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: True,
+    },
+}
+```
+
+The parser recovers the value space by subtracting the reserved metadata keys (`RESERVED_PROPERTY_KEYS`: `explanation`, `allowed_values`, `default`, `context`, `group`, `strict_validation`, `validation_function`, `required_when`, `type_validator`). A value that collides with one of these names therefore cannot be expressed in the flattened form (it is read as metadata); use the explicit `allowed_values` field below for such a value.
+
+### Recommended: explicit `allowed_values`
+
+Declare the value space under `DefaultOptionKeys.allowed_values` so it stays separate from the flags and a doc-only key can never widen the accepted set:
+
+```python
+from mloda.provider import DefaultOptionKeys
+
+PROPERTY_MAPPING = {
+    "operation_type": {
+        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: True,
+    },
+}
+```
+
+When `allowed_values` is present the parser uses it directly and ignores the other keys for value-space purposes. It may be a mapping of value to one-line docstring, or a re-iterable collection (list, tuple, set). Do not pass a one-shot iterator (e.g. a generator) in a hand-written spec: the parser iterates the value space more than once, so an exhausted iterator behaves like an empty set. The value space here is taken verbatim, so it can hold any value (including one whose name matches a reserved key like `explanation`), unlike the flattened form.
+
+### Builder: `property_spec`
+
+`property_spec` builds the same dict and validates its invariants at construction (strict needs a non-empty `allowed_values` or a `validation_function`; `allowed_values` without strict is rejected as a no-op; a strict non-`None` `default` must be in the accepted set). It also materializes iterables, so you never hit the one-shot caveat. The contract stays a plain `dict[str, Any]`, so this is optional sugar:
+
+```python
+from mloda.provider import property_spec
+
+PROPERTY_MAPPING = {
+    "operation_type": property_spec(
+        "Arithmetic operation",
+        strict=True,
+        allowed_values={"add": "Addition", "sub": "Subtraction"},
+        default="add",
+    ),
+}
+```
+
+`property_spec` also accepts `context`, `validation_function`, `required_when`, and `type_validator`, matching the flattened keys of the same name.
+
+### Strict defaults are checked at import time
+
+Since mloda 0.9.0, defining a `FeatureGroup` whose `PROPERTY_MAPPING` declares a `strict_validation: True` default outside the accepted set (or one that fails the key's `validation_function`) raises `ValueError` at class definition, naming the class, key, default, and accepted values. Previously such a spec imported silently and only misbehaved at runtime. A `default` of `None` is exempt (the conventional "unset" sentinel), and the check is a no-op under `strict_validation: False`.
+
 ## Validation and Conditional Requirements
 
 When using `PROPERTY_MAPPING` with `FeatureChainParserMixin`, you can declare validation rules and conditional requirements directly on option entries:
@@ -70,4 +131,4 @@ See [Feature Matching: Conditional Requirements](14-feature-matching.md#conditio
 
 ## Full Documentation
 
-See [Options API](https://mloda-ai.github.io/mloda/in_depth/options/) for detailed patterns.
+See [Options API](https://mloda-ai.github.io/mloda/in_depth/options/) for detailed patterns and [PROPERTY_MAPPING Configuration](https://mloda-ai.github.io/mloda/in_depth/property-mapping/) for the full spec reference.

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -91,6 +91,24 @@ class BaseMyTransform(FeatureChainParserMixin, FeatureGroup):
     # No need to override match_feature_group_criteria() - mixin handles it
 ```
 
+**Recommended shape:** keep the discriminator's value space in its own `allowed_values` key instead of spreading it among the flags. See [Options: PROPERTY_MAPPING value space](11-options.md#property_mapping-value-space).
+
+```python
+from mloda.provider import DefaultOptionKeys, property_spec
+
+PROPERTY_MAPPING = {
+    MY_METHOD: property_spec(
+        "Transform algorithm",
+        strict=True,
+        allowed_values=MY_METHODS,  # {"algo_a": "...", "algo_b": "..."}
+    ),
+    DefaultOptionKeys.in_features: {
+        "explanation": "Source feature",
+        DefaultOptionKeys.context: True,
+    },
+}
+```
+
 **Usage** - both approaches route to the same FeatureGroup:
 
 ```python


### PR DESCRIPTION
## Summary

Documents mloda 0.9.0's explicit `allowed_values` PROPERTY_MAPPING field and the optional `property_spec()` builder in the registry plugin guides. Closes #275.

## Changes

- **`11-options.md`** (primary): new "PROPERTY_MAPPING value space" section covering the recommended explicit `allowed_values` shape, the `property_spec` builder and its construction-time invariants, the reserved-name and re-iterable (no one-shot generator) caveats, and the 0.9.0 import-time `ValueError` for a strict default outside its accepted set. Links to the upstream property-mapping reference.
- **`03-chained-features.md`**: labels the flattened example as still-supported and adds `allowed_values`/`property_spec` to the advanced-features list.
- **`14-feature-matching.md`**: shows the recommended `allowed_values` / `property_spec` shape alongside the flattened discriminator example.
- **`09-create-feature-group.md`**: pointer to the new shape in the PROPERTY_MAPPING decision line.

Legacy flattened examples are retained and labeled still-supported.

## Verification

All API facts (`property_spec` signature and invariants, `RESERVED_PROPERTY_KEYS`, `allowed_values` extraction, import-time default check) verified against the installed mloda 0.9.0 venv. `scripts/lint_docs.py` and full `tox` (4109 passed, ruff, mypy strict, bandit) pass.

Reviewed by an independent Claude Opus pass and codex; both flagged that the reserved-name caveat was inaccurate for the explicit form (reserved names are only unusable as literal values in the flattened form, and there the whole reserved set applies). Corrected in this PR.