### PR TITLE
test(ci-probe): tests+generator only [temporary, do not merge]

### DIFF
--- a/config/packages.toml
+++ b/config/packages.toml
@@ -23,52 +23,62 @@ optional_dependencies = { dev = ["pytest>=9.0.3"] }
 description = "All community plugins for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/community"
+entry_point_bundle = true
 
 [packages.mloda-enterprise]
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 dependencies = ["{core_dependency}"]
 path = "mloda/enterprise"
+entry_point_bundle = true
 
 [packages.mloda-community-example]
 description = "Example community FeatureGroup plugin for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/community/feature_groups/example"
 optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-example-b"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-enterprise-example]
 description = "Example enterprise FeatureGroup plugin for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/enterprise/feature_groups/example"
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-example-a]
 description = "Example A FeatureGroup extending community example base"
 dependencies = ["mloda-community-example>=0.2.0"]
 path = "mloda/community/feature_groups/example/example_a"
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-example-b]
 description = "Example B FeatureGroup extending community example base"
 dependencies = ["mloda-community-example>=0.2.0"]
 path = "mloda/community/feature_groups/example/example_b"
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-compute-frameworks-example]
 description = "Example community ComputeFramework plugin for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/community/compute_frameworks/example"
+entry_point_groups = ["mloda.compute_frameworks"]
 
 [packages.mloda-community-extenders-example]
 description = "Example community Extender plugin for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/community/extenders/example"
+entry_point_groups = ["mloda.extenders"]
 
 [packages.mloda-enterprise-compute-frameworks-example]
 description = "Example enterprise ComputeFramework plugin for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/enterprise/compute_frameworks/example"
+entry_point_groups = ["mloda.compute_frameworks"]
 
 [packages.mloda-enterprise-extenders-example]
 description = "Example enterprise Extender plugin for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/enterprise/extenders/example"
+entry_point_groups = ["mloda.extenders"]
 
 # --- Data Operations ---
 
@@ -83,36 +93,42 @@ description = "Aggregation feature group (reduce, partition_by, one row per grou
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/aggregation"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-rank]
 description = "Rank feature group (row_number, rank, dense_rank, percent_rank, ntile, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/rank"
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-offset]
 description = "Offset feature group (lag, lead, diff, pct_change, first_value, last_value, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/offset"
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-window-aggregation]
 description = "Window aggregation feature group (broadcast, partition_by, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-frame-aggregate]
 description = "Frame aggregate feature group (rolling, cumulative, expanding, time window, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate"
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas>=2.2"], all = ["polars", "pandas>=2.2", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-scalar-aggregate]
 description = "Scalar aggregate feature group (single-column global aggregate broadcast)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-scalar-arithmetic]
 description = "Scalar arithmetic feature group (element-wise column op constant: add, subtract, multiply, divide)"
@@ -120,6 +136,7 @@ description = "Scalar arithmetic feature group (element-wise column op constant:
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-point-arithmetic]
 description = "Point arithmetic feature group (element-wise two-column op: add, subtract, multiply, divide; PyArrow-reference null/IEEE-754 semantics on divide-by-zero; SQLite returns NULL)"
@@ -127,55 +144,65 @@ description = "Point arithmetic feature group (element-wise two-column op: add, 
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-datetime]
 description = "Datetime extraction feature group (element-wise, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/datetime"
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-string]
 description = "String operation feature group (element-wise, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/string"
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-binning]
 description = "Binning feature group (equal-width, quantile, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/binning"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-percentile]
 description = "Percentile feature group (PERCENTILE_CONT, partition_by, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/percentile"
 optional_dependencies = { duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-time-bucketization]
 description = "Time bucketization feature group (floor, ceil, round a timestamp to a bucket interval, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/time_bucketization"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-ffill]
 description = "Forward-fill feature group (ffill a value column across time gaps, per partition, ordered by time, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ffill"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-ema]
 description = "EMA feature group (exponential moving average, adjust=False, null-skipping recurrence, per partition, row-preserving; pandas/polars native, pyarrow/duckdb/sqlite reject)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ema"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-sessionization]
 description = "Sessionization feature group (gap-threshold session id on an ordered timestamp, per partition, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/sessionization"
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-resample]
 description = "Resample feature group (collapse events onto a regular time grid: floor to bucket, group, aggregate; one row per non-empty bucket, row-changing)"
 dependencies = ["mloda-community-data-operations>=0.2.12"]
 path = "mloda/community/feature_groups/data_operations/row_changing/resample"
 optional_dependencies = { pyarrow = ["pyarrow"], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
+entry_point_groups = ["mloda.feature_groups"]

--- a/memory-bank/pyproject-generation.md
+++ b/memory-bank/pyproject-generation.md
@@ -54,6 +54,8 @@ optional_dependencies = { dev = ["mloda-testing", "pytest"] }
 | `dependencies` | Yes | Runtime deps |
 | `path` | Yes | Package directory |
 | `optional_dependencies` | No | Merged with defaults |
+| `entry_point_groups` | No | List of mloda entry-point groups the package's `manifest.py` populates (`mloda.feature_groups`, `mloda.compute_frameworks`, `mloda.extenders`) |
+| `entry_point_bundle` | No | `true` on bundle packages (`mloda-community`, `mloda-enterprise`); aggregates the entry points of every nested plugin package under its path. Mutually exclusive with `entry_point_groups` |
 
 **Generator infers:**
 - `license` from path (`mloda/enterprise/*` → proprietary, else default)
@@ -88,6 +90,36 @@ optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-e
 # dev = ["mloda-testing", "pytest"] added from defaults
 ```
 
+## Entry points
+
+mloda 0.9.0 discovers installed plugins through the entry-point groups
+`mloda.feature_groups`, `mloda.compute_frameworks`, and `mloda.extenders`
+(issue #271). Each plugin package ships a `manifest.py` module that lists the
+package's concrete plugin classes under a per-group attribute:
+
+| Group | Attribute | Base type |
+|-------|-----------|-----------|
+| `mloda.feature_groups` | `FEATURE_GROUPS` | `FeatureGroup` |
+| `mloda.compute_frameworks` | `COMPUTE_FRAMEWORKS` | `ComputeFramework` |
+| `mloda.extenders` | `EXTENDERS` | `Extender` |
+
+Conventions:
+- One `manifest.py` per plugin package. It lists concrete classes only, never the
+  shared base class in `base.py` / `*_base.py` (those are non-abstract and would
+  wrongly register).
+- The generator emits `[project.entry-points."<group>"]` tables whose entry name
+  is the distribution label and whose value is the canonical
+  `<dotted.package.path>.manifest:<ATTR>` target, e.g.
+  `mloda-community-ffill = "mloda.community.feature_groups.data_operations.row_preserving.ffill.manifest:FEATURE_GROUPS"`.
+- Bundle packages (`mloda-community`, `mloda-enterprise`) set
+  `entry_point_bundle = true` and aggregate the entry points of every nested
+  plugin package under their path.
+
+Plugin authors adding a new plugin package must:
+1. Add `entry_point_groups = ["<group>"]` to the package in `config/packages.toml`.
+2. Create `<package path>/manifest.py` listing the concrete plugin classes.
+3. Run `python scripts/generate_pyproject.py` to regenerate the pyproject files.
+
 ## UV Workspace Sources
 
 The generator adds `mloda-testing = { workspace = true }` only for top-level packages (depth ≤ 2) that receive default dev deps. Nested packages can't use workspace sources due to uv resolution limitations.
@@ -102,8 +134,10 @@ python scripts/generate_pyproject.py    # Regenerate
 
 ### Add new package
 ```bash
-# 1. Add to config/packages.toml (just description, deps, path)
-# 2. Generate
+# 1. Add to config/packages.toml (description, deps, path; for a plugin package
+#    also add entry_point_groups = ["mloda.feature_groups" | ...])
+# 2. For a plugin package, create <path>/manifest.py listing the concrete classes
+# 3. Generate
 python scripts/generate_pyproject.py
 uv sync --all-extras
 ```

--- a/mloda/community/compute_frameworks/example/manifest.py
+++ b/mloda/community/compute_frameworks/example/manifest.py
@@ -1,0 +1,15 @@
+"""Entry-point manifest for mloda-community-compute-frameworks-example.
+
+Lists the concrete ComputeFramework classes that mloda discovers via the
+``mloda.compute_frameworks`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import ComputeFramework
+
+from .community_example_compute_framework import CommunityExampleComputeFramework
+
+COMPUTE_FRAMEWORKS: list[type[ComputeFramework]] = [
+    CommunityExampleComputeFramework,
+]

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -21,6 +21,9 @@ dev = ["mloda-testing", "pytest>=9.0.3"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.compute_frameworks"]
+mloda-community-compute-frameworks-example = "mloda.community.compute_frameworks.example.manifest:COMPUTE_FRAMEWORKS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../.."}
 packages = ["mloda.community.compute_frameworks.example"]

--- a/mloda/community/extenders/example/manifest.py
+++ b/mloda/community/extenders/example/manifest.py
@@ -1,0 +1,15 @@
+"""Entry-point manifest for mloda-community-extenders-example.
+
+Lists the concrete Extender classes that mloda discovers via the
+``mloda.extenders`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.steward import Extender
+
+from .community_example_extender import CommunityExampleExtender
+
+EXTENDERS: list[type[Extender]] = [
+    CommunityExampleExtender,
+]

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -21,6 +21,9 @@ dev = ["mloda-testing", "pytest>=9.0.3"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.extenders"]
+mloda-community-extenders-example = "mloda.community.extenders.example.manifest:EXTENDERS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../.."}
 packages = ["mloda.community.extenders.example"]

--- a/mloda/community/feature_groups/data_operations/aggregation/manifest.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-aggregation.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_aggregation import DuckdbAggregation
+from .pandas_aggregation import PandasAggregation
+from .polars_lazy_aggregation import PolarsLazyAggregation
+from .pyarrow_aggregation import PyArrowAggregation
+from .sqlite_aggregation import SqliteAggregation
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbAggregation,
+    PandasAggregation,
+    PolarsLazyAggregation,
+    PyArrowAggregation,
+    SqliteAggregation,
+]

--- a/mloda/community/feature_groups/data_operations/aggregation/manifest.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-aggregation.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_aggregation import DuckdbAggregation
-from .pandas_aggregation import PandasAggregation
-from .polars_lazy_aggregation import PolarsLazyAggregation
-from .pyarrow_aggregation import PyArrowAggregation
-from .sqlite_aggregation import SqliteAggregation
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbAggregation,
-    PandasAggregation,
-    PolarsLazyAggregation,
-    PyArrowAggregation,
-    SqliteAggregation,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_aggregation", "DuckdbAggregation"),
+        ("pandas_aggregation", "PandasAggregation"),
+        ("polars_lazy_aggregation", "PolarsLazyAggregation"),
+        ("pyarrow_aggregation", "PyArrowAggregation"),
+        ("sqlite_aggregation", "SqliteAggregation"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-aggregation = "mloda.community.feature_groups.data_operations.aggregation.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.aggregation"]

--- a/mloda/community/feature_groups/data_operations/manifest_utils.py
+++ b/mloda/community/feature_groups/data_operations/manifest_utils.py
@@ -1,0 +1,41 @@
+"""Helpers for building entry-point manifests resilient to missing optional backends.
+
+A data_operations plugin package ships one concrete plugin class per compute
+framework, and each backend module top-imports its framework (pandas, polars,
+duckdb, pyarrow). mloda's entry-point loader skips a whole entry point if
+importing its manifest raises ModuleNotFoundError, so a manifest that eagerly
+imports every backend becomes undiscoverable unless every optional framework is
+installed. ``load_plugin_classes`` imports each backend individually and drops
+only the backends whose optional framework is absent, while still raising on any
+other import error (so typos and real breakage stay loud). See issue #271.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterable
+from typing import Any
+
+# Optional compute-framework roots used by data_operations backends. A missing
+# import whose root is one of these means "framework not installed" -> skip that
+# backend only. Any other ModuleNotFoundError is a real error and re-raised.
+_OPTIONAL_BACKENDS = frozenset({"pandas", "polars", "duckdb", "pyarrow"})
+
+
+def load_plugin_classes(package: str, specs: Iterable[tuple[str, str]]) -> list[type[Any]]:
+    """Import ``(submodule, class_name)`` pairs under ``package``.
+
+    Skips a backend whose optional framework dependency is not installed;
+    re-raises every other import error. Order follows ``specs``.
+    """
+    classes: list[type[Any]] = []
+    for submodule, class_name in specs:
+        try:
+            module = importlib.import_module(f"{package}.{submodule}")
+        except ModuleNotFoundError as exc:
+            root = (exc.name or "").split(".")[0]
+            if root in _OPTIONAL_BACKENDS:
+                continue
+            raise
+        classes.append(getattr(module, class_name))
+    return classes

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/manifest.py
@@ -1,0 +1,21 @@
+"""Entry-point manifest for mloda-community-resample.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_resample import DuckdbResample
+from .pandas_resample import PandasResample
+from .polars_lazy_resample import PolarsLazyResample
+from .pyarrow_resample import PyArrowResample
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbResample,
+    PandasResample,
+    PolarsLazyResample,
+    PyArrowResample,
+]

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/manifest.py
@@ -1,21 +1,22 @@
 """Entry-point manifest for mloda-community-resample.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_resample import DuckdbResample
-from .pandas_resample import PandasResample
-from .polars_lazy_resample import PolarsLazyResample
-from .pyarrow_resample import PyArrowResample
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbResample,
-    PandasResample,
-    PolarsLazyResample,
-    PyArrowResample,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_resample", "DuckdbResample"),
+        ("pandas_resample", "PandasResample"),
+        ("polars_lazy_resample", "PolarsLazyResample"),
+        ("pyarrow_resample", "PyArrowResample"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
@@ -26,6 +26,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-resample = "mloda.community.feature_groups.data_operations.row_changing.resample.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_changing.resample"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-binning.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_binning import DuckdbBinning
-from .pandas_binning import PandasBinning
-from .polars_lazy_binning import PolarsLazyBinning
-from .pyarrow_binning import PyArrowBinning
-from .sqlite_binning import SqliteBinning
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbBinning,
-    PandasBinning,
-    PolarsLazyBinning,
-    PyArrowBinning,
-    SqliteBinning,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_binning", "DuckdbBinning"),
+        ("pandas_binning", "PandasBinning"),
+        ("polars_lazy_binning", "PolarsLazyBinning"),
+        ("pyarrow_binning", "PyArrowBinning"),
+        ("sqlite_binning", "SqliteBinning"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-binning.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_binning import DuckdbBinning
+from .pandas_binning import PandasBinning
+from .polars_lazy_binning import PolarsLazyBinning
+from .pyarrow_binning import PyArrowBinning
+from .sqlite_binning import SqliteBinning
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbBinning,
+    PandasBinning,
+    PolarsLazyBinning,
+    PyArrowBinning,
+    SqliteBinning,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-binning = "mloda.community.feature_groups.data_operations.row_preserving.binning.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.binning"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-datetime.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_datetime import DuckdbDateTimeExtraction
+from .pandas_datetime import PandasDateTimeExtraction
+from .polars_lazy_datetime import PolarsLazyDateTimeExtraction
+from .pyarrow_datetime import PyArrowDateTimeExtraction
+from .sqlite_datetime import SqliteDateTimeExtraction
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbDateTimeExtraction,
+    PandasDateTimeExtraction,
+    PolarsLazyDateTimeExtraction,
+    PyArrowDateTimeExtraction,
+    SqliteDateTimeExtraction,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-datetime.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_datetime import DuckdbDateTimeExtraction
-from .pandas_datetime import PandasDateTimeExtraction
-from .polars_lazy_datetime import PolarsLazyDateTimeExtraction
-from .pyarrow_datetime import PyArrowDateTimeExtraction
-from .sqlite_datetime import SqliteDateTimeExtraction
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbDateTimeExtraction,
-    PandasDateTimeExtraction,
-    PolarsLazyDateTimeExtraction,
-    PyArrowDateTimeExtraction,
-    SqliteDateTimeExtraction,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_datetime", "DuckdbDateTimeExtraction"),
+        ("pandas_datetime", "PandasDateTimeExtraction"),
+        ("polars_lazy_datetime", "PolarsLazyDateTimeExtraction"),
+        ("pyarrow_datetime", "PyArrowDateTimeExtraction"),
+        ("sqlite_datetime", "SqliteDateTimeExtraction"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
@@ -21,6 +21,9 @@ dev = ["mloda-testing", "pytest>=9.0.3"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-datetime = "mloda.community.feature_groups.data_operations.row_preserving.datetime.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.datetime"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-ema.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_ema import DuckdbEma
-from .pandas_ema import PandasEma
-from .polars_lazy_ema import PolarsLazyEma
-from .pyarrow_ema import PyArrowEma
-from .sqlite_ema import SqliteEma
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbEma,
-    PandasEma,
-    PolarsLazyEma,
-    PyArrowEma,
-    SqliteEma,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_ema", "DuckdbEma"),
+        ("pandas_ema", "PandasEma"),
+        ("polars_lazy_ema", "PolarsLazyEma"),
+        ("pyarrow_ema", "PyArrowEma"),
+        ("sqlite_ema", "SqliteEma"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-ema.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_ema import DuckdbEma
+from .pandas_ema import PandasEma
+from .polars_lazy_ema import PolarsLazyEma
+from .pyarrow_ema import PyArrowEma
+from .sqlite_ema import SqliteEma
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbEma,
+    PandasEma,
+    PolarsLazyEma,
+    PyArrowEma,
+    SqliteEma,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-ema = "mloda.community.feature_groups.data_operations.row_preserving.ema.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.ema"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-ffill.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_ffill import DuckdbFfill
+from .pandas_ffill import PandasFfill
+from .polars_lazy_ffill import PolarsLazyFfill
+from .pyarrow_ffill import PyArrowFfill
+from .sqlite_ffill import SqliteFfill
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbFfill,
+    PandasFfill,
+    PolarsLazyFfill,
+    PyArrowFfill,
+    SqliteFfill,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-ffill.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_ffill import DuckdbFfill
-from .pandas_ffill import PandasFfill
-from .polars_lazy_ffill import PolarsLazyFfill
-from .pyarrow_ffill import PyArrowFfill
-from .sqlite_ffill import SqliteFfill
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbFfill,
-    PandasFfill,
-    PolarsLazyFfill,
-    PyArrowFfill,
-    SqliteFfill,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_ffill", "DuckdbFfill"),
+        ("pandas_ffill", "PandasFfill"),
+        ("polars_lazy_ffill", "PolarsLazyFfill"),
+        ("pyarrow_ffill", "PyArrowFfill"),
+        ("sqlite_ffill", "SqliteFfill"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-ffill = "mloda.community.feature_groups.data_operations.row_preserving.ffill.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.ffill"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/manifest.py
@@ -1,21 +1,22 @@
 """Entry-point manifest for mloda-community-frame-aggregate.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_frame_aggregate import DuckdbFrameAggregate
-from .pandas_frame_aggregate import PandasFrameAggregate
-from .polars_lazy_frame_aggregate import PolarsLazyFrameAggregate
-from .sqlite_frame_aggregate import SqliteFrameAggregate
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbFrameAggregate,
-    PandasFrameAggregate,
-    PolarsLazyFrameAggregate,
-    SqliteFrameAggregate,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_frame_aggregate", "DuckdbFrameAggregate"),
+        ("pandas_frame_aggregate", "PandasFrameAggregate"),
+        ("polars_lazy_frame_aggregate", "PolarsLazyFrameAggregate"),
+        ("sqlite_frame_aggregate", "SqliteFrameAggregate"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/manifest.py
@@ -1,0 +1,21 @@
+"""Entry-point manifest for mloda-community-frame-aggregate.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_frame_aggregate import DuckdbFrameAggregate
+from .pandas_frame_aggregate import PandasFrameAggregate
+from .polars_lazy_frame_aggregate import PolarsLazyFrameAggregate
+from .sqlite_frame_aggregate import SqliteFrameAggregate
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbFrameAggregate,
+    PandasFrameAggregate,
+    PolarsLazyFrameAggregate,
+    SqliteFrameAggregate,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
@@ -26,6 +26,9 @@ all = ["polars", "pandas>=2.2", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-frame-aggregate = "mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/manifest.py
@@ -1,21 +1,22 @@
 """Entry-point manifest for mloda-community-offset.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_offset import DuckdbOffset
-from .pandas_offset import PandasOffset
-from .polars_lazy_offset import PolarsLazyOffset
-from .sqlite_offset import SqliteOffset
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbOffset,
-    PandasOffset,
-    PolarsLazyOffset,
-    SqliteOffset,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_offset", "DuckdbOffset"),
+        ("pandas_offset", "PandasOffset"),
+        ("polars_lazy_offset", "PolarsLazyOffset"),
+        ("sqlite_offset", "SqliteOffset"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/manifest.py
@@ -1,0 +1,21 @@
+"""Entry-point manifest for mloda-community-offset.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_offset import DuckdbOffset
+from .pandas_offset import PandasOffset
+from .polars_lazy_offset import PolarsLazyOffset
+from .sqlite_offset import SqliteOffset
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbOffset,
+    PandasOffset,
+    PolarsLazyOffset,
+    SqliteOffset,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
@@ -26,6 +26,9 @@ all = ["polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-offset = "mloda.community.feature_groups.data_operations.row_preserving.offset.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.offset"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/manifest.py
@@ -1,0 +1,19 @@
+"""Entry-point manifest for mloda-community-percentile.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_percentile import DuckdbPercentile
+from .pandas_percentile import PandasPercentile
+from .polars_lazy_percentile import PolarsLazyPercentile
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbPercentile,
+    PandasPercentile,
+    PolarsLazyPercentile,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/manifest.py
@@ -1,19 +1,21 @@
 """Entry-point manifest for mloda-community-percentile.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_percentile import DuckdbPercentile
-from .pandas_percentile import PandasPercentile
-from .polars_lazy_percentile import PolarsLazyPercentile
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbPercentile,
-    PandasPercentile,
-    PolarsLazyPercentile,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_percentile", "DuckdbPercentile"),
+        ("pandas_percentile", "PandasPercentile"),
+        ("polars_lazy_percentile", "PolarsLazyPercentile"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
@@ -25,6 +25,9 @@ all = ["polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-percentile = "mloda.community.feature_groups.data_operations.row_preserving.percentile.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.percentile"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-point-arithmetic.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_point_arithmetic import DuckdbPointArithmetic
+from .pandas_point_arithmetic import PandasPointArithmetic
+from .polars_lazy_point_arithmetic import PolarsLazyPointArithmetic
+from .pyarrow_point_arithmetic import PyArrowPointArithmetic
+from .sqlite_point_arithmetic import SqlitePointArithmetic
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbPointArithmetic,
+    PandasPointArithmetic,
+    PolarsLazyPointArithmetic,
+    PyArrowPointArithmetic,
+    SqlitePointArithmetic,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-point-arithmetic.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_point_arithmetic import DuckdbPointArithmetic
-from .pandas_point_arithmetic import PandasPointArithmetic
-from .polars_lazy_point_arithmetic import PolarsLazyPointArithmetic
-from .pyarrow_point_arithmetic import PyArrowPointArithmetic
-from .sqlite_point_arithmetic import SqlitePointArithmetic
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbPointArithmetic,
-    PandasPointArithmetic,
-    PolarsLazyPointArithmetic,
-    PyArrowPointArithmetic,
-    SqlitePointArithmetic,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_point_arithmetic", "DuckdbPointArithmetic"),
+        ("pandas_point_arithmetic", "PandasPointArithmetic"),
+        ("polars_lazy_point_arithmetic", "PolarsLazyPointArithmetic"),
+        ("pyarrow_point_arithmetic", "PyArrowPointArithmetic"),
+        ("sqlite_point_arithmetic", "SqlitePointArithmetic"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-point-arithmetic = "mloda.community.feature_groups.data_operations.row_preserving.point_arithmetic.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.point_arithmetic"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/manifest.py
@@ -1,21 +1,22 @@
 """Entry-point manifest for mloda-community-rank.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_rank import DuckdbRank
-from .pandas_rank import PandasRank
-from .polars_lazy_rank import PolarsLazyRank
-from .sqlite_rank import SqliteRank
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbRank,
-    PandasRank,
-    PolarsLazyRank,
-    SqliteRank,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_rank", "DuckdbRank"),
+        ("pandas_rank", "PandasRank"),
+        ("polars_lazy_rank", "PolarsLazyRank"),
+        ("sqlite_rank", "SqliteRank"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/manifest.py
@@ -1,0 +1,21 @@
+"""Entry-point manifest for mloda-community-rank.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_rank import DuckdbRank
+from .pandas_rank import PandasRank
+from .polars_lazy_rank import PolarsLazyRank
+from .sqlite_rank import SqliteRank
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbRank,
+    PandasRank,
+    PolarsLazyRank,
+    SqliteRank,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
@@ -26,6 +26,9 @@ all = ["polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-rank = "mloda.community.feature_groups.data_operations.row_preserving.rank.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.rank"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-scalar-aggregate.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_scalar_aggregate import DuckdbScalarAggregate
+from .pandas_scalar_aggregate import PandasScalarAggregate
+from .polars_lazy_scalar_aggregate import PolarsLazyScalarAggregate
+from .pyarrow_scalar_aggregate import PyArrowScalarAggregate
+from .sqlite_scalar_aggregate import SqliteScalarAggregate
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbScalarAggregate,
+    PandasScalarAggregate,
+    PolarsLazyScalarAggregate,
+    PyArrowScalarAggregate,
+    SqliteScalarAggregate,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-scalar-aggregate.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_scalar_aggregate import DuckdbScalarAggregate
-from .pandas_scalar_aggregate import PandasScalarAggregate
-from .polars_lazy_scalar_aggregate import PolarsLazyScalarAggregate
-from .pyarrow_scalar_aggregate import PyArrowScalarAggregate
-from .sqlite_scalar_aggregate import SqliteScalarAggregate
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbScalarAggregate,
-    PandasScalarAggregate,
-    PolarsLazyScalarAggregate,
-    PyArrowScalarAggregate,
-    SqliteScalarAggregate,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_scalar_aggregate", "DuckdbScalarAggregate"),
+        ("pandas_scalar_aggregate", "PandasScalarAggregate"),
+        ("polars_lazy_scalar_aggregate", "PolarsLazyScalarAggregate"),
+        ("pyarrow_scalar_aggregate", "PyArrowScalarAggregate"),
+        ("sqlite_scalar_aggregate", "SqliteScalarAggregate"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-scalar-aggregate = "mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-scalar-arithmetic.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_scalar_arithmetic import DuckdbScalarArithmetic
-from .pandas_scalar_arithmetic import PandasScalarArithmetic
-from .polars_lazy_scalar_arithmetic import PolarsLazyScalarArithmetic
-from .pyarrow_scalar_arithmetic import PyArrowScalarArithmetic
-from .sqlite_scalar_arithmetic import SqliteScalarArithmetic
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbScalarArithmetic,
-    PandasScalarArithmetic,
-    PolarsLazyScalarArithmetic,
-    PyArrowScalarArithmetic,
-    SqliteScalarArithmetic,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_scalar_arithmetic", "DuckdbScalarArithmetic"),
+        ("pandas_scalar_arithmetic", "PandasScalarArithmetic"),
+        ("polars_lazy_scalar_arithmetic", "PolarsLazyScalarArithmetic"),
+        ("pyarrow_scalar_arithmetic", "PyArrowScalarArithmetic"),
+        ("sqlite_scalar_arithmetic", "SqliteScalarArithmetic"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-scalar-arithmetic.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_scalar_arithmetic import DuckdbScalarArithmetic
+from .pandas_scalar_arithmetic import PandasScalarArithmetic
+from .polars_lazy_scalar_arithmetic import PolarsLazyScalarArithmetic
+from .pyarrow_scalar_arithmetic import PyArrowScalarArithmetic
+from .sqlite_scalar_arithmetic import SqliteScalarArithmetic
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbScalarArithmetic,
+    PandasScalarArithmetic,
+    PolarsLazyScalarArithmetic,
+    PyArrowScalarArithmetic,
+    SqliteScalarArithmetic,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-scalar-arithmetic = "mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-sessionization.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_sessionization import DuckdbSessionization
-from .pandas_sessionization import PandasSessionization
-from .polars_lazy_sessionization import PolarsLazySessionization
-from .pyarrow_sessionization import PyArrowSessionization
-from .sqlite_sessionization import SqliteSessionization
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbSessionization,
-    PandasSessionization,
-    PolarsLazySessionization,
-    PyArrowSessionization,
-    SqliteSessionization,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_sessionization", "DuckdbSessionization"),
+        ("pandas_sessionization", "PandasSessionization"),
+        ("polars_lazy_sessionization", "PolarsLazySessionization"),
+        ("pyarrow_sessionization", "PyArrowSessionization"),
+        ("sqlite_sessionization", "SqliteSessionization"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-sessionization.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_sessionization import DuckdbSessionization
+from .pandas_sessionization import PandasSessionization
+from .polars_lazy_sessionization import PolarsLazySessionization
+from .pyarrow_sessionization import PyArrowSessionization
+from .sqlite_sessionization import SqliteSessionization
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbSessionization,
+    PandasSessionization,
+    PolarsLazySessionization,
+    PyArrowSessionization,
+    SqliteSessionization,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-sessionization = "mloda.community.feature_groups.data_operations.row_preserving.sessionization.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.sessionization"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-time-bucketization.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_time_bucketization import DuckdbTimeBucketization
-from .pandas_time_bucketization import PandasTimeBucketization
-from .polars_lazy_time_bucketization import PolarsLazyTimeBucketization
-from .pyarrow_time_bucketization import PyArrowTimeBucketization
-from .sqlite_time_bucketization import SqliteTimeBucketization
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbTimeBucketization,
-    PandasTimeBucketization,
-    PolarsLazyTimeBucketization,
-    PyArrowTimeBucketization,
-    SqliteTimeBucketization,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_time_bucketization", "DuckdbTimeBucketization"),
+        ("pandas_time_bucketization", "PandasTimeBucketization"),
+        ("polars_lazy_time_bucketization", "PolarsLazyTimeBucketization"),
+        ("pyarrow_time_bucketization", "PyArrowTimeBucketization"),
+        ("sqlite_time_bucketization", "SqliteTimeBucketization"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-time-bucketization.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_time_bucketization import DuckdbTimeBucketization
+from .pandas_time_bucketization import PandasTimeBucketization
+from .polars_lazy_time_bucketization import PolarsLazyTimeBucketization
+from .pyarrow_time_bucketization import PyArrowTimeBucketization
+from .sqlite_time_bucketization import SqliteTimeBucketization
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbTimeBucketization,
+    PandasTimeBucketization,
+    PolarsLazyTimeBucketization,
+    PyArrowTimeBucketization,
+    SqliteTimeBucketization,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-time-bucketization = "mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.time_bucketization"]

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-window-aggregation.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_window_aggregation import DuckdbWindowAggregation
-from .pandas_window_aggregation import PandasWindowAggregation
-from .polars_lazy_window_aggregation import PolarsLazyWindowAggregation
-from .pyarrow_window_aggregation import PyArrowWindowAggregation
-from .sqlite_window_aggregation import SqliteWindowAggregation
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbWindowAggregation,
-    PandasWindowAggregation,
-    PolarsLazyWindowAggregation,
-    PyArrowWindowAggregation,
-    SqliteWindowAggregation,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_window_aggregation", "DuckdbWindowAggregation"),
+        ("pandas_window_aggregation", "PandasWindowAggregation"),
+        ("polars_lazy_window_aggregation", "PolarsLazyWindowAggregation"),
+        ("pyarrow_window_aggregation", "PyArrowWindowAggregation"),
+        ("sqlite_window_aggregation", "SqliteWindowAggregation"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/manifest.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-window-aggregation.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_window_aggregation import DuckdbWindowAggregation
+from .pandas_window_aggregation import PandasWindowAggregation
+from .polars_lazy_window_aggregation import PolarsLazyWindowAggregation
+from .pyarrow_window_aggregation import PyArrowWindowAggregation
+from .sqlite_window_aggregation import SqliteWindowAggregation
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbWindowAggregation,
+    PandasWindowAggregation,
+    PolarsLazyWindowAggregation,
+    PyArrowWindowAggregation,
+    SqliteWindowAggregation,
+]

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
@@ -27,6 +27,9 @@ all = ["pyarrow", "polars", "pandas", "duckdb"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-window-aggregation = "mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.row_preserving.window_aggregation"]

--- a/mloda/community/feature_groups/data_operations/string/manifest.py
+++ b/mloda/community/feature_groups/data_operations/string/manifest.py
@@ -1,23 +1,23 @@
 """Entry-point manifest for mloda-community-string.
 
 Lists the concrete FeatureGroup classes that mloda discovers via the
-``mloda.feature_groups`` entry point. See issue #271.
+``mloda.feature_groups`` entry point. Backends whose optional framework is not
+installed are skipped so the rest still register. See issue #271.
 """
 
 from __future__ import annotations
 
 from mloda.provider import FeatureGroup
 
-from .duckdb_string import DuckdbStringOps
-from .pandas_string import PandasStringOps
-from .polars_lazy_string import PolarsLazyStringOps
-from .pyarrow_string import PyArrowStringOps
-from .sqlite_string import SqliteStringOps
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
 
-FEATURE_GROUPS: list[type[FeatureGroup]] = [
-    DuckdbStringOps,
-    PandasStringOps,
-    PolarsLazyStringOps,
-    PyArrowStringOps,
-    SqliteStringOps,
-]
+FEATURE_GROUPS: list[type[FeatureGroup]] = load_plugin_classes(
+    __package__ or __name__.rpartition(".")[0],
+    [
+        ("duckdb_string", "DuckdbStringOps"),
+        ("pandas_string", "PandasStringOps"),
+        ("polars_lazy_string", "PolarsLazyStringOps"),
+        ("pyarrow_string", "PyArrowStringOps"),
+        ("sqlite_string", "SqliteStringOps"),
+    ],
+)

--- a/mloda/community/feature_groups/data_operations/string/manifest.py
+++ b/mloda/community/feature_groups/data_operations/string/manifest.py
@@ -1,0 +1,23 @@
+"""Entry-point manifest for mloda-community-string.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .duckdb_string import DuckdbStringOps
+from .pandas_string import PandasStringOps
+from .polars_lazy_string import PolarsLazyStringOps
+from .pyarrow_string import PyArrowStringOps
+from .sqlite_string import SqliteStringOps
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    DuckdbStringOps,
+    PandasStringOps,
+    PolarsLazyStringOps,
+    PyArrowStringOps,
+    SqliteStringOps,
+]

--- a/mloda/community/feature_groups/data_operations/string/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/string/pyproject.toml
@@ -21,6 +21,9 @@ dev = ["mloda-testing", "pytest>=9.0.3"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-string = "mloda.community.feature_groups.data_operations.string.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../.."}
 packages = ["mloda.community.feature_groups.data_operations.string"]

--- a/mloda/community/feature_groups/example/example_a/manifest.py
+++ b/mloda/community/feature_groups/example/example_a/manifest.py
@@ -1,0 +1,15 @@
+"""Entry-point manifest for mloda-community-example-a.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .example_a_feature_group import ExampleAFeatureGroup
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    ExampleAFeatureGroup,
+]

--- a/mloda/community/feature_groups/example/example_a/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_a/pyproject.toml
@@ -21,6 +21,9 @@ dev = ["mloda-testing", "pytest>=9.0.3"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-example-a = "mloda.community.feature_groups.example.example_a.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../.."}
 packages = ["mloda.community.feature_groups.example.example_a"]

--- a/mloda/community/feature_groups/example/example_b/manifest.py
+++ b/mloda/community/feature_groups/example/example_b/manifest.py
@@ -1,0 +1,15 @@
+"""Entry-point manifest for mloda-community-example-b.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .example_b_feature_group import ExampleBFeatureGroup
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    ExampleBFeatureGroup,
+]

--- a/mloda/community/feature_groups/example/example_b/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_b/pyproject.toml
@@ -21,6 +21,9 @@ dev = ["mloda-testing", "pytest>=9.0.3"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-example-b = "mloda.community.feature_groups.example.example_b.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../../.."}
 packages = ["mloda.community.feature_groups.example.example_b"]

--- a/mloda/community/feature_groups/example/manifest.py
+++ b/mloda/community/feature_groups/example/manifest.py
@@ -1,0 +1,15 @@
+"""Entry-point manifest for mloda-community-example.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .community_example_feature_group import CommunityExampleFeatureGroup
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    CommunityExampleFeatureGroup,
+]

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -22,6 +22,9 @@ all = ["mloda-community-example-a", "mloda-community-example-b"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-example = "mloda.community.feature_groups.example.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../.."}
 packages = ["mloda.community.feature_groups.example"]

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -18,6 +18,34 @@ requires-python = ">=3.10,<3.15"
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-community-aggregation = "mloda.community.feature_groups.data_operations.aggregation.manifest:FEATURE_GROUPS"
+mloda-community-binning = "mloda.community.feature_groups.data_operations.row_preserving.binning.manifest:FEATURE_GROUPS"
+mloda-community-datetime = "mloda.community.feature_groups.data_operations.row_preserving.datetime.manifest:FEATURE_GROUPS"
+mloda-community-ema = "mloda.community.feature_groups.data_operations.row_preserving.ema.manifest:FEATURE_GROUPS"
+mloda-community-example = "mloda.community.feature_groups.example.manifest:FEATURE_GROUPS"
+mloda-community-example-a = "mloda.community.feature_groups.example.example_a.manifest:FEATURE_GROUPS"
+mloda-community-example-b = "mloda.community.feature_groups.example.example_b.manifest:FEATURE_GROUPS"
+mloda-community-ffill = "mloda.community.feature_groups.data_operations.row_preserving.ffill.manifest:FEATURE_GROUPS"
+mloda-community-frame-aggregate = "mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.manifest:FEATURE_GROUPS"
+mloda-community-offset = "mloda.community.feature_groups.data_operations.row_preserving.offset.manifest:FEATURE_GROUPS"
+mloda-community-percentile = "mloda.community.feature_groups.data_operations.row_preserving.percentile.manifest:FEATURE_GROUPS"
+mloda-community-point-arithmetic = "mloda.community.feature_groups.data_operations.row_preserving.point_arithmetic.manifest:FEATURE_GROUPS"
+mloda-community-rank = "mloda.community.feature_groups.data_operations.row_preserving.rank.manifest:FEATURE_GROUPS"
+mloda-community-resample = "mloda.community.feature_groups.data_operations.row_changing.resample.manifest:FEATURE_GROUPS"
+mloda-community-scalar-aggregate = "mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.manifest:FEATURE_GROUPS"
+mloda-community-scalar-arithmetic = "mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.manifest:FEATURE_GROUPS"
+mloda-community-sessionization = "mloda.community.feature_groups.data_operations.row_preserving.sessionization.manifest:FEATURE_GROUPS"
+mloda-community-string = "mloda.community.feature_groups.data_operations.string.manifest:FEATURE_GROUPS"
+mloda-community-time-bucketization = "mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.manifest:FEATURE_GROUPS"
+mloda-community-window-aggregation = "mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.manifest:FEATURE_GROUPS"
+
+[project.entry-points."mloda.compute_frameworks"]
+mloda-community-compute-frameworks-example = "mloda.community.compute_frameworks.example.manifest:COMPUTE_FRAMEWORKS"
+
+[project.entry-points."mloda.extenders"]
+mloda-community-extenders-example = "mloda.community.extenders.example.manifest:EXTENDERS"
+
 [tool.setuptools]
 package-dir = {"" = "../.."}
 packages = ["mloda.community.compute_frameworks.example", "mloda.community.extenders.example", "mloda.community.feature_groups.data_operations", "mloda.community.feature_groups.data_operations.aggregation", "mloda.community.feature_groups.data_operations.row_changing", "mloda.community.feature_groups.data_operations.row_changing.resample", "mloda.community.feature_groups.data_operations.row_preserving", "mloda.community.feature_groups.data_operations.row_preserving.arithmetic", "mloda.community.feature_groups.data_operations.row_preserving.binning", "mloda.community.feature_groups.data_operations.row_preserving.datetime", "mloda.community.feature_groups.data_operations.row_preserving.ema", "mloda.community.feature_groups.data_operations.row_preserving.ffill", "mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate", "mloda.community.feature_groups.data_operations.row_preserving.offset", "mloda.community.feature_groups.data_operations.row_preserving.percentile", "mloda.community.feature_groups.data_operations.row_preserving.point_arithmetic", "mloda.community.feature_groups.data_operations.row_preserving.rank", "mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate", "mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic", "mloda.community.feature_groups.data_operations.row_preserving.sessionization", "mloda.community.feature_groups.data_operations.row_preserving.time_bucketization", "mloda.community.feature_groups.data_operations.row_preserving.window_aggregation", "mloda.community.feature_groups.data_operations.string", "mloda.community.feature_groups.example", "mloda.community.feature_groups.example.example_a", "mloda.community.feature_groups.example.example_b"]

--- a/mloda/enterprise/compute_frameworks/example/manifest.py
+++ b/mloda/enterprise/compute_frameworks/example/manifest.py
@@ -1,0 +1,15 @@
+"""Entry-point manifest for mloda-enterprise-compute-frameworks-example.
+
+Lists the concrete ComputeFramework classes that mloda discovers via the
+``mloda.compute_frameworks`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import ComputeFramework
+
+from .enterprise_example_compute_framework import EnterpriseExampleComputeFramework
+
+COMPUTE_FRAMEWORKS: list[type[ComputeFramework]] = [
+    EnterpriseExampleComputeFramework,
+]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -21,6 +21,9 @@ dev = ["mloda-testing", "pytest>=9.0.3"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.compute_frameworks"]
+mloda-enterprise-compute-frameworks-example = "mloda.enterprise.compute_frameworks.example.manifest:COMPUTE_FRAMEWORKS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../.."}
 packages = ["mloda.enterprise.compute_frameworks.example"]

--- a/mloda/enterprise/extenders/example/manifest.py
+++ b/mloda/enterprise/extenders/example/manifest.py
@@ -1,0 +1,15 @@
+"""Entry-point manifest for mloda-enterprise-extenders-example.
+
+Lists the concrete Extender classes that mloda discovers via the
+``mloda.extenders`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.steward import Extender
+
+from .enterprise_example_extender import EnterpriseExampleExtender
+
+EXTENDERS: list[type[Extender]] = [
+    EnterpriseExampleExtender,
+]

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -21,6 +21,9 @@ dev = ["mloda-testing", "pytest>=9.0.3"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.extenders"]
+mloda-enterprise-extenders-example = "mloda.enterprise.extenders.example.manifest:EXTENDERS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../.."}
 packages = ["mloda.enterprise.extenders.example"]

--- a/mloda/enterprise/feature_groups/example/manifest.py
+++ b/mloda/enterprise/feature_groups/example/manifest.py
@@ -1,0 +1,15 @@
+"""Entry-point manifest for mloda-enterprise-example.
+
+Lists the concrete FeatureGroup classes that mloda discovers via the
+``mloda.feature_groups`` entry point. See issue #271.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import FeatureGroup
+
+from .enterprise_example_feature_group import EnterpriseExampleFeatureGroup
+
+FEATURE_GROUPS: list[type[FeatureGroup]] = [
+    EnterpriseExampleFeatureGroup,
+]

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -21,6 +21,9 @@ dev = ["mloda-testing", "pytest>=9.0.3"]
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-enterprise-example = "mloda.enterprise.feature_groups.example.manifest:FEATURE_GROUPS"
+
 [tool.setuptools]
 package-dir = {"" = "../../../.."}
 packages = ["mloda.enterprise.feature_groups.example"]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -18,6 +18,15 @@ requires-python = ">=3.10,<3.15"
 Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
+[project.entry-points."mloda.feature_groups"]
+mloda-enterprise-example = "mloda.enterprise.feature_groups.example.manifest:FEATURE_GROUPS"
+
+[project.entry-points."mloda.compute_frameworks"]
+mloda-enterprise-compute-frameworks-example = "mloda.enterprise.compute_frameworks.example.manifest:COMPUTE_FRAMEWORKS"
+
+[project.entry-points."mloda.extenders"]
+mloda-enterprise-extenders-example = "mloda.enterprise.extenders.example.manifest:EXTENDERS"
+
 [tool.setuptools]
 package-dir = {"" = "../.."}
 packages = ["mloda.enterprise.compute_frameworks.example", "mloda.enterprise.extenders.example", "mloda.enterprise.feature_groups.example"]

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -29,6 +29,51 @@ HEADER = """\
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 """
 
+# Entry-point group -> manifest attribute exposing the concrete plugin classes.
+# mloda 0.9.0 discovers installed plugins through these entry-point groups; each
+# plugin package ships a ``manifest.py`` listing its concrete plugin classes
+# under the mapped attribute. See issue #271.
+ENTRY_POINT_ATTRS = {
+    "mloda.feature_groups": "FEATURE_GROUPS",
+    "mloda.compute_frameworks": "COMPUTE_FRAMEWORKS",
+    "mloda.extenders": "EXTENDERS",
+}
+
+
+def compute_entry_points(
+    pkg_name: str,
+    pkg_config: dict[str, Any],
+    all_packages: dict[str, dict[str, Any]],
+) -> dict[str, list[tuple[str, str]]]:
+    """Compute entry-point tables for a package.
+
+    Returns a mapping of entry-point group -> sorted list of ``(label, value)``
+    pairs, where ``value`` is the canonical ``<dotted>.manifest:<ATTR>`` target.
+
+    Bundle packages (``entry_point_bundle = true``) aggregate the entry points of
+    every nested plugin package whose path lives under the bundle path. Regular
+    plugin packages emit their own declared ``entry_point_groups``.
+    """
+    result: dict[str, list[tuple[str, str]]] = {}
+
+    if pkg_config.get("entry_point_bundle"):
+        bundle_prefix = pkg_config["path"].rstrip("/") + "/"
+        for name, cfg in all_packages.items():
+            groups = cfg.get("entry_point_groups")
+            if not groups:
+                continue
+            if not cfg["path"].startswith(bundle_prefix):
+                continue
+            for group in groups:
+                value = f"{cfg['path'].replace('/', '.')}.manifest:{ENTRY_POINT_ATTRS[group]}"
+                result.setdefault(group, []).append((name, value))
+    else:
+        for group in pkg_config.get("entry_point_groups", []):
+            value = f"{pkg_config['path'].replace('/', '.')}.manifest:{ENTRY_POINT_ATTRS[group]}"
+            result.setdefault(group, []).append((pkg_name, value))
+
+    return {group: sorted(pairs, key=lambda pair: pair[0]) for group, pairs in result.items() if pairs}
+
 
 def to_toml_list(items: list[str]) -> str:
     """Format a list as TOML with double quotes."""
@@ -148,6 +193,19 @@ def generate_pyproject(
     for key, value in shared["project"]["urls"].items():
         lines.append(f'{key} = "{value}"')
     lines.append("")
+
+    # Entry points - mloda plugin discovery (issue #271). Emit groups in the
+    # stable ENTRY_POINT_ATTRS insertion order; entry-point labels are
+    # distribution names containing hyphens, which are valid bare TOML keys.
+    entry_points = compute_entry_points(pkg_name, pkg_config, all_packages)
+    for group in ENTRY_POINT_ATTRS:
+        pairs = entry_points.get(group)
+        if not pairs:
+            continue
+        lines.append(f'[project.entry-points."{group}"]')
+        for label, value in pairs:
+            lines.append(f'{label} = "{value}"')
+        lines.append("")
 
     # Setuptools config - infer meta-package from workspace_deps
     if "workspace_deps" in pkg_config:

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -54,6 +54,9 @@ def compute_entry_points(
     every nested plugin package whose path lives under the bundle path. Regular
     plugin packages emit their own declared ``entry_point_groups``.
     """
+    if pkg_config.get("entry_point_bundle") and pkg_config.get("entry_point_groups"):
+        raise ValueError(f"{pkg_name}: entry_point_bundle and entry_point_groups are mutually exclusive")
+
     result: dict[str, list[tuple[str, str]]] = {}
 
     if pkg_config.get("entry_point_bundle"):

--- a/scripts/verify_builds.py
+++ b/scripts/verify_builds.py
@@ -156,7 +156,9 @@ def get_wheel_entry_points(wheel_path: Path) -> dict[str, dict[str, str]]:
             return {}
         content = zf.read(entry_points_name).decode()
 
-    parser = configparser.ConfigParser()
+    # interpolation=None so a literal "%" in an entry-point value (e.g. a module
+    # path or object ref) cannot raise InterpolationSyntaxError.
+    parser = configparser.ConfigParser(interpolation=None)
     parser.read_string(content)
 
     result: dict[str, dict[str, str]] = {}

--- a/scripts/verify_builds.py
+++ b/scripts/verify_builds.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import configparser
 import shutil
 import subprocess
 import sys
@@ -15,50 +16,44 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
 
-PACKAGES = [
-    ("mloda-registry", "mloda/registry/pyproject.toml"),
-    ("mloda-testing", "mloda/testing/pyproject.toml"),
-    ("mloda-community", "mloda/community/pyproject.toml"),
-    ("mloda-enterprise", "mloda/enterprise/pyproject.toml"),
-    ("mloda-community-example", "mloda/community/feature_groups/example/pyproject.toml"),
-    ("mloda-enterprise-example", "mloda/enterprise/feature_groups/example/pyproject.toml"),
-    ("mloda-community-example-a", "mloda/community/feature_groups/example/example_a/pyproject.toml"),
-    ("mloda-community-example-b", "mloda/community/feature_groups/example/example_b/pyproject.toml"),
-    ("mloda-community-data-operations", "mloda/community/feature_groups/data_operations/pyproject.toml"),
-    ("mloda-community-aggregation", "mloda/community/feature_groups/data_operations/aggregation/pyproject.toml"),
-    ("mloda-community-rank", "mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml"),
-    ("mloda-community-offset", "mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml"),
-    (
-        "mloda-community-window-aggregation",
-        "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml",
-    ),
-    (
-        "mloda-community-frame-aggregate",
-        "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml",
-    ),
-    (
-        "mloda-community-scalar-aggregate",
-        "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml",
-    ),
-    (
-        "mloda-community-scalar-arithmetic",
-        "mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml",
-    ),
-    (
-        "mloda-community-point-arithmetic",
-        "mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml",
-    ),
-    (
-        "mloda-community-datetime",
-        "mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml",
-    ),
-    ("mloda-community-string", "mloda/community/feature_groups/data_operations/string/pyproject.toml"),
-    ("mloda-community-binning", "mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml"),
-    (
-        "mloda-community-percentile",
-        "mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml",
-    ),
-]
+CONFIG_DIR = Path("config")
+PACKAGES_CONFIG = CONFIG_DIR / "packages.toml"
+
+# Valid manifest attributes for the mloda plugin entry-point groups (issue #271).
+_VALID_ENTRY_POINT_ATTRS = {"FEATURE_GROUPS", "COMPUTE_FRAMEWORKS", "EXTENDERS"}
+
+
+def load_packages_from_config() -> list[tuple[str, str]]:
+    """Return [(pkg_name, pyproject_path), ...] for every configured package, in config order."""
+    with open(PACKAGES_CONFIG, "rb") as f:
+        data = tomllib.load(f)
+    packages = data.get("packages", {})
+    return [(name, f"{cfg['path']}/pyproject.toml") for name, cfg in packages.items()]
+
+
+PACKAGES = load_packages_from_config()
+
+
+def namespaced_entry_point_error(group: str, name: str, value: str) -> str | None:
+    """Return an error message if an entry-point target is not a valid namespaced manifest, else None."""
+    if ":" not in value:
+        return f"{group}: entry point {name!r} value {value!r} has no ':' manifest-attribute separator"
+
+    module, _, attr = value.partition(":")
+
+    if not (module.startswith("mloda.community.") or module.startswith("mloda.enterprise.")):
+        return (
+            f"{group}: entry point {name!r} module {module!r} is not under the "
+            "'mloda.community.' or 'mloda.enterprise.' namespace"
+        )
+
+    if not module.endswith(".manifest"):
+        return f"{group}: entry point {name!r} module {module!r} does not end with '.manifest'"
+
+    if attr not in _VALID_ENTRY_POINT_ATTRS:
+        return f"{group}: entry point {name!r} attribute {attr!r} is not one of {sorted(_VALID_ENTRY_POINT_ATTRS)}"
+
+    return None
 
 
 def get_versions_from_pyproject() -> dict[str, str]:
@@ -141,6 +136,62 @@ def verify_wheel_metadata(wheels: dict[str, Path]) -> list[str]:
             init_file = f"{ns_dir}__init__.py"
             if init_file in files:
                 errors.append(f"{pkg_name}: contains {init_file} (breaks PEP 420 namespace package)")
+
+    return errors
+
+
+def get_wheel_entry_points(wheel_path: Path) -> dict[str, dict[str, str]]:
+    """Read a wheel's dist-info entry_points.txt, returning only mloda.* groups.
+
+    Returns {group: {name: value}} for every entry-point group whose name starts
+    with ``mloda.``. Returns {} if the wheel has no entry_points.txt.
+    """
+    with zipfile.ZipFile(wheel_path) as zf:
+        entry_points_name = None
+        for name in zf.namelist():
+            if name.endswith(".dist-info/entry_points.txt"):
+                entry_points_name = name
+                break
+        if entry_points_name is None:
+            return {}
+        content = zf.read(entry_points_name).decode()
+
+    parser = configparser.ConfigParser()
+    parser.read_string(content)
+
+    result: dict[str, dict[str, str]] = {}
+    for group in parser.sections():
+        if not group.startswith("mloda."):
+            continue
+        result[group] = {name: value for name, value in parser.items(group)}
+    return result
+
+
+def verify_entry_points(built_wheels: dict[str, Path]) -> list[str]:
+    """Verify built wheels declare the mloda.* entry points from their generated pyproject.toml."""
+    errors: list[str] = []
+    pyproject_paths = dict(load_packages_from_config())
+
+    for pkg_name, wheel_path in built_wheels.items():
+        pyproject_path = pyproject_paths.get(pkg_name)
+        if pyproject_path is None or not Path(pyproject_path).exists():
+            continue
+
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+        all_entry_points = data.get("project", {}).get("entry-points", {})
+        expected = {group: mapping for group, mapping in all_entry_points.items() if group.startswith("mloda.")}
+
+        actual = get_wheel_entry_points(wheel_path)
+
+        if expected != actual:
+            errors.append(f"{pkg_name}: entry points mismatch (expected {expected}, wheel has {actual})")
+
+        for group, mapping in actual.items():
+            for name, value in mapping.items():
+                error = namespaced_entry_point_error(group, name, value)
+                if error is not None:
+                    errors.append(f"{pkg_name}: {error}")
 
     return errors
 
@@ -272,6 +323,14 @@ def main() -> int:
             errors.extend(metadata_errors)
         else:
             print("  ✓ wheel metadata correct")
+
+        # Verify mloda plugin entry points (issue #271)
+        print("\nVerifying entry points...")
+        entry_point_errors = verify_entry_points(built_wheels)
+        if entry_point_errors:
+            errors.extend(entry_point_errors)
+        else:
+            print("  ✓ entry points correct")
 
     # Verify PEP 420 source compliance (outside temp dir context)
     print("\nVerifying PEP 420 source compliance...")

--- a/tests/test_end2end/test_entry_points.py
+++ b/tests/test_end2end/test_entry_points.py
@@ -212,6 +212,52 @@ def test_manifest_modules_list_only_concrete_plugins() -> None:
                 )
 
 
+def test_bundle_and_groups_are_mutually_exclusive() -> None:
+    """A package config declaring both entry_point_bundle and entry_point_groups must be rejected."""
+    pkg_config: dict[str, Any] = {
+        "path": "mloda/community",
+        "entry_point_bundle": True,
+        "entry_point_groups": ["mloda.feature_groups"],
+    }
+    all_packages: dict[str, dict[str, Any]] = {"mloda-bogus": pkg_config}
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        gen.compute_entry_points("mloda-bogus", pkg_config, all_packages)
+
+
+# 0.3.3 is the first registry release shipping manifest_utils, which the
+# data_operations manifest.py files import; older floors permit installs
+# whose entry points fail silently at discovery time.
+_MANIFEST_UTILS_MIN = (0, 3, 3)
+
+_DATA_OPERATIONS_PREFIX = "mloda/community/feature_groups/data_operations/"
+_DATA_OPERATIONS_DEP_PREFIX = "mloda-community-data-operations>="
+
+
+def test_data_operations_plugins_require_manifest_utils_capable_floor() -> None:
+    """data_operations plugin packages must require a manifest_utils-capable base package."""
+    _shared, packages_config = gen.load_configs()
+    packages: dict[str, dict[str, Any]] = packages_config["packages"]
+
+    checked = 0
+    for pkg_name, pkg_config in packages.items():
+        if not pkg_config.get("entry_point_groups"):
+            continue
+        if not pkg_config["path"].startswith(_DATA_OPERATIONS_PREFIX):
+            continue
+        for dep in pkg_config.get("dependencies", []):
+            if not dep.startswith(_DATA_OPERATIONS_DEP_PREFIX):
+                continue
+            checked += 1
+            floor = tuple(int(part) for part in dep.removeprefix(_DATA_OPERATIONS_DEP_PREFIX).split("."))
+            assert floor >= _MANIFEST_UTILS_MIN, (
+                f"{pkg_name}: dependency {dep!r} permits versions without manifest_utils; "
+                f"the floor must be >= {'.'.join(str(p) for p in _MANIFEST_UTILS_MIN)}"
+            )
+
+    assert checked, "expected at least one data_operations plugin package with a base-package dependency"
+
+
 def test_verify_builds_namespace_helper() -> None:
     """verify_builds must expose namespaced_entry_point_error validating entry-point targets."""
     helper = getattr(vb, "namespaced_entry_point_error", None)

--- a/tests/test_end2end/test_entry_points.py
+++ b/tests/test_end2end/test_entry_points.py
@@ -1,0 +1,239 @@
+"""Entry-point declaration tests for issue #271.
+
+mloda 0.9.0 discovers installed plugins through the entry-point groups
+``mloda.feature_groups``, ``mloda.compute_frameworks`` and ``mloda.extenders``.
+Each plugin package ships a ``manifest.py`` module exposing a list of concrete
+plugin classes under a per-group attribute (``FEATURE_GROUPS``,
+``COMPUTE_FRAMEWORKS`` or ``EXTENDERS``). The generator
+``scripts/generate_pyproject.py`` must emit a
+``[project.entry-points."<group>"]`` table whose entry name is the distribution
+label and whose value is the canonical ``<dotted>.manifest:<ATTR>`` target.
+Bundle packages (``mloda-community`` / ``mloda-enterprise``) aggregate the entry
+points of every nested plugin package under their path.
+
+Both the generator and the ``scripts/verify_builds.py`` script live as loose
+scripts (not installed packages), so they are loaded here by file path using the
+same ``importlib.util`` pattern as ``test_generate_pyproject_guards.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import inspect
+import re
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+import pytest
+
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
+_VERIFY_BUILDS_PATH = _REPO_ROOT / "scripts" / "verify_builds.py"
+
+# The three valid entry-point groups mapped to (manifest attribute, base type).
+_GROUP_INFO: dict[str, tuple[str, type]] = {
+    "mloda.feature_groups": ("FEATURE_GROUPS", FeatureGroup),
+    "mloda.compute_frameworks": ("COMPUTE_FRAMEWORKS", ComputeFramework),
+    "mloda.extenders": ("EXTENDERS", Extender),
+}
+
+_VALUE_PATTERN = re.compile(
+    r"^(mloda\.community\.|mloda\.enterprise\.).*\.manifest:(FEATURE_GROUPS|COMPUTE_FRAMEWORKS|EXTENDERS)$"
+)
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    """Import a loose script by file path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"could not load spec for {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gen = _load_module("generate_pyproject", _GEN_PATH)
+vb = _load_module("verify_builds", _VERIFY_BUILDS_PATH)
+
+
+def _generate(pkg_name: str) -> str:
+    """Load configs and generate the pyproject text for a single package."""
+    shared, packages_config = gen.load_configs()
+    packages = packages_config["packages"]
+    return str(gen.generate_pyproject(pkg_name, packages[pkg_name], shared, packages))
+
+
+def test_feature_group_package_declares_entry_point() -> None:
+    """A FeatureGroup plugin package must declare a mloda.feature_groups entry point."""
+    content = _generate("mloda-community-ffill")
+    assert '[project.entry-points."mloda.feature_groups"]' in content, content
+    assert (
+        'mloda-community-ffill = "mloda.community.feature_groups.data_operations.row_preserving.ffill.manifest:FEATURE_GROUPS"'
+        in content
+    ), content
+
+
+def test_compute_framework_package_declares_entry_point() -> None:
+    """A ComputeFramework plugin package must declare a mloda.compute_frameworks entry point."""
+    content = _generate("mloda-community-compute-frameworks-example")
+    assert '[project.entry-points."mloda.compute_frameworks"]' in content, content
+    assert (
+        'mloda-community-compute-frameworks-example = "mloda.community.compute_frameworks.example.manifest:COMPUTE_FRAMEWORKS"'
+        in content
+    ), content
+
+
+def test_extender_package_declares_entry_point() -> None:
+    """An Extender plugin package must declare a mloda.extenders entry point."""
+    content = _generate("mloda-community-extenders-example")
+    assert '[project.entry-points."mloda.extenders"]' in content, content
+    assert 'mloda-community-extenders-example = "mloda.community.extenders.example.manifest:EXTENDERS"' in content, (
+        content
+    )
+
+
+def test_bundle_aggregates_child_entry_points() -> None:
+    """Bundle packages must aggregate the entry points of all nested plugin packages."""
+    community = _generate("mloda-community")
+
+    assert '[project.entry-points."mloda.feature_groups"]' in community, community
+    assert (
+        'mloda-community-ffill = "mloda.community.feature_groups.data_operations.row_preserving.ffill.manifest:FEATURE_GROUPS"'
+        in community
+    ), community
+    assert 'mloda-community-example = "mloda.community.feature_groups.example.manifest:FEATURE_GROUPS"' in community, (
+        community
+    )
+
+    assert '[project.entry-points."mloda.compute_frameworks"]' in community, community
+    assert (
+        'mloda-community-compute-frameworks-example = "mloda.community.compute_frameworks.example.manifest:COMPUTE_FRAMEWORKS"'
+        in community
+    ), community
+
+    assert '[project.entry-points."mloda.extenders"]' in community, community
+    assert 'mloda-community-extenders-example = "mloda.community.extenders.example.manifest:EXTENDERS"' in community, (
+        community
+    )
+
+    enterprise = _generate("mloda-enterprise")
+
+    assert '[project.entry-points."mloda.feature_groups"]' in enterprise, enterprise
+    assert (
+        'mloda-enterprise-example = "mloda.enterprise.feature_groups.example.manifest:FEATURE_GROUPS"' in enterprise
+    ), enterprise
+
+    assert '[project.entry-points."mloda.compute_frameworks"]' in enterprise, enterprise
+    assert (
+        'mloda-enterprise-compute-frameworks-example = "mloda.enterprise.compute_frameworks.example.manifest:COMPUTE_FRAMEWORKS"'
+        in enterprise
+    ), enterprise
+
+    assert '[project.entry-points."mloda.extenders"]' in enterprise, enterprise
+    assert (
+        'mloda-enterprise-extenders-example = "mloda.enterprise.extenders.example.manifest:EXTENDERS"' in enterprise
+    ), enterprise
+
+
+@pytest.mark.parametrize(
+    "pkg_name",
+    ["mloda-registry", "mloda-testing", "mloda-community-data-operations"],
+)
+def test_non_plugin_packages_have_no_entry_points(pkg_name: str) -> None:
+    """Non-plugin packages (tools, test utilities, shared bases) declare no entry points."""
+    content = _generate(pkg_name)
+    assert "[project.entry-points." not in content, content
+
+
+def test_all_entry_point_values_are_namespaced_manifests() -> None:
+    """Every emitted entry-point target must be a namespaced ``.manifest:<ATTR>`` value."""
+    shared, packages_config = gen.load_configs()
+    packages: dict[str, dict[str, Any]] = packages_config["packages"]
+
+    for pkg_name, pkg_config in packages.items():
+        content = gen.generate_pyproject(pkg_name, pkg_config, shared, packages)
+        data = tomllib.loads(content)
+        entry_points = data.get("project", {}).get("entry-points")
+        if not entry_points:
+            continue
+        for group, mapping in entry_points.items():
+            assert group in _GROUP_INFO, f"{pkg_name}: unexpected entry-point group {group!r}"
+            for name, value in mapping.items():
+                assert _VALUE_PATTERN.match(value), (
+                    f"{pkg_name}: entry point {name!r} in group {group!r} has non-namespaced-manifest value {value!r}"
+                )
+
+
+def _plugin_packages() -> list[tuple[str, dict[str, Any]]]:
+    """Config-driven list of plugin packages (those declaring entry_point_groups)."""
+    _shared, packages_config = gen.load_configs()
+    packages: dict[str, dict[str, Any]] = packages_config["packages"]
+    return [(name, cfg) for name, cfg in packages.items() if cfg.get("entry_point_groups")]
+
+
+def test_manifest_modules_list_only_concrete_plugins() -> None:
+    """Each manifest attribute must list only concrete, correctly based, non-shared plugin classes."""
+    plugin_packages = _plugin_packages()
+    assert plugin_packages, "expected at least one package with entry_point_groups declared in config"
+
+    for pkg_name, pkg_config in plugin_packages:
+        dotted = pkg_config["path"].replace("/", ".")
+        manifest_name = f"{dotted}.manifest"
+        module = importlib.import_module(manifest_name)
+
+        for group in pkg_config["entry_point_groups"]:
+            assert group in _GROUP_INFO, f"{pkg_name}: unexpected entry-point group {group!r}"
+            attr_name, base_type = _GROUP_INFO[group]
+            assert hasattr(module, attr_name), f"{manifest_name}: missing attribute {attr_name}"
+            plugins = getattr(module, attr_name)
+
+            assert isinstance(plugins, list), f"{manifest_name}.{attr_name} must be a list"
+            assert plugins, f"{manifest_name}.{attr_name} must be non-empty"
+
+            for cls in plugins:
+                assert inspect.isclass(cls), f"{manifest_name}.{attr_name}: {cls!r} is not a class"
+                assert not inspect.isabstract(cls), f"{manifest_name}.{attr_name}: {cls!r} is abstract"
+                assert issubclass(cls, base_type), (
+                    f"{manifest_name}.{attr_name}: {cls!r} is not a subclass of {base_type.__name__}"
+                )
+                assert not (cls.__module__.endswith(".base") or cls.__module__.endswith("_base")), (
+                    f"{manifest_name}.{attr_name}: {cls!r} is a shared base class ({cls.__module__})"
+                )
+
+
+def test_verify_builds_namespace_helper() -> None:
+    """verify_builds must expose namespaced_entry_point_error validating entry-point targets."""
+    helper = getattr(vb, "namespaced_entry_point_error", None)
+    assert callable(helper), "verify_builds.namespaced_entry_point_error must be a callable"
+
+    # Valid target -> no error.
+    assert (
+        helper(
+            "mloda.feature_groups",
+            "mloda-community-ffill",
+            "mloda.community.feature_groups.data_operations.row_preserving.ffill.manifest:FEATURE_GROUPS",
+        )
+        is None
+    )
+
+    # Value not under the mloda namespace -> error.
+    assert helper("mloda.feature_groups", "some-pkg", "some_pkg.manifest:FEATURE_GROUPS") is not None
+
+    # Module does not end in .manifest -> error.
+    assert (
+        helper("mloda.feature_groups", "mloda-community-foo", "mloda.community.foo.plugins:FEATURE_GROUPS") is not None
+    )
+
+    # Attribute not one of the three allowed -> error.
+    assert helper("mloda.feature_groups", "mloda-community-foo", "mloda.community.foo.manifest:PLUGINS") is not None

--- a/tests/test_end2end/test_manifest_resilience.py
+++ b/tests/test_end2end/test_manifest_resilience.py
@@ -1,0 +1,62 @@
+"""Unit tests for the resilient manifest loader helper (issue #271).
+
+``load_plugin_classes`` builds an entry-point manifest's class list by importing
+each backend module individually. A backend whose optional compute framework
+(pandas, polars, duckdb, pyarrow) is not installed must be skipped so the rest
+still register, while any other import error must stay loud. These tests drive
+that behaviour by monkeypatching the helper module's ``importlib.import_module``,
+so they need no optional framework installed and touch no network.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from mloda.community.feature_groups.data_operations.manifest_utils import load_plugin_classes
+
+_IMPORT_MODULE_TARGET = "mloda.community.feature_groups.data_operations.manifest_utils.importlib.import_module"
+
+
+class _KeptClass:
+    """Placeholder class returned by a successfully imported backend."""
+
+
+def test_skips_backend_with_missing_optional_framework(monkeypatch: pytest.MonkeyPatch) -> None:
+    kept_module = SimpleNamespace(KeptClass=_KeptClass)
+
+    def fake_import(name: str) -> Any:
+        if name.endswith("polars_backend"):
+            raise ModuleNotFoundError("No module named 'polars'", name="polars")
+        return kept_module
+
+    monkeypatch.setattr(_IMPORT_MODULE_TARGET, fake_import)
+
+    classes = load_plugin_classes(
+        "pkg",
+        [
+            ("polars_backend", "PolarsClass"),
+            ("pandas_backend", "KeptClass"),
+        ],
+    )
+
+    assert [c.__name__ for c in classes] == ["_KeptClass"]
+
+
+def test_reraises_non_optional_module_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_import(name: str) -> ModuleType:
+        raise ModuleNotFoundError(
+            "No module named 'mloda.community.foo.bar'",
+            name="mloda.community.foo.bar",
+        )
+
+    monkeypatch.setattr(_IMPORT_MODULE_TARGET, fake_import)
+
+    with pytest.raises(ModuleNotFoundError):
+        load_plugin_classes("pkg", [("missing_backend", "MissingClass")])
+
+
+def test_empty_specs_returns_empty_list() -> None:
+    assert load_plugin_classes("pkg", []) == []


### PR DESCRIPTION
Temporary CI probe to bisect the PR #289 CI failure. Contains only the test and generator changes from df96778 on top of eb5692b (the floor test is expected to fail here; the signal is whether test_manifest_modules_list_only_concrete_plugins hits the ModuleNotFoundError). Will be closed after CI reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)