### PR TITLE
feat(data_operations): runtime DataOperationsCatalog derived from the capability hook

### DIFF
--- a/docs/guides/data-operation-patterns/01-overview.md
+++ b/docs/guides/data-operation-patterns/01-overview.md
@@ -56,6 +56,8 @@ AggregationFeatureGroup.PREFIX_PATTERN  # r".*__([\w]+)_agg$"
 StringFeatureGroup.PREFIX_PATTERN       # r".+__(upper|lower|trim|length|reverse)$"
 ```
 
+All patterns, subtypes, and per-framework support are also queryable at runtime via `DataOperationsCatalog`; see [Framework support matrix](framework-support-matrix.md#querying-capabilities-at-runtime).
+
 ---
 
 ## A minimal example

--- a/docs/guides/data-operation-patterns/framework-support-matrix.md
+++ b/docs/guides/data-operation-patterns/framework-support-matrix.md
@@ -1,21 +1,21 @@
 # Framework Support Matrix
 
-One-page lookup for "does operation *X* work on framework *Y*?". Rows are the eleven data operations (and their subtypes, where applicable); columns are the five compute frameworks mloda ships: PyArrow, Pandas, Polars lazy, DuckDB, SQLite.
+One-page lookup for "does operation *X* work on framework *Y*?". Rows are the seventeen data operations (and their subtypes, where applicable); columns are the five compute frameworks mloda ships: PyArrow, Pandas, Polars lazy, DuckDB, SQLite.
 
-**What**: A capability matrix that mirrors the `supported_*()` class methods declared on every framework test class. If a cell is ✓, the shared reference-based test suite runs that subtype against that framework and compares the result to PyArrow. If a cell is ✗, the framework either cannot express that subtype or has been deliberately excluded (see [Known divergences](known-divergences.md)).
+**What**: A capability matrix rendered from the production capability declarations (`compute_framework_rule`, the `supports_compute_framework` hook, and match-time restrictions), queryable at runtime via `DataOperationsCatalog` (`from mloda.community.feature_groups.data_operations import DataOperationsCatalog`). If a cell is ✓, the framework's production implementation declares support for that subtype and the shared reference-based test suite runs it against that framework. If a cell is ✗, the implementation rejects the subtype at match time (see [Known divergences](known-divergences.md)).
 **When**: Use before picking an op/framework pair, before adding a new framework implementation for an existing op, or while debugging why a feature resolves on one framework but skips on another.
-**Why**: The authoritative information lives in `supported_agg_types()` / `supported_ops()` / `supported_offset_types()` / `supported_rank_types()` overrides scattered across ten operation directories. This page flattens them into a single table and keeps it in sync via a drift check.
-**Where**: The tables below are guarded by a pytest drift check in `mloda/community/feature_groups/data_operations/tests/test_framework_support_matrix.py`. Do not edit the block between the `BEGIN GENERATED` and `END GENERATED` markers by hand. After changing any `supported_*()` override, run `tox` (or at minimum that one test file). If the drift check fails, regenerate the block with a coding agent so its contents match what the test produces, then rerun until the test passes.
-**How**: The test reflects each framework's test class, reads its `supported_*()` set, renders the expected block, and asserts it matches the on-disk doc. CI runs `tox`, which runs the test, so a drifted matrix fails the build.
+**Why**: The authoritative information is the capability each concrete class declares in production code. `DataOperationsCatalog` flattens those declarations into one queryable structure; this page renders it as a single table and keeps it in sync via a drift check. The test-twin `supported_*()` sets are checked mirrors of the catalog, enforced by `tests/test_twin_catalog_consistency.py`.
+**Where**: The tables below are guarded by a pytest drift check in `mloda/community/feature_groups/data_operations/tests/test_framework_support_matrix.py`. Do not edit the block between the `BEGIN GENERATED` and `END GENERATED` markers by hand. After changing any capability declaration, run `tox` (or at minimum that one test file). If the drift check fails, regenerate the block with a coding agent so its contents match what the test produces, then rerun until the test passes.
+**How**: The test queries `DataOperationsCatalog`, renders the expected block, and asserts it matches the on-disk doc. CI runs `tox`, which runs the test, so a drifted matrix fails the build.
 
 ---
 
 ## Reading the tables
 
-- The **summary** shows, per framework, whether an operation is fully covered (`full`), only partially covered (`partial (k/n)`), or absent (`--`).
-- The **per-operation detail** tables show every subtype that any framework supports, with ✓ / ✗ per cell. `--` means that framework has no test class (and therefore no implementation) for this operation.
-- A ✗ is not a bug. It is a deliberate exclusion documented in [Known divergences](known-divergences.md) or recorded by a `supported_*()` override in `*/tests/test_{framework}.py`. See the matching entry there before attempting to add support.
-- The matrix does not list every percentile quantile. For `percentile` and `datetime` the op either ships in full or does not ship at all: see the detail tables, where the single "(all)" row reflects that absence of a `supported_*()` method. For `frame_aggregate` the per-frame-type detail breaks out time-window units (`time:second`, ..., `time:year`) so framework-specific unit gaps (e.g. SQLite/Pandas rejecting `time:month`) surface as ✗ rather than being hidden behind a single `time` row.
+- The **summary** shows, per framework, whether an operation is fully supported (`full`), only partially supported (`partial (k/n)`), or absent (`--`).
+- The **per-operation detail** tables show every subtype the operation defines, with ✓ / ✗ per cell. `--` means no production implementation ships for this framework (the catalog has no entry for it).
+- A ✗ is not a bug. It is a deliberate exclusion declared by the production implementation at match time and documented in [Known divergences](known-divergences.md). The framework test class mirrors the exclusion with a `supported_*()` override in `*/tests/test_{framework}.py`, kept honest by `tests/test_twin_catalog_consistency.py`. See the matching divergence entry before attempting to add support.
+- The matrix does not list every percentile quantile. Operations without a subtype axis (`percentile`, `ffill`, `ema`, `sessionization`, `resample`) render a single "(all)" row: the op either ships in full or does not ship at all. For `frame_aggregate` the per-frame-type detail breaks out time-window units (`time:second`, ..., `time:year`) so framework-specific unit gaps (e.g. SQLite/Pandas rejecting `time:month`) surface as ✗ rather than being hidden behind a single `time` row.
 
 ## Not in this matrix: joins
 
@@ -27,11 +27,11 @@ This matrix only covers data-operation feature groups (single-source column tran
 
 ## Summary
 
-`full` means every subtype listed in the per-operation table below is supported. `partial (k/n)` means the framework's test class restricts `supported_*()` to k of the n subtypes this operation defines. `--` means the framework has no test class for this operation (typically because no production implementation exists).
+Cells reflect the production capability declarations (`compute_framework_rule`, the `supports_compute_framework` hook, and match-time restrictions), queryable via `DataOperationsCatalog`. `full` means the framework's production implementation declares support for every subtype this operation defines. `partial (k/n)` means it declares k of the n subtypes and rejects the rest. `--` means no implementation ships for this framework.
 
 | Operation | PyArrow | Pandas | Polars lazy | DuckDB | SQLite |
 |---|---|---|---|---|---|
-| aggregation | partial (15/17) | partial (16/17) | partial (16/17) | partial (16/17) | partial (5/17) |
+| aggregation | partial (15/17) | full | full | full | partial (6/17) |
 | binning | full | full | full | full | full |
 | datetime | full | full | full | full | full |
 | frame_aggregate | -- | partial (8/10) | full | full | partial (8/10) |
@@ -45,13 +45,13 @@ This matrix only covers data-operation feature groups (single-source column tran
 | ffill | full | full | full | full | full |
 | ema | -- | full | full | -- | -- |
 | sessionization | full | full | full | full | full |
-| window_aggregation | partial (15/17) | partial (16/17) | partial (16/17) | partial (16/17) | partial (5/17) |
+| window_aggregation | partial (15/17) | full | full | full | partial (6/17) |
 | string | full | full | full | full | partial (2/5) |
 | resample | full | full | full | full | -- |
 
 ## Per-operation detail
 
-✓ = the framework's test-class `supported_*()` includes this subtype. ✗ = excluded. `--` = no test class for this framework.
+✓ = the framework's production implementation declares support for this subtype. ✗ = the implementation rejects it. `--` = no implementation ships for this framework.
 
 ### aggregation
 
@@ -59,7 +59,7 @@ This matrix only covers data-operation feature groups (single-source column tran
 |---|---|---|---|---|---|
 | `sum` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `avg` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `mean` | ✓ | ✗ | ✗ | ✗ | ✗ |
+| `mean` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `count` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `min` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `max` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -86,7 +86,15 @@ This matrix only covers data-operation feature groups (single-source column tran
 
 | Op | PyArrow | Pandas | Polars lazy | DuckDB | SQLite |
 |---|---|---|---|---|---|
-| (all) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `year` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `month` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `day` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `hour` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `minute` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `second` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `dayofweek` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `is_weekend` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `quarter` | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ### frame_aggregate
 
@@ -134,11 +142,11 @@ This matrix only covers data-operation feature groups (single-source column tran
 | Agg type | PyArrow | Pandas | Polars lazy | DuckDB | SQLite |
 |---|---|---|---|---|---|
 | `sum` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `min` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `max` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `avg` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `mean` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `count` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `min` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `max` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `std` | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `var` | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `std_pop` | ✓ | ✓ | ✓ | ✓ | ✗ |
@@ -197,7 +205,7 @@ This matrix only covers data-operation feature groups (single-source column tran
 |---|---|---|---|---|---|
 | `sum` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `avg` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `mean` | ✓ | ✗ | ✗ | ✗ | ✗ |
+| `mean` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `count` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `min` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `max` | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/docs/guides/data-operation-patterns/framework-support-matrix.md
+++ b/docs/guides/data-operation-patterns/framework-support-matrix.md
@@ -17,6 +17,46 @@ One-page lookup for "does operation *X* work on framework *Y*?". Rows are the se
 - A ✗ is not a bug. It is a deliberate exclusion declared by the production implementation at match time and documented in [Known divergences](known-divergences.md). The framework test class mirrors the exclusion with a `supported_*()` override in `*/tests/test_{framework}.py`, kept honest by `tests/test_twin_catalog_consistency.py`. See the matching divergence entry before attempting to add support.
 - The matrix does not list every percentile quantile. Operations without a subtype axis (`percentile`, `ffill`, `ema`, `sessionization`, `resample`) render a single "(all)" row: the op either ships in full or does not ship at all. For `frame_aggregate` the per-frame-type detail breaks out time-window units (`time:second`, ..., `time:year`) so framework-specific unit gaps (e.g. SQLite/Pandas rejecting `time:month`) surface as ✗ rather than being hidden behind a single `time` row.
 
+## Querying capabilities at runtime
+
+Everything in this page is available programmatically through `DataOperationsCatalog`, so you can check an op/framework pair before building features instead of reading tables:
+
+```python
+from mloda.community.feature_groups.data_operations import DataOperationsCatalog
+
+# Exact cell: is median aggregation available on SQLite?
+DataOperationsCatalog.is_supported("aggregation", "median", "SqliteFramework")  # False
+DataOperationsCatalog.is_supported("aggregation", "mean", "SqliteFramework")    # True
+
+# Operation-level: does percentile ship on DuckDB at all?
+DataOperationsCatalog.is_supported("percentile", framework="DuckDBFramework")   # True
+
+# Full record: naming pattern, subtype universe, per-framework support.
+info = DataOperationsCatalog.get("aggregation")
+info.prefix_pattern            # r".*__([\w]+)_agg$"
+info.subtypes                  # ("sum", "avg", "mean", "count", ...)
+info.frameworks["SqliteFramework"]  # frozenset({"sum", "avg", "mean", "count", "min", "max"})
+
+for op in DataOperationsCatalog.list():
+    print(op.name, op.prefix_pattern)
+```
+
+Framework names are the compute framework class names (`PyArrowTable`, `PandasDataFrame`, `PolarsLazyDataFrame`, `DuckDBFramework`, `SqliteFramework`), matched case-insensitively. Unknown operations and out-of-universe subtypes raise a `ValueError` listing the valid values; an unknown framework simply returns `False`.
+
+To check a concrete feature name instead of an op/subtype pair, use core's `resolve_feature`; the same capability hook feeds both:
+
+```python
+from mloda.user import PluginLoader
+from mloda.steward import resolve_feature
+
+PluginLoader.all()
+resolved = resolve_feature("value__median_scalar")
+resolved.supported_compute_frameworks    # ["DuckDBFramework", "PandasDataFrame", ...]
+resolved.unsupported_compute_frameworks  # ["SqliteFramework"]
+```
+
+Unsupported combinations are also rejected at match time when running a pipeline, so a request pinned to an incapable framework fails at planning with a message naming the supported frameworks, not at compute.
+
 ## Not in this matrix: joins
 
 This matrix only covers data-operation feature groups (single-source column transforms). Joins are a separate concern handled by the compute frameworks' merge engines in core, not by registry feature groups, so they do not appear above. The **as-of (point-in-time) join** added in mloda 0.8.0 has its own per-backend support table and a worked example in [Links and joins](../feature-group-patterns/08-links-joins.md#as-of-point-in-time-joins).

--- a/docs/guides/data-operation-patterns/framework-support-matrix.md
+++ b/docs/guides/data-operation-patterns/framework-support-matrix.md
@@ -176,6 +176,9 @@ Cells reflect the production capability declarations (`compute_framework_rule`, 
 | `rank` | -- | ✓ | ✓ | ✓ | ✓ |
 | `dense_rank` | -- | ✓ | ✓ | ✓ | ✓ |
 | `percent_rank` | -- | ✓ | ✓ | ✓ | ✓ |
+| `ntile` | -- | ✓ | ✓ | ✓ | ✓ |
+| `top` | -- | ✓ | ✓ | ✓ | ✓ |
+| `bottom` | -- | ✓ | ✓ | ✓ | ✓ |
 
 ### scalar_aggregate
 

--- a/mloda/community/feature_groups/data_operations/__init__.py
+++ b/mloda/community/feature_groups/data_operations/__init__.py
@@ -1,1 +1,5 @@
 """mloda-community-data-operations: Shared base classes for data operation feature groups."""
+
+from mloda.community.feature_groups.data_operations.catalog import DataOperationsCatalog, OperationInfo
+
+__all__ = ["DataOperationsCatalog", "OperationInfo"]

--- a/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyarrow_aggregation.py
@@ -56,6 +56,10 @@ class PyArrowAggregation(AggregationFeatureGroup):
         return {PyArrowTable}
 
     @classmethod
+    def supported_agg_types(cls) -> frozenset[str] | None:
+        return frozenset(_SUPPORTED_AGG_TYPES)
+
+    @classmethod
     def _compute_group(
         cls,
         table: pa.Table,

--- a/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/sqlite_aggregation.py
@@ -32,6 +32,10 @@ class SqliteAggregation(AggregationFeatureGroup):
         return {SqliteFramework}
 
     @classmethod
+    def supported_agg_types(cls) -> frozenset[str] | None:
+        return frozenset(_SQLITE_AGG_FUNCS)
+
+    @classmethod
     def _compute_group(
         cls,
         data: SqliteRelation,

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_duckdb.py
@@ -23,3 +23,7 @@ class TestDuckdbAggregation(DuckdbTestMixin, AggregationTestBase):
     @classmethod
     def implementation_class(cls) -> Any:
         return DuckdbAggregation
+
+    @classmethod
+    def supported_agg_types(cls) -> set[str]:
+        return {*cls.ALL_AGG_TYPES, "mean"}

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_pandas.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_pandas.py
@@ -26,6 +26,10 @@ class TestPandasAggregation(PandasTestMixin, AggregationTestBase):
     def implementation_class(cls) -> Any:
         return PandasAggregation
 
+    @classmethod
+    def supported_agg_types(cls) -> set[str]:
+        return {*cls.ALL_AGG_TYPES, "mean"}
+
 
 class TestPandasModeVectorized:
     """Targeted tests for the vectorized ``_compute_mode`` implementation.

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_polars_lazy.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_polars_lazy.py
@@ -26,5 +26,9 @@ class TestPolarsLazyAggregation(ReservedColumnsTestMixin, PolarsLazyTestMixin, A
         return PolarsLazyAggregation
 
     @classmethod
+    def supported_agg_types(cls) -> set[str]:
+        return {*cls.ALL_AGG_TYPES, "mean"}
+
+    @classmethod
     def reserved_columns_feature_name(cls) -> str:
         return "value_int__sum_agg"

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_sqlite.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_sqlite.py
@@ -18,7 +18,7 @@ class TestSqliteAggregation(SqliteTestMixin, AggregationTestBase):
 
     @classmethod
     def supported_agg_types(cls) -> set[str]:
-        return {"sum", "avg", "count", "min", "max"}
+        return {"sum", "avg", "mean", "count", "min", "max"}
 
     @classmethod
     def implementation_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/aggregation_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation_base.py
@@ -21,7 +21,9 @@ from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
-from mloda.provider import FeatureGroup
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import ComputeFramework, FeatureGroup
 
 AGGREGATION_TYPES: dict[str, str] = {
     "sum": "Sum of values",
@@ -81,6 +83,39 @@ class AggregationFeatureGroupBase(FeatureChainParserMixin, FeatureGroup):
         if agg_type is None:
             raise ValueError(f"Could not extract aggregation type for {feature_name}")
         return str(agg_type)
+
+    @classmethod
+    def supported_agg_types(cls) -> frozenset[str] | None:
+        """Aggregation types the backend computes natively; None means unrestricted."""
+        return None
+
+    @classmethod
+    def _resolve_agg_type(cls, feature_name: str, options: Options) -> str | None:
+        """Resolve the aggregation type from the feature name or options; None if unresolvable."""
+        try:
+            operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, cls._get_prefix_patterns())
+        except ValueError:
+            return None
+        if operation_config is not None:
+            return operation_config
+        agg_type = options.get(cls.AGGREGATION_TYPE)
+        return None if agg_type is None else str(agg_type)
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        """Reject aggregation types the backend cannot compute; unresolvable stays True."""
+        supported = cls.supported_agg_types()
+        if supported is None:
+            return True
+        agg_type = cls._resolve_agg_type(str(feature_name), options)
+        if agg_type is None:
+            return True
+        return agg_type in supported
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:

--- a/mloda/community/feature_groups/data_operations/catalog.py
+++ b/mloda/community/feature_groups/data_operations/catalog.py
@@ -1,0 +1,471 @@
+"""Runtime catalog of the built-in data operations and their per-framework capability (issue #247).
+
+The catalog enumerates every built-in data operation from its production base
+class (``PREFIX_PATTERN`` and the subtype universe) and derives per-framework
+capability from the mloda match-time machinery: a subtype is supported on a
+framework iff the concrete backend class both matches a probe feature
+(``match_feature_group_criteria``) and accepts the framework
+(``supports_compute_framework``). Nothing framework-heavy is imported at module
+import time; backend modules are imported lazily and skipped when their
+optional dependency (or their whole pip package) is missing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import lru_cache
+from types import ModuleType
+from typing import Any
+
+from mloda.core.abstract_plugins.components.options import Options
+
+from mloda.community.feature_groups.data_operations.errors import (
+    _build_unsupported_value_error,
+    unsupported_op_error,
+)
+
+_PKG = "mloda.community.feature_groups.data_operations"
+
+#: Backend module filename prefixes, one per potential compute framework.
+_FRAMEWORK_MODULE_PREFIXES: tuple[str, ...] = ("pyarrow", "pandas", "polars_lazy", "duckdb", "sqlite")
+
+#: Order hints only; membership always comes from the base-class constants.
+_FRAME_TYPE_ORDER: tuple[str, ...] = ("rolling", "time", "cumulative", "expanding")
+_TIME_UNIT_ORDER: tuple[str, ...] = ("second", "minute", "hour", "day", "week", "month", "year")
+
+
+@dataclass(frozen=True)
+class OperationInfo:
+    """Describes one built-in data operation and its per-framework capability."""
+
+    name: str
+    prefix_pattern: str
+    subtype_label: str
+    subtypes: tuple[str, ...] | None
+    frameworks: dict[str, frozenset[str] | None]
+
+
+_SubtypesFn = Callable[[ModuleType], tuple[str, ...]]
+_ProbeFn = Callable[[ModuleType, str], tuple[str, Options]]
+
+
+@dataclass(frozen=True)
+class _OperationSpec:
+    """Where to find an operation's production classes and how to probe its subtypes."""
+
+    name: str
+    package: str
+    base_class: str
+    subtype_label: str
+    subtypes: _SubtypesFn | None = None
+    probe: _ProbeFn | None = None
+
+
+def _ordered(values: Any, hint: tuple[str, ...]) -> tuple[str, ...]:
+    """Sort *values* by their position in *hint* (unknown entries last, alphabetically)."""
+    index = {name: pos for pos, name in enumerate(hint)}
+    return tuple(sorted((str(value) for value in values), key=lambda name: (index.get(name, len(hint)), name)))
+
+
+def _partition_options() -> Options:
+    """Options carrying the partition_by context the group-by families require to match."""
+    return Options(context={"partition_by": ["region"]})
+
+
+def _partition_order_options() -> Options:
+    """Options carrying partition_by and order_by for the ordered-partition families."""
+    return Options(context={"partition_by": ["region"], "order_by": "ts"})
+
+
+# ---------------------------------------------------------------------------
+# Per-operation subtype universes (from production base constants only)
+# ---------------------------------------------------------------------------
+
+
+def _keys(mapping: Any) -> tuple[str, ...]:
+    """Tuple of a constant's keys in insertion order."""
+    return tuple(str(key) for key in mapping)
+
+
+def _aggregation_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    return _keys(base_module.AggregationFeatureGroup.AGGREGATION_TYPES)
+
+
+def _binning_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    return _keys(base_module.BINNING_OPS)
+
+
+def _datetime_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    return _keys(base_module.DATETIME_OPS)
+
+
+def _frame_aggregate_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    """Flatten (frame_type, time_unit) into compound subtypes such as ``time:month``."""
+    cls = base_module.FrameAggregateFeatureGroup
+    time_units = _ordered(cls.SUPPORTED_TIME_UNITS, _TIME_UNIT_ORDER)
+    out: list[str] = []
+    for frame_type in _ordered(cls.SUPPORTED_FRAME_TYPES, _FRAME_TYPE_ORDER):
+        if frame_type == "time":
+            out.extend(f"time:{unit}" for unit in time_units)
+        else:
+            out.append(frame_type)
+    return tuple(out)
+
+
+def _offset_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    cls = base_module.OffsetFeatureGroup
+    return _keys(cls.PARAMETRIC_OFFSET_FAMILIES) + _keys(cls.OFFSET_TYPES)
+
+
+def _arithmetic_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    return _keys(base_module.ARITHMETIC_OPERATIONS)
+
+
+def _rank_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    return _keys(base_module.RankFeatureGroup.RANK_TYPES)
+
+
+def _scalar_aggregate_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    return _keys(base_module.ScalarAggregateFeatureGroup.AGGREGATION_TYPES)
+
+
+def _string_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    return _keys(base_module.STRING_OPS)
+
+
+def _time_bucketization_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    return _keys(base_module.TIME_BUCKETIZATION_OPS)
+
+
+def _window_aggregation_subtypes(base_module: ModuleType) -> tuple[str, ...]:
+    return _keys(base_module.WindowAggregationFeatureGroup.AGGREGATION_TYPES)
+
+
+# ---------------------------------------------------------------------------
+# Per-operation probes (feature name + Options shapes that reach match time)
+# ---------------------------------------------------------------------------
+
+
+def _aggregation_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"value__{subtype}_agg", _partition_options()
+
+
+def _binning_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"value__{subtype}_5", Options()
+
+
+def _datetime_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"ts__{subtype}", Options()
+
+
+def _frame_aggregate_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    """Probe rolling via the string pattern; time/cumulative/expanding via config Options."""
+    if subtype == "rolling":
+        return "value__sum_rolling_3", _partition_order_options()
+    context: dict[str, Any] = {
+        "aggregation_type": "sum",
+        "in_features": "value",
+        "partition_by": ["region"],
+        "order_by": "ts",
+    }
+    if subtype.startswith("time:"):
+        context.update({"frame_type": "time", "frame_size": 3, "frame_unit": subtype.split(":", 1)[1]})
+    else:
+        context["frame_type"] = subtype
+    return "value_frame_probe", Options(context=context)
+
+
+def _offset_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    """Parametric families probe with N=1; static offset types probe verbatim."""
+    if subtype in base_module.OffsetFeatureGroup.PARAMETRIC_OFFSET_FAMILIES:
+        subtype = f"{subtype}_1"
+    return f"value__{subtype}_offset", _partition_order_options()
+
+
+def _point_arithmetic_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"a&b__{subtype}_point", Options()
+
+
+def _rank_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"value__{subtype}_ranked", _partition_order_options()
+
+
+def _scalar_aggregate_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"value__{subtype}_scalar", Options()
+
+
+def _scalar_arithmetic_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"value__{subtype}_constant", Options()
+
+
+def _string_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"value__{subtype}", Options()
+
+
+def _time_bucketization_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"ts__{subtype}_1_day", Options()
+
+
+def _window_aggregation_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    return f"value__{subtype}_window", _partition_order_options()
+
+
+_OPERATION_SPECS: tuple[_OperationSpec, ...] = (
+    _OperationSpec(
+        name="aggregation",
+        package=f"{_PKG}.aggregation",
+        base_class="AggregationFeatureGroup",
+        subtype_label="agg type",
+        subtypes=_aggregation_subtypes,
+        probe=_aggregation_probe,
+    ),
+    _OperationSpec(
+        name="binning",
+        package=f"{_PKG}.row_preserving.binning",
+        base_class="BinningFeatureGroup",
+        subtype_label="op",
+        subtypes=_binning_subtypes,
+        probe=_binning_probe,
+    ),
+    _OperationSpec(
+        name="datetime",
+        package=f"{_PKG}.row_preserving.datetime",
+        base_class="DateTimeFeatureGroup",
+        subtype_label="op",
+        subtypes=_datetime_subtypes,
+        probe=_datetime_probe,
+    ),
+    _OperationSpec(
+        name="ema",
+        package=f"{_PKG}.row_preserving.ema",
+        base_class="EmaFeatureGroup",
+        subtype_label="op",
+    ),
+    _OperationSpec(
+        name="ffill",
+        package=f"{_PKG}.row_preserving.ffill",
+        base_class="FfillFeatureGroup",
+        subtype_label="op",
+    ),
+    _OperationSpec(
+        name="frame_aggregate",
+        package=f"{_PKG}.row_preserving.frame_aggregate",
+        base_class="FrameAggregateFeatureGroup",
+        subtype_label="frame type",
+        subtypes=_frame_aggregate_subtypes,
+        probe=_frame_aggregate_probe,
+    ),
+    _OperationSpec(
+        name="offset",
+        package=f"{_PKG}.row_preserving.offset",
+        base_class="OffsetFeatureGroup",
+        subtype_label="offset type",
+        subtypes=_offset_subtypes,
+        probe=_offset_probe,
+    ),
+    _OperationSpec(
+        name="percentile",
+        package=f"{_PKG}.row_preserving.percentile",
+        base_class="PercentileFeatureGroup",
+        subtype_label="op",
+    ),
+    _OperationSpec(
+        name="point_arithmetic",
+        package=f"{_PKG}.row_preserving.point_arithmetic",
+        base_class="PointArithmeticFeatureGroup",
+        subtype_label="op",
+        subtypes=_arithmetic_subtypes,
+        probe=_point_arithmetic_probe,
+    ),
+    _OperationSpec(
+        name="rank",
+        package=f"{_PKG}.row_preserving.rank",
+        base_class="RankFeatureGroup",
+        subtype_label="rank type",
+        subtypes=_rank_subtypes,
+        probe=_rank_probe,
+    ),
+    _OperationSpec(
+        name="resample",
+        package=f"{_PKG}.row_changing.resample",
+        base_class="ResampleFeatureGroup",
+        subtype_label="op",
+    ),
+    _OperationSpec(
+        name="scalar_aggregate",
+        package=f"{_PKG}.row_preserving.scalar_aggregate",
+        base_class="ScalarAggregateFeatureGroup",
+        subtype_label="agg type",
+        subtypes=_scalar_aggregate_subtypes,
+        probe=_scalar_aggregate_probe,
+    ),
+    _OperationSpec(
+        name="scalar_arithmetic",
+        package=f"{_PKG}.row_preserving.scalar_arithmetic",
+        base_class="ScalarArithmeticFeatureGroup",
+        subtype_label="op",
+        subtypes=_arithmetic_subtypes,
+        probe=_scalar_arithmetic_probe,
+    ),
+    _OperationSpec(
+        name="sessionization",
+        package=f"{_PKG}.row_preserving.sessionization",
+        base_class="SessionizationFeatureGroup",
+        subtype_label="op",
+    ),
+    _OperationSpec(
+        name="string",
+        package=f"{_PKG}.string",
+        base_class="StringFeatureGroup",
+        subtype_label="op",
+        subtypes=_string_subtypes,
+        probe=_string_probe,
+    ),
+    _OperationSpec(
+        name="time_bucketization",
+        package=f"{_PKG}.row_preserving.time_bucketization",
+        base_class="TimeBucketizationFeatureGroup",
+        subtype_label="op",
+        subtypes=_time_bucketization_subtypes,
+        probe=_time_bucketization_probe,
+    ),
+    _OperationSpec(
+        name="window_aggregation",
+        package=f"{_PKG}.row_preserving.window_aggregation",
+        base_class="WindowAggregationFeatureGroup",
+        subtype_label="agg type",
+        subtypes=_window_aggregation_subtypes,
+        probe=_window_aggregation_probe,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Catalog construction
+# ---------------------------------------------------------------------------
+
+
+def _import_optional(module_name: str) -> ModuleType | None:
+    """Import *module_name*, returning None when it (or an optional dependency) is missing."""
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        return None
+
+
+def _module_local_subclass(module: ModuleType, base_cls: type[Any]) -> type[Any] | None:
+    """Return the concrete subclass of *base_cls* defined in *module*, or None."""
+    for _, obj in inspect.getmembers(module, inspect.isclass):
+        if obj.__module__ != module.__name__:
+            continue
+        if issubclass(obj, base_cls) and obj is not base_cls:
+            return obj
+    return None
+
+
+def _supported_subtypes(
+    concrete: type[Any],
+    framework: type[Any],
+    base_module: ModuleType,
+    subtypes: tuple[str, ...],
+    probe: _ProbeFn,
+) -> frozenset[str]:
+    """Subtypes the concrete class both matches and accepts for *framework* at match time."""
+    supported: set[str] = set()
+    for subtype in subtypes:
+        feature_name, options = probe(base_module, subtype)
+        if not concrete.match_feature_group_criteria(feature_name, options):
+            continue
+        if concrete.supports_compute_framework(feature_name, options, framework) is not True:
+            continue
+        supported.add(subtype)
+    return frozenset(supported)
+
+
+def _build_operation(spec: _OperationSpec) -> OperationInfo | None:
+    """Build one OperationInfo, or None when the operation's package is not installed."""
+    base_module = _import_optional(f"{spec.package}.base")
+    if base_module is None:
+        return None
+    base_cls: type[Any] = getattr(base_module, spec.base_class)
+    subtypes = spec.subtypes(base_module) if spec.subtypes is not None else None
+
+    frameworks: dict[str, frozenset[str] | None] = {}
+    op_dirname = spec.package.rsplit(".", 1)[-1]
+    for prefix in _FRAMEWORK_MODULE_PREFIXES:
+        backend_module = _import_optional(f"{spec.package}.{prefix}_{op_dirname}")
+        if backend_module is None:
+            continue
+        concrete = _module_local_subclass(backend_module, base_cls)
+        if concrete is None:
+            continue
+        for framework in concrete.compute_framework_definition():
+            key = str(framework.__name__)
+            if subtypes is None or spec.probe is None:
+                frameworks[key] = None
+            else:
+                frameworks[key] = _supported_subtypes(concrete, framework, base_module, subtypes, spec.probe)
+
+    return OperationInfo(
+        name=spec.name,
+        prefix_pattern=str(base_cls.PREFIX_PATTERN),
+        subtype_label=spec.subtype_label,
+        subtypes=subtypes,
+        frameworks=frameworks,
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_catalog() -> tuple[OperationInfo, ...]:
+    """Build (once) and cache the catalog, sorted by operation name."""
+    infos = [info for spec in _OPERATION_SPECS if (info := _build_operation(spec)) is not None]
+    return tuple(sorted(infos, key=lambda info: info.name))
+
+
+class DataOperationsCatalog:
+    """Queryable catalog of the built-in data operations and their framework support."""
+
+    @classmethod
+    def list(cls) -> list[OperationInfo]:
+        """Return every installed built-in operation, sorted by name."""
+        return list(_load_catalog())
+
+    @classmethod
+    def get(cls, name: str) -> OperationInfo:
+        """Return the OperationInfo for *name*; unknown names raise a ValueError listing all operations."""
+        for info in _load_catalog():
+            if info.name == name:
+                return info
+        raise unsupported_op_error(name, (info.name for info in _load_catalog()))
+
+    @classmethod
+    def is_supported(cls, operation: str, subtype: str | None = None, framework: str | None = None) -> bool:
+        """Whether *operation* (optionally narrowed to a subtype and/or framework) is supported.
+
+        Framework names match case-insensitively; unknown or absent frameworks
+        return False. ``subtype=None`` asks whether the operation exists on the
+        framework at all; ``framework=None`` asks whether any framework supports
+        the subtype. Unknown operations and subtypes raise ValueError.
+        """
+        info = cls.get(operation)
+        if subtype is not None and (info.subtypes is None or subtype not in info.subtypes):
+            raise _build_unsupported_value_error(
+                subtype,
+                info.subtypes or (),
+                value_label=f"{info.name} subtype",
+                supported_plural="subtypes",
+            )
+        if framework is None:
+            if subtype is None:
+                return bool(info.frameworks)
+            return any(supported is not None and subtype in supported for supported in info.frameworks.values())
+        for key, supported in info.frameworks.items():
+            if key.lower() != framework.lower():
+                continue
+            if subtype is None:
+                return True
+            return supported is not None and subtype in supported
+        return False

--- a/mloda/community/feature_groups/data_operations/catalog.py
+++ b/mloda/community/feature_groups/data_operations/catalog.py
@@ -14,17 +14,17 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from functools import lru_cache
-from types import ModuleType
+from types import MappingProxyType, ModuleType
 from typing import Any
 
 from mloda.core.abstract_plugins.components.options import Options
 
 from mloda.community.feature_groups.data_operations.errors import (
-    _build_unsupported_value_error,
     unsupported_op_error,
+    unsupported_subtype_error,
 )
 
 _PKG = "mloda.community.feature_groups.data_operations"
@@ -45,7 +45,7 @@ class OperationInfo:
     prefix_pattern: str
     subtype_label: str
     subtypes: tuple[str, ...] | None
-    frameworks: dict[str, frozenset[str] | None]
+    frameworks: Mapping[str, frozenset[str] | None]
 
 
 _SubtypesFn = Callable[[ModuleType], tuple[str, ...]]
@@ -125,7 +125,8 @@ def _arithmetic_subtypes(base_module: ModuleType) -> tuple[str, ...]:
 
 
 def _rank_subtypes(base_module: ModuleType) -> tuple[str, ...]:
-    return _keys(base_module.RankFeatureGroup.RANK_TYPES)
+    cls = base_module.RankFeatureGroup
+    return _keys(cls.RANK_TYPES) + _keys(cls.PARAMETRIC_RANK_FAMILIES)
 
 
 def _scalar_aggregate_subtypes(base_module: ModuleType) -> tuple[str, ...]:
@@ -189,7 +190,14 @@ def _point_arithmetic_probe(base_module: ModuleType, subtype: str) -> tuple[str,
     return f"a&b__{subtype}_point", Options()
 
 
+#: Representative N per parametric rank family used when probing capability.
+_RANK_FAMILY_PROBE_N: dict[str, int] = {"ntile": 2, "top": 3, "bottom": 2}
+
+
 def _rank_probe(base_module: ModuleType, subtype: str) -> tuple[str, Options]:
+    """Parametric families probe with a representative N; named rank types probe verbatim."""
+    if subtype in base_module.RankFeatureGroup.PARAMETRIC_RANK_FAMILIES:
+        subtype = f"{subtype}_{_RANK_FAMILY_PROBE_N[subtype]}"
     return f"value__{subtype}_ranked", _partition_order_options()
 
 
@@ -414,7 +422,7 @@ def _build_operation(spec: _OperationSpec) -> OperationInfo | None:
         prefix_pattern=str(base_cls.PREFIX_PATTERN),
         subtype_label=spec.subtype_label,
         subtypes=subtypes,
-        frameworks=frameworks,
+        frameworks=MappingProxyType(frameworks),
     )
 
 
@@ -436,10 +444,11 @@ class DataOperationsCatalog:
     @classmethod
     def get(cls, name: str) -> OperationInfo:
         """Return the OperationInfo for *name*; unknown names raise a ValueError listing all operations."""
-        for info in _load_catalog():
+        catalog = _load_catalog()
+        for info in catalog:
             if info.name == name:
                 return info
-        raise unsupported_op_error(name, (info.name for info in _load_catalog()))
+        raise unsupported_op_error(name, (info.name for info in catalog))
 
     @classmethod
     def is_supported(cls, operation: str, subtype: str | None = None, framework: str | None = None) -> bool:
@@ -452,12 +461,7 @@ class DataOperationsCatalog:
         """
         info = cls.get(operation)
         if subtype is not None and (info.subtypes is None or subtype not in info.subtypes):
-            raise _build_unsupported_value_error(
-                subtype,
-                info.subtypes or (),
-                value_label=f"{info.name} subtype",
-                supported_plural="subtypes",
-            )
+            raise unsupported_subtype_error(subtype, info.subtypes or (), operation=info.name)
         if framework is None:
             if subtype is None:
                 return bool(info.frameworks)

--- a/mloda/community/feature_groups/data_operations/errors.py
+++ b/mloda/community/feature_groups/data_operations/errors.py
@@ -28,7 +28,7 @@ def _build_unsupported_value_error(
 ) -> ValueError:
     """Build a ``ValueError`` for an unsupported value of a given label.
 
-    Internal helper. All three public ``unsupported_*_error`` functions
+    Internal helper. The public ``unsupported_*_error`` functions
     delegate to this; they exist as thin wrappers that fix the
     ``value_label`` and ``supported_plural`` strings.
     """
@@ -116,4 +116,28 @@ def unsupported_op_error(
         value_label="operation",
         supported_plural="operations",
         framework=framework,
+    )
+
+
+def unsupported_subtype_error(
+    subtype: str,
+    supported: Iterable[str],
+    *,
+    operation: str,
+) -> ValueError:
+    """Build a ``ValueError`` describing an unsupported subtype of a data operation.
+
+    Args:
+        subtype: The value the caller provided.
+        supported: All subtype values the caller *could* have used.
+            Deduplicated and sorted alphabetically in the message.
+        operation: The operation name (``"aggregation"``, ``"rank"``, ...),
+            included in the value label so the user knows which operation
+            rejected the subtype.
+    """
+    return _build_unsupported_value_error(
+        subtype,
+        supported,
+        value_label=f"{operation} subtype",
+        supported_plural="subtypes",
     )

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -11,7 +11,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import ComputeFramework, DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
@@ -302,6 +302,30 @@ class FrameAggregateFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if not isinstance(order_by, str):
             return False
 
+        return True
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        """Reject frame types or time units the backend cannot compute; unresolvable stays True."""
+        parsed = cls._parse_frame_feature(str(feature_name))
+        if parsed is not None:
+            frame_type: str | None = parsed["frame_type"]
+            frame_unit_raw = parsed["frame_unit"]
+        else:
+            frame_type_raw = options.get(cls.FRAME_TYPE)
+            frame_type = None if frame_type_raw is None else str(frame_type_raw)
+            frame_unit_raw = options.get(cls.FRAME_UNIT)
+        if frame_type is None:
+            return True
+        if frame_type not in cls.SUPPORTED_FRAME_TYPES:
+            return False
+        if frame_type == "time" and frame_unit_raw is not None and str(frame_unit_raw) not in cls.SUPPORTED_TIME_UNITS:
+            return False
         return True
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -91,6 +91,9 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "last_value": "Last value in partition",
     }
 
+    #: Parametric offset families; each accepts a positive integer suffix (e.g. ``lag_3``).
+    PARAMETRIC_OFFSET_FAMILIES: tuple[str, ...] = ("lag", "lead", "diff", "pct_change")
+
     PROPERTY_MAPPING = {
         OFFSET_TYPE: {
             **OFFSET_TYPES,
@@ -120,7 +123,8 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Check if the given offset type is supported."""
         if offset_type in cls.OFFSET_TYPES:
             return True
-        for prefix in ("lag_", "lead_", "diff_", "pct_change_"):
+        for family in cls.PARAMETRIC_OFFSET_FAMILIES:
+            prefix = f"{family}_"
             if offset_type.startswith(prefix):
                 suffix = offset_type[len(prefix) :]
                 if suffix.isdigit() and int(suffix) >= 1:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -8,8 +8,10 @@ from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import ComputeFramework, DefaultOptionKeys, FeatureGroup
 
 
 class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -201,6 +203,40 @@ class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if rank_type is None:
             raise ValueError(f"Could not extract rank type for {feature_name}")
         return str(rank_type)
+
+    @classmethod
+    def supported_rank_types(cls) -> frozenset[str] | None:
+        """Rank types the backend computes natively; None means unrestricted."""
+        return None
+
+    @classmethod
+    def _resolve_rank_type(cls, feature_name: str, options: Options) -> str | None:
+        """Resolve the rank type from the feature name or options; None if unresolvable."""
+        try:
+            operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, cls._get_prefix_patterns())
+        except ValueError:
+            return None
+        if operation_config is not None:
+            return operation_config
+        rank_type = options.get(cls.RANK_TYPE)
+        return None if rank_type is None else str(rank_type)
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        """Reject named rank types the backend cannot compute; unresolvable stays True."""
+        supported = cls.supported_rank_types()
+        if supported is None:
+            return True
+        rank_type = cls._resolve_rank_type(str(feature_name), options)
+        if rank_type is None or rank_type not in cls.RANK_TYPES:
+            # Parametric types (ntile_N, top_N, bottom_N) and unresolvable inputs stay open.
+            return True
+        return rank_type in supported
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -107,6 +107,9 @@ class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "percent_rank": "Relative rank as fraction (0.0 to 1.0)",
     }
 
+    #: Parametric rank families; each accepts a positive integer suffix (e.g. ``ntile_4``).
+    PARAMETRIC_RANK_FAMILIES: tuple[str, ...] = ("ntile", "top", "bottom")
+
     PROPERTY_MAPPING = {
         RANK_TYPE: {
             **RANK_TYPES,
@@ -135,7 +138,8 @@ class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Check if the given rank type is supported, including ntile_N, top_N, and bottom_N."""
         if rank_type in cls.RANK_TYPES:
             return True
-        for prefix in ("ntile_", "top_", "bottom_"):
+        for family in cls.PARAMETRIC_RANK_FAMILIES:
+            prefix = f"{family}_"
             if rank_type.startswith(prefix):
                 suffix = rank_type[len(prefix) :]
                 if suffix.isdigit() and int(suffix) >= 1:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pandas_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pandas_rank.py
@@ -25,10 +25,6 @@ class PandasRank(RankFeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def supported_rank_types(cls) -> frozenset[str] | None:
-        return frozenset(_PANDAS_RANK_METHODS)
-
-    @classmethod
     def _compute_rank(
         cls,
         data: pd.DataFrame,

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pandas_rank.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pandas_rank.py
@@ -25,6 +25,10 @@ class PandasRank(RankFeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
+    def supported_rank_types(cls) -> frozenset[str] | None:
+        return frozenset(_PANDAS_RANK_METHODS)
+
+    @classmethod
     def _compute_rank(
         cls,
         data: pd.DataFrame,

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/sqlite_scalar_aggregate.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/sqlite_scalar_aggregate.py
@@ -31,6 +31,10 @@ class SqliteScalarAggregate(ScalarAggregateFeatureGroup):
         return {SqliteFramework}
 
     @classmethod
+    def supported_agg_types(cls) -> frozenset[str] | None:
+        return frozenset(_SQLITE_AGG_FUNCS)
+
+    @classmethod
     def _compute_aggregation(
         cls,
         data: SqliteRelation,

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyarrow_window_aggregation.py
@@ -56,6 +56,10 @@ class PyArrowWindowAggregation(WindowAggregationFeatureGroup):
         return {PyArrowTable}
 
     @classmethod
+    def supported_agg_types(cls) -> frozenset[str] | None:
+        return frozenset(_SUPPORTED_AGG_TYPES)
+
+    @classmethod
     def _compute_window(
         cls,
         table: pa.Table,

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/sqlite_window_aggregation.py
@@ -32,6 +32,10 @@ class SqliteWindowAggregation(WindowAggregationFeatureGroup):
         return {SqliteFramework}
 
     @classmethod
+    def supported_agg_types(cls) -> frozenset[str] | None:
+        return frozenset(_SQLITE_AGG_FUNCS)
+
+    @classmethod
     def _compute_window(
         cls,
         data: SqliteRelation,

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_duckdb.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_duckdb.py
@@ -23,3 +23,7 @@ class TestDuckdbWindowAggregation(DuckdbTestMixin, WindowAggregationTestBase):
     @classmethod
     def implementation_class(cls) -> Any:
         return DuckdbWindowAggregation
+
+    @classmethod
+    def supported_agg_types(cls) -> set[str]:
+        return {*cls.ALL_AGG_TYPES, "mean"}

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_pandas.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_pandas.py
@@ -26,6 +26,10 @@ class TestPandasWindowAggregation(PandasTestMixin, WindowAggregationTestBase):
     def implementation_class(cls) -> Any:
         return PandasWindowAggregation
 
+    @classmethod
+    def supported_agg_types(cls) -> set[str]:
+        return {*cls.ALL_AGG_TYPES, "mean"}
+
 
 class TestPandasWindowModeVectorized:
     """Targeted tests for the vectorized window ``_compute_mode``.

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_polars_lazy.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_polars_lazy.py
@@ -23,3 +23,7 @@ class TestPolarsLazyWindowAggregation(PolarsLazyTestMixin, WindowAggregationTest
     @classmethod
     def implementation_class(cls) -> Any:
         return PolarsLazyWindowAggregation
+
+    @classmethod
+    def supported_agg_types(cls) -> set[str]:
+        return {*cls.ALL_AGG_TYPES, "mean"}

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_sqlite.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_sqlite.py
@@ -18,7 +18,7 @@ class TestSqliteWindowAggregation(SqliteTestMixin, WindowAggregationTestBase):
 
     @classmethod
     def supported_agg_types(cls) -> set[str]:
-        return {"sum", "avg", "count", "min", "max"}
+        return {"sum", "avg", "mean", "count", "min", "max"}
 
     @classmethod
     def implementation_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/tests/test_capability_hook.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_capability_hook.py
@@ -1,0 +1,354 @@
+"""Per-op, per-framework capability checks via ``supports_compute_framework`` (issue #247).
+
+mloda core 0.9.0 evaluates ``FeatureGroup.supports_compute_framework(feature_name, options,
+compute_framework)`` per feature at match time. The data_operations backends must override
+it so that operations a backend cannot compute (e.g. ``median`` on SQLite) are rejected at
+match time instead of failing later inside ``calculate_feature``. Backends stay conservative:
+anything they cannot parse into an operation keeps the default ``True``.
+
+The tests import only what the specific framework needs and skip when that framework's
+optional dependency is missing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.core.abstract_plugins.components.options import Options
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _config_aggregation_options(agg_type: str) -> Options:
+    """Build config-based aggregation options carrying the aggregation_type discriminator."""
+    return Options(
+        context={
+            "aggregation_type": agg_type,
+            "in_features": "value",
+            "partition_by": ["region"],
+        }
+    )
+
+
+def _time_frame_options(frame_unit: str) -> Options:
+    """Build config-based time-frame options for the given frame_unit."""
+    return Options(
+        context={
+            "aggregation_type": "sum",
+            "frame_type": "time",
+            "frame_size": 3,
+            "frame_unit": frame_unit,
+            "in_features": "value",
+            "partition_by": ["region"],
+            "order_by": "ts",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Aggregation (group-by)
+# ---------------------------------------------------------------------------
+
+
+class TestAggregationCapability:
+    def test_sqlite_rejects_median(self) -> None:
+        """SQLite cannot compute median natively, so the hook must reject it."""
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+        from mloda.community.feature_groups.data_operations.aggregation.sqlite_aggregation import (
+            SqliteAggregation,
+        )
+
+        result = SqliteAggregation.supports_compute_framework("value__median_agg", Options(), SqliteFramework)
+        assert result is False
+
+    @pytest.mark.parametrize("feature_name", ["value__sum_agg", "value__mean_agg"])
+    def test_sqlite_accepts_supported_types(self, feature_name: str) -> None:
+        """SQLite supports sum and mean (avg alias in _SQLITE_AGG_FUNCS), so the hook allows them."""
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+        from mloda.community.feature_groups.data_operations.aggregation.sqlite_aggregation import (
+            SqliteAggregation,
+        )
+
+        result = SqliteAggregation.supports_compute_framework(feature_name, Options(), SqliteFramework)
+        assert result is True
+
+    @pytest.mark.parametrize("feature_name", ["value__median_agg", "value__mode_agg"])
+    def test_pyarrow_rejects_unsupported_types(self, feature_name: str) -> None:
+        """PyArrow group_by has no median or mode kernel, so the hook must reject them."""
+        pytest.importorskip("pyarrow")
+        from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+        from mloda.community.feature_groups.data_operations.aggregation.pyarrow_aggregation import (
+            PyArrowAggregation,
+        )
+
+        result = PyArrowAggregation.supports_compute_framework(feature_name, Options(), PyArrowTable)
+        assert result is False
+
+    def test_pyarrow_accepts_nunique(self) -> None:
+        """PyArrow supports nunique via count_distinct, so the hook allows it."""
+        pytest.importorskip("pyarrow")
+        from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+        from mloda.community.feature_groups.data_operations.aggregation.pyarrow_aggregation import (
+            PyArrowAggregation,
+        )
+
+        result = PyArrowAggregation.supports_compute_framework("value__nunique_agg", Options(), PyArrowTable)
+        assert result is True
+
+    @pytest.mark.parametrize("feature_name", ["value__median_agg", "value__mode_agg"])
+    def test_pandas_is_unrestricted(self, feature_name: str) -> None:
+        """Pandas supports the full aggregation-type table, so the hook allows everything."""
+        pytest.importorskip("pandas")
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+        from mloda.community.feature_groups.data_operations.aggregation.pandas_aggregation import (
+            PandasAggregation,
+        )
+
+        result = PandasAggregation.supports_compute_framework(feature_name, Options(), PandasDataFrame)
+        assert result is True
+
+    def test_sqlite_rejects_config_based_median(self) -> None:
+        """Config-based features carry the agg type in options; SQLite must reject median there too."""
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+        from mloda.community.feature_groups.data_operations.aggregation.sqlite_aggregation import (
+            SqliteAggregation,
+        )
+
+        options = _config_aggregation_options("median")
+        result = SqliteAggregation.supports_compute_framework("median_result", options, SqliteFramework)
+        assert result is False
+
+    def test_sqlite_conservative_default_for_unparsable_name(self) -> None:
+        """A name encoding no parsable agg type keeps the default True (conservative)."""
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+        from mloda.community.feature_groups.data_operations.aggregation.sqlite_aggregation import (
+            SqliteAggregation,
+        )
+
+        result = SqliteAggregation.supports_compute_framework("totally_unrelated", Options(), SqliteFramework)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Window aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestWindowAggregationCapability:
+    def test_sqlite_rejects_median_window(self) -> None:
+        """SQLite window functions cannot compute median, so the hook must reject it."""
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.sqlite_window_aggregation import (
+            SqliteWindowAggregation,
+        )
+
+        result = SqliteWindowAggregation.supports_compute_framework("value__median_window", Options(), SqliteFramework)
+        assert result is False
+
+    def test_pyarrow_rejects_mode_window(self) -> None:
+        """PyArrow window aggregation has no mode kernel, so the hook must reject it."""
+        pytest.importorskip("pyarrow")
+        from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.pyarrow_window_aggregation import (
+            PyArrowWindowAggregation,
+        )
+
+        result = PyArrowWindowAggregation.supports_compute_framework("value__mode_window", Options(), PyArrowTable)
+        assert result is False
+
+    def test_duckdb_accepts_median_window(self) -> None:
+        """DuckDB computes median in window frames, so the hook allows it."""
+        pytest.importorskip("duckdb")
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.duckdb_window_aggregation import (
+            DuckdbWindowAggregation,
+        )
+
+        result = DuckdbWindowAggregation.supports_compute_framework("value__median_window", Options(), DuckDBFramework)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Scalar aggregate
+# ---------------------------------------------------------------------------
+
+
+class TestScalarAggregateCapability:
+    def test_sqlite_rejects_median_scalar(self) -> None:
+        """SQLite cannot compute a median scalar, so the hook must reject it."""
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.sqlite_scalar_aggregate import (
+            SqliteScalarAggregate,
+        )
+
+        result = SqliteScalarAggregate.supports_compute_framework("value__median_scalar", Options(), SqliteFramework)
+        assert result is False
+
+    def test_sqlite_accepts_sum_scalar(self) -> None:
+        """SQLite supports sum, so the hook allows it."""
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.sqlite_scalar_aggregate import (
+            SqliteScalarAggregate,
+        )
+
+        result = SqliteScalarAggregate.supports_compute_framework("value__sum_scalar", Options(), SqliteFramework)
+        assert result is True
+
+    def test_pandas_accepts_median_scalar(self) -> None:
+        """Pandas computes median natively, so the hook allows it."""
+        pytest.importorskip("pandas")
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pandas_scalar_aggregate import (
+            PandasScalarAggregate,
+        )
+
+        result = PandasScalarAggregate.supports_compute_framework("value__median_scalar", Options(), PandasDataFrame)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Rank
+# ---------------------------------------------------------------------------
+
+
+class TestRankCapability:
+    def test_pandas_rejects_percent_rank(self) -> None:
+        """Pandas percent_rank diverges from SQL semantics, so the hook must reject it."""
+        pytest.importorskip("pandas")
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+        from mloda.community.feature_groups.data_operations.row_preserving.rank.pandas_rank import (
+            PandasRank,
+        )
+
+        result = PandasRank.supports_compute_framework("value__percent_rank_ranked", Options(), PandasDataFrame)
+        assert result is False
+
+    def test_pandas_accepts_dense_rank(self) -> None:
+        """Pandas supports dense_rank, so the hook allows it."""
+        pytest.importorskip("pandas")
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+        from mloda.community.feature_groups.data_operations.row_preserving.rank.pandas_rank import (
+            PandasRank,
+        )
+
+        result = PandasRank.supports_compute_framework("value__dense_rank_ranked", Options(), PandasDataFrame)
+        assert result is True
+
+    def test_duckdb_accepts_percent_rank(self) -> None:
+        """DuckDB supports SQL percent_rank natively, so the hook allows it."""
+        pytest.importorskip("duckdb")
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+
+        from mloda.community.feature_groups.data_operations.row_preserving.rank.duckdb_rank import (
+            DuckdbRank,
+        )
+
+        result = DuckdbRank.supports_compute_framework("value__percent_rank_ranked", Options(), DuckDBFramework)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Frame aggregate (frame_type / time_unit capability, not agg types)
+# ---------------------------------------------------------------------------
+
+
+class TestFrameAggregateCapability:
+    def test_pandas_rejects_month_time_unit(self) -> None:
+        """Pandas SUPPORTED_TIME_UNITS excludes month, so the hook must reject a month time frame."""
+        pytest.importorskip("pandas")
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.pandas_frame_aggregate import (
+            PandasFrameAggregate,
+        )
+
+        options = _time_frame_options("month")
+        result = PandasFrameAggregate.supports_compute_framework("value_time_frame", options, PandasDataFrame)
+        assert result is False
+
+    def test_pandas_accepts_day_time_unit(self) -> None:
+        """Pandas supports day time frames, so the hook allows the same probe with unit day."""
+        pytest.importorskip("pandas")
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.pandas_frame_aggregate import (
+            PandasFrameAggregate,
+        )
+
+        options = _time_frame_options("day")
+        result = PandasFrameAggregate.supports_compute_framework("value_time_frame", options, PandasDataFrame)
+        assert result is True
+
+    def test_pandas_accepts_rolling_name(self) -> None:
+        """Pandas supports rolling row-count frames, so the hook allows the string-based name."""
+        pytest.importorskip("pandas")
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.pandas_frame_aggregate import (
+            PandasFrameAggregate,
+        )
+
+        result = PandasFrameAggregate.supports_compute_framework("value__sum_rolling_3", Options(), PandasDataFrame)
+        assert result is True
+
+    def test_duckdb_accepts_month_time_unit(self) -> None:
+        """DuckDB supports calendar time units, so the hook allows the month probe."""
+        pytest.importorskip("duckdb")
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+
+        from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.duckdb_frame_aggregate import (
+            DuckdbFrameAggregate,
+        )
+
+        options = _time_frame_options("month")
+        result = DuckdbFrameAggregate.supports_compute_framework("value_time_frame", options, DuckDBFramework)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: resolve_feature surfaces the capability split
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFeatureIntegration:
+    def test_resolve_feature_splits_frameworks_for_median_scalar(self) -> None:
+        """resolve_feature must list SqliteFramework as unsupported and PandasDataFrame as supported.
+
+        resolve_feature evaluates matching under empty Options, and the group-by
+        aggregation family requires partition_by to match, so the scalar aggregate
+        family (matching string-based with empty Options) is the integration probe
+        for the SQLite-rejects-median capability.
+        """
+        pytest.importorskip("pandas")
+        from mloda.steward import resolve_feature
+
+        # Importing the production classes registers them as FeatureGroup subclasses.
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pandas_scalar_aggregate import (  # noqa: F401
+            PandasScalarAggregate,
+        )
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.sqlite_scalar_aggregate import (  # noqa: F401
+            SqliteScalarAggregate,
+        )
+
+        result = resolve_feature("value__median_scalar")
+
+        assert "SqliteFramework" in result.unsupported_compute_frameworks
+        assert "PandasDataFrame" in result.supported_compute_frameworks

--- a/mloda/community/feature_groups/data_operations/tests/test_capability_hook.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_capability_hook.py
@@ -228,8 +228,8 @@ class TestScalarAggregateCapability:
 
 
 class TestRankCapability:
-    def test_pandas_rejects_percent_rank(self) -> None:
-        """Pandas percent_rank diverges from SQL semantics, so the hook must reject it."""
+    def test_pandas_accepts_percent_rank(self) -> None:
+        """Pandas computes percent_rank with SQL semantics ((rank-1)/(count-1)), so the hook allows it."""
         pytest.importorskip("pandas")
         from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
@@ -238,7 +238,7 @@ class TestRankCapability:
         )
 
         result = PandasRank.supports_compute_framework("value__percent_rank_ranked", Options(), PandasDataFrame)
-        assert result is False
+        assert result is True
 
     def test_pandas_accepts_dense_rank(self) -> None:
         """Pandas supports dense_rank, so the hook allows it."""
@@ -252,6 +252,18 @@ class TestRankCapability:
         result = PandasRank.supports_compute_framework("value__dense_rank_ranked", Options(), PandasDataFrame)
         assert result is True
 
+    def test_polars_lazy_accepts_percent_rank(self) -> None:
+        """Polars lazy supports percent_rank, so the hook allows it."""
+        pytest.importorskip("polars")
+        from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
+
+        from mloda.community.feature_groups.data_operations.row_preserving.rank.polars_lazy_rank import (
+            PolarsLazyRank,
+        )
+
+        result = PolarsLazyRank.supports_compute_framework("value__percent_rank_ranked", Options(), PolarsLazyDataFrame)
+        assert result is True
+
     def test_duckdb_accepts_percent_rank(self) -> None:
         """DuckDB supports SQL percent_rank natively, so the hook allows it."""
         pytest.importorskip("duckdb")
@@ -263,6 +275,40 @@ class TestRankCapability:
 
         result = DuckdbRank.supports_compute_framework("value__percent_rank_ranked", Options(), DuckDBFramework)
         assert result is True
+
+    def test_sqlite_accepts_percent_rank(self) -> None:
+        """SQLite supports SQL percent_rank natively, so the hook allows it."""
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+        from mloda.community.feature_groups.data_operations.row_preserving.rank.sqlite_rank import (
+            SqliteRank,
+        )
+
+        result = SqliteRank.supports_compute_framework("value__percent_rank_ranked", Options(), SqliteFramework)
+        assert result is True
+
+    def test_base_default_is_unrestricted(self) -> None:
+        """No rank backend restricts today: the base supported_rank_types() default is None."""
+        from mloda.community.feature_groups.data_operations.row_preserving.rank.base import RankFeatureGroup
+
+        assert RankFeatureGroup.supported_rank_types() is None
+
+    def test_restricting_subclass_rejects_unlisted_named_types(self) -> None:
+        """The hook mechanism: a subclass restricting supported_rank_types rejects unlisted named types."""
+        pytest.importorskip("pandas")
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+        from mloda.community.feature_groups.data_operations.row_preserving.rank.base import RankFeatureGroup
+
+        class _RestrictedRank(RankFeatureGroup):
+            @classmethod
+            def supported_rank_types(cls) -> frozenset[str] | None:
+                return frozenset({"row_number", "rank", "dense_rank"})
+
+        rejected = _RestrictedRank.supports_compute_framework("value__percent_rank_ranked", Options(), PandasDataFrame)
+        accepted = _RestrictedRank.supports_compute_framework("value__dense_rank_ranked", Options(), PandasDataFrame)
+        assert rejected is False
+        assert accepted is True
 
 
 # ---------------------------------------------------------------------------

--- a/mloda/community/feature_groups/data_operations/tests/test_catalog.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_catalog.py
@@ -12,6 +12,7 @@ without an implementation are simply absent from ``OperationInfo.frameworks``.
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Mapping
 
 import pytest
 
@@ -77,6 +78,10 @@ FRAME_AGGREGATE_SUBTYPES: frozenset[str] = frozenset(
 
 OFFSET_SUBTYPES: frozenset[str] = frozenset({"lag", "lead", "diff", "pct_change", "first_value", "last_value"})
 
+RANK_SUBTYPES: frozenset[str] = frozenset(
+    {"row_number", "rank", "dense_rank", "percent_rank", "ntile", "top", "bottom"}
+)
+
 
 # ---------------------------------------------------------------------------
 # OperationInfo shape
@@ -106,8 +111,14 @@ class TestOperationInfoShape:
         assert isinstance(info.prefix_pattern, str)
         assert isinstance(info.subtype_label, str)
         assert isinstance(info.subtypes, tuple)
-        assert isinstance(info.frameworks, dict)
+        assert isinstance(info.frameworks, Mapping)
         assert isinstance(info.frameworks["SqliteFramework"], frozenset)
+
+    def test_frameworks_mapping_is_immutable(self) -> None:
+        """Mutating the frameworks mapping raises TypeError (read-only proxy)."""
+        info = DataOperationsCatalog.get("aggregation")
+        with pytest.raises(TypeError):
+            info.frameworks["SqliteFramework"] = frozenset()  # type: ignore[index]
 
 
 # ---------------------------------------------------------------------------
@@ -249,11 +260,18 @@ class TestRankCell:
         info = DataOperationsCatalog.get("rank")
         assert info.subtype_label == "rank type"
 
+    def test_subtype_universe(self) -> None:
+        """rank defines the four named rank types plus the three parametric families."""
+        info = DataOperationsCatalog.get("rank")
+        assert info.subtypes is not None
+        assert len(info.subtypes) == 7
+        assert set(info.subtypes) == set(RANK_SUBTYPES)
+
     def test_pandas_supports_full_rank_type_set(self) -> None:
-        """Pandas computes all four named rank types, including SQL-semantics percent_rank."""
+        """Pandas computes all four named rank types plus the ntile/top/bottom families."""
         pytest.importorskip("pandas")
         info = DataOperationsCatalog.get("rank")
-        assert info.frameworks["PandasDataFrame"] == frozenset({"row_number", "rank", "dense_rank", "percent_rank"})
+        assert info.frameworks["PandasDataFrame"] == RANK_SUBTYPES
 
     def test_duckdb_includes_percent_rank(self) -> None:
         """DuckDB supports SQL percent_rank natively."""
@@ -336,6 +354,11 @@ class TestIsSupported:
     def test_exact_cell_sqlite_mean_true(self) -> None:
         """SQLite supports mean via its AVG alias."""
         assert DataOperationsCatalog.is_supported("aggregation", "mean", "SqliteFramework") is True
+
+    def test_exact_cell_duckdb_rank_ntile_true(self) -> None:
+        """DuckDB supports the parametric ntile rank family."""
+        pytest.importorskip("duckdb")
+        assert DataOperationsCatalog.is_supported("rank", "ntile", "DuckDBFramework") is True
 
     def test_operation_level_ema_pyarrow_false(self) -> None:
         """subtype=None asks whether the operation exists on the framework at all."""

--- a/mloda/community/feature_groups/data_operations/tests/test_catalog.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_catalog.py
@@ -1,0 +1,380 @@
+"""Runtime catalog of built-in data operations (issue #247).
+
+The ``data_operations`` package init must export a ``DataOperationsCatalog``
+(implemented in a sibling ``catalog.py``) that describes every built-in data
+operation and its per-framework capability. Capability is derived from the
+mloda core match-time machinery: per concrete production class, a subtype is
+supported on a framework iff ``match_feature_group_criteria`` is truthy AND
+``supports_compute_framework`` returns True for that framework. Frameworks
+without an implementation are simply absent from ``OperationInfo.frameworks``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from mloda.community.feature_groups.data_operations import DataOperationsCatalog, OperationInfo
+
+
+EXPECTED_OPERATION_NAMES: list[str] = [
+    "aggregation",
+    "binning",
+    "datetime",
+    "ema",
+    "ffill",
+    "frame_aggregate",
+    "offset",
+    "percentile",
+    "point_arithmetic",
+    "rank",
+    "resample",
+    "scalar_aggregate",
+    "scalar_arithmetic",
+    "sessionization",
+    "string",
+    "time_bucketization",
+    "window_aggregation",
+]
+
+AGGREGATION_SUBTYPES: frozenset[str] = frozenset(
+    {
+        "sum",
+        "avg",
+        "mean",
+        "count",
+        "min",
+        "max",
+        "std",
+        "var",
+        "std_pop",
+        "std_samp",
+        "var_pop",
+        "var_samp",
+        "median",
+        "mode",
+        "nunique",
+        "first",
+        "last",
+    }
+)
+
+FRAME_AGGREGATE_SUBTYPES: frozenset[str] = frozenset(
+    {
+        "rolling",
+        "time:second",
+        "time:minute",
+        "time:hour",
+        "time:day",
+        "time:week",
+        "time:month",
+        "time:year",
+        "cumulative",
+        "expanding",
+    }
+)
+
+OFFSET_SUBTYPES: frozenset[str] = frozenset({"lag", "lead", "diff", "pct_change", "first_value", "last_value"})
+
+
+# ---------------------------------------------------------------------------
+# OperationInfo shape
+# ---------------------------------------------------------------------------
+
+
+class TestOperationInfoShape:
+    def test_operation_info_is_dataclass(self) -> None:
+        """OperationInfo is a dataclass type."""
+        assert dataclasses.is_dataclass(OperationInfo)
+
+    def test_operation_info_field_names(self) -> None:
+        """OperationInfo exposes exactly the documented fields."""
+        field_names = {f.name for f in dataclasses.fields(OperationInfo)}
+        assert field_names == {"name", "prefix_pattern", "subtype_label", "subtypes", "frameworks"}
+
+    def test_operation_info_is_frozen(self) -> None:
+        """OperationInfo instances are immutable (frozen dataclass)."""
+        info = DataOperationsCatalog.get("aggregation")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            info.name = "renamed"  # type: ignore[misc]
+
+    def test_field_value_types(self) -> None:
+        """Fields carry the documented runtime types."""
+        info = DataOperationsCatalog.get("aggregation")
+        assert isinstance(info.name, str)
+        assert isinstance(info.prefix_pattern, str)
+        assert isinstance(info.subtype_label, str)
+        assert isinstance(info.subtypes, tuple)
+        assert isinstance(info.frameworks, dict)
+        assert isinstance(info.frameworks["SqliteFramework"], frozenset)
+
+
+# ---------------------------------------------------------------------------
+# DataOperationsCatalog.list()
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    def test_lists_all_operations_sorted_by_name(self) -> None:
+        """list() returns all 17 built-in operations sorted by name."""
+        names = [info.name for info in DataOperationsCatalog.list()]
+        assert names == EXPECTED_OPERATION_NAMES
+
+    def test_entries_are_operation_info(self) -> None:
+        """Every list() entry is an OperationInfo."""
+        assert all(isinstance(info, OperationInfo) for info in DataOperationsCatalog.list())
+
+    def test_list_is_deterministic(self) -> None:
+        """Two successive list() calls return equal results."""
+        assert DataOperationsCatalog.list() == DataOperationsCatalog.list()
+
+
+# ---------------------------------------------------------------------------
+# DataOperationsCatalog.get()
+# ---------------------------------------------------------------------------
+
+
+class TestGet:
+    def test_get_returns_named_operation(self) -> None:
+        """get(name) returns the OperationInfo for that operation."""
+        info = DataOperationsCatalog.get("aggregation")
+        assert isinstance(info, OperationInfo)
+        assert info.name == "aggregation"
+
+    def test_unknown_name_raises_value_error(self) -> None:
+        """Unknown operation names raise ValueError."""
+        with pytest.raises(ValueError):
+            DataOperationsCatalog.get("no_such_operation")
+
+    def test_unknown_name_error_lists_valid_operations(self) -> None:
+        """The ValueError message echoes the rejected name and lists all valid operations."""
+        with pytest.raises(ValueError) as exc_info:
+            DataOperationsCatalog.get("no_such_operation")
+        message = str(exc_info.value)
+        assert "no_such_operation" in message
+        for name in EXPECTED_OPERATION_NAMES:
+            assert name in message
+
+
+# ---------------------------------------------------------------------------
+# Per-operation cells
+# ---------------------------------------------------------------------------
+
+
+class TestAggregationCell:
+    def test_prefix_pattern(self) -> None:
+        """aggregation carries the production base class PREFIX_PATTERN."""
+        info = DataOperationsCatalog.get("aggregation")
+        assert info.prefix_pattern == r".*__([\w]+)_agg$"
+
+    def test_subtype_label(self) -> None:
+        info = DataOperationsCatalog.get("aggregation")
+        assert info.subtype_label == "agg type"
+
+    def test_subtype_universe(self) -> None:
+        """aggregation defines 17 subtypes including median, mean and mode."""
+        info = DataOperationsCatalog.get("aggregation")
+        assert info.subtypes is not None
+        assert len(info.subtypes) == 17
+        assert set(info.subtypes) == set(AGGREGATION_SUBTYPES)
+        assert {"median", "mean", "mode"} <= set(info.subtypes)
+
+    def test_sqlite_supports_only_native_functions(self) -> None:
+        """SQLite supports exactly the six natively computable agg types."""
+        info = DataOperationsCatalog.get("aggregation")
+        assert info.frameworks["SqliteFramework"] == frozenset({"sum", "avg", "mean", "count", "min", "max"})
+
+    def test_pandas_supports_full_universe(self) -> None:
+        """Pandas supports the full 17-entry aggregation-type set."""
+        pytest.importorskip("pandas")
+        info = DataOperationsCatalog.get("aggregation")
+        assert info.frameworks["PandasDataFrame"] == AGGREGATION_SUBTYPES
+
+    def test_pyarrow_excludes_median_and_mode(self) -> None:
+        """PyArrow supports everything except median and mode (15 entries)."""
+        pytest.importorskip("pyarrow")
+        info = DataOperationsCatalog.get("aggregation")
+        pyarrow_set = info.frameworks["PyArrowTable"]
+        assert pyarrow_set == AGGREGATION_SUBTYPES - {"median", "mode"}
+        assert pyarrow_set is not None
+        assert len(pyarrow_set) == 15
+
+
+class TestStringCell:
+    def test_sqlite_supports_only_trim_and_length(self) -> None:
+        """SQLite string refuses upper/lower/reverse at match time; the catalog must reflect it."""
+        info = DataOperationsCatalog.get("string")
+        assert info.frameworks["SqliteFramework"] == frozenset({"trim", "length"})
+
+
+class TestEmaCell:
+    def test_has_no_subtype_axis(self) -> None:
+        """ema has no subtype axis, so subtypes is None."""
+        info = DataOperationsCatalog.get("ema")
+        assert info.subtypes is None
+
+    def test_framework_keys_and_values(self) -> None:
+        """ema exists only on Pandas and Polars lazy; values are None (no subtype axis)."""
+        pytest.importorskip("pandas")
+        pytest.importorskip("polars")
+        info = DataOperationsCatalog.get("ema")
+        assert set(info.frameworks) == {"PandasDataFrame", "PolarsLazyDataFrame"}
+        assert all(value is None for value in info.frameworks.values())
+
+
+class TestPercentileCell:
+    def test_unimplemented_frameworks_are_absent(self) -> None:
+        """percentile has no SQLite or PyArrow implementation, so those keys are absent."""
+        info = DataOperationsCatalog.get("percentile")
+        assert "SqliteFramework" not in info.frameworks
+        assert "PyArrowTable" not in info.frameworks
+
+    def test_duckdb_is_present(self) -> None:
+        """percentile is implemented on DuckDB."""
+        pytest.importorskip("duckdb")
+        info = DataOperationsCatalog.get("percentile")
+        assert "DuckDBFramework" in info.frameworks
+
+
+class TestResampleCell:
+    def test_sqlite_is_absent(self) -> None:
+        """resample has no SQLite implementation, so the key is absent."""
+        info = DataOperationsCatalog.get("resample")
+        assert "SqliteFramework" not in info.frameworks
+
+
+class TestRankCell:
+    def test_subtype_label(self) -> None:
+        info = DataOperationsCatalog.get("rank")
+        assert info.subtype_label == "rank type"
+
+    def test_pandas_excludes_percent_rank(self) -> None:
+        """Pandas percent_rank diverges from SQL semantics, so it is excluded."""
+        pytest.importorskip("pandas")
+        info = DataOperationsCatalog.get("rank")
+        assert info.frameworks["PandasDataFrame"] == frozenset({"row_number", "rank", "dense_rank"})
+
+    def test_duckdb_includes_percent_rank(self) -> None:
+        """DuckDB supports SQL percent_rank natively."""
+        pytest.importorskip("duckdb")
+        info = DataOperationsCatalog.get("rank")
+        duckdb_set = info.frameworks["DuckDBFramework"]
+        assert duckdb_set is not None
+        assert "percent_rank" in duckdb_set
+
+
+class TestFrameAggregateCell:
+    def test_subtype_label(self) -> None:
+        info = DataOperationsCatalog.get("frame_aggregate")
+        assert info.subtype_label == "frame type"
+
+    def test_subtype_universe_uses_compound_time_subtypes(self) -> None:
+        """frame_aggregate flattens (frame_type, time_unit) into 10 compound subtypes."""
+        info = DataOperationsCatalog.get("frame_aggregate")
+        assert info.subtypes is not None
+        assert len(info.subtypes) == 10
+        assert set(info.subtypes) == set(FRAME_AGGREGATE_SUBTYPES)
+
+    def test_pandas_excludes_calendar_time_units(self) -> None:
+        """Pandas supports rolling and day frames but not month or year time units."""
+        pytest.importorskip("pandas")
+        info = DataOperationsCatalog.get("frame_aggregate")
+        pandas_set = info.frameworks["PandasDataFrame"]
+        assert pandas_set is not None
+        assert {"rolling", "time:day"} <= pandas_set
+        assert "time:month" not in pandas_set
+        assert "time:year" not in pandas_set
+
+    def test_duckdb_includes_month_time_unit(self) -> None:
+        """DuckDB supports calendar time units."""
+        pytest.importorskip("duckdb")
+        info = DataOperationsCatalog.get("frame_aggregate")
+        duckdb_set = info.frameworks["DuckDBFramework"]
+        assert duckdb_set is not None
+        assert "time:month" in duckdb_set
+
+    def test_pyarrow_is_absent(self) -> None:
+        """frame_aggregate has no PyArrow implementation, so the key is absent."""
+        info = DataOperationsCatalog.get("frame_aggregate")
+        assert "PyArrowTable" not in info.frameworks
+
+
+class TestOffsetCell:
+    def test_subtype_label(self) -> None:
+        info = DataOperationsCatalog.get("offset")
+        assert info.subtype_label == "offset type"
+
+    def test_subtype_universe(self) -> None:
+        """offset defines exactly the six offset types."""
+        info = DataOperationsCatalog.get("offset")
+        assert info.subtypes is not None
+        assert len(info.subtypes) == 6
+        assert set(info.subtypes) == set(OFFSET_SUBTYPES)
+
+    def test_pyarrow_is_absent(self) -> None:
+        """offset has no PyArrow implementation, so the key is absent."""
+        info = DataOperationsCatalog.get("offset")
+        assert "PyArrowTable" not in info.frameworks
+
+
+# ---------------------------------------------------------------------------
+# DataOperationsCatalog.is_supported()
+# ---------------------------------------------------------------------------
+
+
+class TestIsSupported:
+    def test_exact_cell_sqlite_median_false(self) -> None:
+        """SQLite cannot compute a median aggregation."""
+        assert DataOperationsCatalog.is_supported("aggregation", "median", "SqliteFramework") is False
+
+    def test_exact_cell_duckdb_median_true(self) -> None:
+        """DuckDB computes median natively."""
+        pytest.importorskip("duckdb")
+        assert DataOperationsCatalog.is_supported("aggregation", "median", "DuckDBFramework") is True
+
+    def test_exact_cell_sqlite_mean_true(self) -> None:
+        """SQLite supports mean via its AVG alias."""
+        assert DataOperationsCatalog.is_supported("aggregation", "mean", "SqliteFramework") is True
+
+    def test_operation_level_ema_pyarrow_false(self) -> None:
+        """subtype=None asks whether the operation exists on the framework at all."""
+        assert DataOperationsCatalog.is_supported("ema", framework="PyArrowTable") is False
+
+    def test_operation_level_ema_pandas_true(self) -> None:
+        pytest.importorskip("pandas")
+        assert DataOperationsCatalog.is_supported("ema", framework="PandasDataFrame") is True
+
+    def test_operation_level_percentile_sqlite_false(self) -> None:
+        assert DataOperationsCatalog.is_supported("percentile", framework="SqliteFramework") is False
+
+    def test_framework_matching_is_case_insensitive(self) -> None:
+        """Framework names match case-insensitively."""
+        assert DataOperationsCatalog.is_supported("aggregation", "sum", "sqliteframework") is True
+
+    def test_any_framework_median_true(self) -> None:
+        """framework=None asks whether at least one framework supports the subtype."""
+        pytest.importorskip("duckdb")
+        assert DataOperationsCatalog.is_supported("aggregation", subtype="median") is True
+
+    def test_unknown_operation_raises_value_error_listing_operations(self) -> None:
+        """Unknown operations raise ValueError listing the valid operation names."""
+        with pytest.raises(ValueError) as exc_info:
+            DataOperationsCatalog.is_supported("no_such_operation", "sum", "SqliteFramework")
+        message = str(exc_info.value)
+        assert "no_such_operation" in message
+        assert "aggregation" in message
+        assert "window_aggregation" in message
+
+    def test_unknown_subtype_raises_value_error_listing_subtypes(self) -> None:
+        """A subtype outside the operation's universe raises ValueError listing valid subtypes."""
+        with pytest.raises(ValueError) as exc_info:
+            DataOperationsCatalog.is_supported("aggregation", "bogus", "SqliteFramework")
+        message = str(exc_info.value)
+        assert "bogus" in message
+        assert "median" in message
+        assert "sum" in message
+
+    def test_unknown_framework_returns_false(self) -> None:
+        """Unknown or absent frameworks return False (open world, no error)."""
+        assert DataOperationsCatalog.is_supported("aggregation", "sum", "NoSuchFramework") is False

--- a/mloda/community/feature_groups/data_operations/tests/test_catalog.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_catalog.py
@@ -249,11 +249,11 @@ class TestRankCell:
         info = DataOperationsCatalog.get("rank")
         assert info.subtype_label == "rank type"
 
-    def test_pandas_excludes_percent_rank(self) -> None:
-        """Pandas percent_rank diverges from SQL semantics, so it is excluded."""
+    def test_pandas_supports_full_rank_type_set(self) -> None:
+        """Pandas computes all four named rank types, including SQL-semantics percent_rank."""
         pytest.importorskip("pandas")
         info = DataOperationsCatalog.get("rank")
-        assert info.frameworks["PandasDataFrame"] == frozenset({"row_number", "rank", "dense_rank"})
+        assert info.frameworks["PandasDataFrame"] == frozenset({"row_number", "rank", "dense_rank", "percent_rank"})
 
     def test_duckdb_includes_percent_rank(self) -> None:
         """DuckDB supports SQL percent_rank natively."""

--- a/mloda/community/feature_groups/data_operations/tests/test_framework_support_matrix.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_framework_support_matrix.py
@@ -1,31 +1,18 @@
-"""Drift check: the framework support matrix doc must match supported_*() sets.
+"""Drift check: the framework support matrix doc must match DataOperationsCatalog.
 
-The matrix page at ``docs/guides/data-operation-patterns/framework-support-matrix.md``
-lists, per data operation and per framework, which subtypes (agg_type /
-offset_type / rank_type / op) are supported. Its source of truth is the
-``supported_*()`` classmethods on the framework test classes under
-``mloda/community/feature_groups/data_operations/**/tests/test_{framework}.py``.
-
-Two tests live here:
-
-- ``test_framework_support_matrix_is_in_sync`` asserts the generated block
-  between the ``BEGIN GENERATED`` / ``END GENERATED`` markers in the doc
-  matches what the current ``supported_*()`` sets produce.
-- ``test_operations_list_covers_every_data_operation_on_disk`` guards against
-  a new data-operation directory being added without extending ``OPERATIONS``.
-
-When the drift test fails, regenerate the block between the markers with a
-coding agent so its contents match what this test produces, then rerun.
+The source of truth for ``docs/guides/data-operation-patterns/framework-support-matrix.md``
+is the production capability declared by the concrete classes (``compute_framework_rule``,
+the ``supports_compute_framework`` hook, and match-time restrictions), queried via
+``DataOperationsCatalog``. When ``test_framework_support_matrix_is_in_sync`` fails,
+regenerate the block between the ``BEGIN GENERATED`` / ``END GENERATED`` markers so it
+matches what this module renders, then rerun.
 """
 
 from __future__ import annotations
 
-import importlib
-import inspect
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
 
+from mloda.community.feature_groups.data_operations import DataOperationsCatalog, OperationInfo
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
 DOC_PATH = REPO_ROOT / "docs" / "guides" / "data-operation-patterns" / "framework-support-matrix.md"
@@ -34,6 +21,7 @@ DATA_OPERATIONS_ROOT = REPO_ROOT / "mloda" / "community" / "feature_groups" / "d
 BEGIN_MARKER = "<!-- BEGIN GENERATED: framework-support-matrix -->"
 END_MARKER = "<!-- END GENERATED: framework-support-matrix -->"
 
+#: Doc column order: (framework key, doc column label).
 FRAMEWORKS: list[tuple[str, str]] = [
     ("pyarrow", "PyArrow"),
     ("pandas", "Pandas"),
@@ -42,463 +30,122 @@ FRAMEWORKS: list[tuple[str, str]] = [
     ("sqlite", "SQLite"),
 ]
 
-SUPPORT_METHODS = (
-    "supported_agg_types",
-    "supported_ops",
-    "supported_frame_types",
-    "supported_offset_types",
-    "supported_rank_types",
-)
+#: Catalog framework key (``OperationInfo.frameworks``) per framework key.
+FRAMEWORK_CATALOG_KEYS: dict[str, str] = {
+    "pyarrow": "PyArrowTable",
+    "pandas": "PandasDataFrame",
+    "polars_lazy": "PolarsLazyDataFrame",
+    "duckdb": "DuckDBFramework",
+    "sqlite": "SqliteFramework",
+}
 
-
-def _frame_aggregate_subtypes(cls: type) -> set[str]:
-    """Flatten frame_aggregate's two-dimensional support into a single subtype set.
-
-    ``frame_aggregate`` is the only operation whose capability is governed by two
-    orthogonal axes: ``supported_frame_types()`` (rolling / time / cumulative /
-    expanding) and ``supported_time_units()`` (second / minute / ... / year, applied
-    only when ``time`` is in the frame-type set). Flatten to ``rolling``,
-    ``time:second``, ..., ``time:year``, ``cumulative``, ``expanding`` so a framework
-    that excludes ``time:month`` shows up as partial in the summary table.
-    """
-    frame_types: set[str] = set(cls.supported_frame_types())  # type: ignore[attr-defined]
-    time_units: set[str] = set(cls.supported_time_units())  # type: ignore[attr-defined]
-    out: set[str] = set()
-    for ft in frame_types:
-        if ft == "time":
-            for unit in time_units:
-                out.add(f"time:{unit}")
-        else:
-            out.add(ft)
-    return out
-
-
-@dataclass(frozen=True)
-class OperationSpec:
-    """Where to find an operation's test classes and its full subtype set."""
-
-    key: str
-    display: str
-    tests_pkg: str
-    base_module: str
-    base_class: str
-    subtype_label: str
-    order_hint: tuple[str, ...] = ()
-    # Optional callable that overrides the default ``supported_*`` lookup. Used by
-    # frame_aggregate to flatten (frame_type, time_unit) into compound subtypes.
-    subtype_extractor: Any = None
-
-
-OPERATIONS: list[OperationSpec] = [
-    OperationSpec(
-        key="aggregation",
-        display="aggregation",
-        tests_pkg="mloda.community.feature_groups.data_operations.aggregation.tests",
-        base_module="mloda.testing.feature_groups.data_operations.aggregation.aggregation",
-        base_class="AggregationTestBase",
-        subtype_label="agg type",
-        order_hint=(
-            "sum",
-            "avg",
-            "mean",
-            "count",
-            "min",
-            "max",
-            "std",
-            "var",
-            "std_pop",
-            "std_samp",
-            "var_pop",
-            "var_samp",
-            "median",
-            "mode",
-            "nunique",
-            "first",
-            "last",
-        ),
-    ),
-    OperationSpec(
-        key="binning",
-        display="binning",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.binning.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.binning.binning",
-        base_class="BinningTestBase",
-        subtype_label="op",
-        order_hint=("bin", "qbin"),
-    ),
-    OperationSpec(
-        key="datetime",
-        display="datetime",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.datetime.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.datetime.datetime",
-        base_class="DateTimeTestBase",
-        subtype_label="op",
-    ),
-    OperationSpec(
-        key="frame_aggregate",
-        display="frame_aggregate",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.frame_aggregate.frame_aggregate",
-        base_class="FrameAggregateTestBase",
-        subtype_label="frame type",
-        order_hint=(
-            "rolling",
-            "time:second",
-            "time:minute",
-            "time:hour",
-            "time:day",
-            "time:week",
-            "time:month",
-            "time:year",
-            "cumulative",
-            "expanding",
-        ),
-        subtype_extractor=_frame_aggregate_subtypes,
-    ),
-    OperationSpec(
-        key="offset",
-        display="offset",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.offset.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.offset.offset",
-        base_class="OffsetTestBase",
-        subtype_label="offset type",
-        order_hint=("lag", "lead", "diff", "pct_change", "first_value", "last_value"),
-    ),
-    OperationSpec(
-        key="percentile",
-        display="percentile",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.percentile.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.percentile.percentile",
-        base_class="PercentileTestBase",
-        subtype_label="op",
-    ),
-    OperationSpec(
-        key="rank",
-        display="rank",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.rank.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.rank.rank",
-        base_class="RankTestBase",
-        subtype_label="rank type",
-        order_hint=("row_number", "rank", "dense_rank", "percent_rank"),
-    ),
-    OperationSpec(
-        key="scalar_aggregate",
-        display="scalar_aggregate",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.scalar_aggregate.scalar_aggregate",
-        base_class="ScalarAggregateTestBase",
-        subtype_label="agg type",
-        order_hint=(
-            "sum",
-            "avg",
-            "mean",
-            "count",
-            "min",
-            "max",
-            "std",
-            "var",
-            "std_pop",
-            "std_samp",
-            "var_pop",
-            "var_samp",
-            "median",
-        ),
-    ),
-    OperationSpec(
-        key="scalar_arithmetic",
-        display="scalar_arithmetic",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.scalar_arithmetic.scalar_arithmetic",
-        base_class="ScalarArithmeticTestBase",
-        subtype_label="op",
-        order_hint=("add", "subtract", "multiply", "divide"),
-    ),
-    OperationSpec(
-        key="point_arithmetic",
-        display="point_arithmetic",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.point_arithmetic.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.point_arithmetic.point_arithmetic",
-        base_class="PointArithmeticTestBase",
-        subtype_label="op",
-        order_hint=("add", "subtract", "multiply", "divide"),
-    ),
-    OperationSpec(
-        key="time_bucketization",
-        display="time_bucketization",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.time_bucketization.time_bucketization",
-        base_class="TimeBucketizationTestBase",
-        subtype_label="op",
-        order_hint=("floor", "ceil", "round"),
-    ),
-    OperationSpec(
-        key="ffill",
-        display="ffill",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.ffill.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.ffill.ffill",
-        base_class="FfillTestBase",
-        subtype_label="op",
-    ),
-    OperationSpec(
-        key="ema",
-        display="ema",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.ema.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.ema.ema",
-        base_class="EmaTestBase",
-        subtype_label="op",
-    ),
-    OperationSpec(
-        key="sessionization",
-        display="sessionization",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.sessionization.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.sessionization.sessionization",
-        base_class="SessionizationTestBase",
-        subtype_label="op",
-    ),
-    OperationSpec(
-        key="window_aggregation",
-        display="window_aggregation",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_preserving.window_aggregation.window_aggregation",
-        base_class="WindowAggregationTestBase",
-        subtype_label="agg type",
-        order_hint=(
-            "sum",
-            "avg",
-            "mean",
-            "count",
-            "min",
-            "max",
-            "std",
-            "var",
-            "std_pop",
-            "std_samp",
-            "var_pop",
-            "var_samp",
-            "median",
-            "mode",
-            "nunique",
-            "first",
-            "last",
-        ),
-    ),
-    OperationSpec(
-        key="string",
-        display="string",
-        tests_pkg="mloda.community.feature_groups.data_operations.string.tests",
-        base_module="mloda.testing.feature_groups.data_operations.string.string",
-        base_class="StringTestBase",
-        subtype_label="op",
-        order_hint=("upper", "lower", "trim", "length", "reverse"),
-    ),
-    OperationSpec(
-        key="resample",
-        display="resample",
-        tests_pkg="mloda.community.feature_groups.data_operations.row_changing.resample.tests",
-        base_module="mloda.testing.feature_groups.data_operations.row_changing.resample.resample",
-        base_class="ResampleTestBase",
-        subtype_label="op",
-    ),
+#: Doc display order for operations. ``DataOperationsCatalog.list()`` is
+#: name-sorted; the doc keeps its historical grouping instead.
+OPERATIONS: list[str] = [
+    "aggregation",
+    "binning",
+    "datetime",
+    "frame_aggregate",
+    "offset",
+    "percentile",
+    "rank",
+    "scalar_aggregate",
+    "scalar_arithmetic",
+    "point_arithmetic",
+    "time_bucketization",
+    "ffill",
+    "ema",
+    "sessionization",
+    "window_aggregation",
+    "string",
+    "resample",
 ]
 
 
-def import_test_class(tests_pkg: str, framework: str, base_cls: type) -> type | None:
-    """Import test_{framework}.py under *tests_pkg* and return the concrete test class.
-
-    The concrete class is the one module-local subclass of *base_cls* (or ``None``
-    if the module does not exist)."""
-    mod_name = f"{tests_pkg}.test_{framework}"
-    try:
-        mod = importlib.import_module(mod_name)
-    except ModuleNotFoundError as e:
-        # Only treat the test module (or a missing parent tests package) as
-        # "framework absent". Broken imports *inside* an existing test module
-        # name a different module in ``e.name`` and must surface loudly.
-        if e.name and (e.name == mod_name or mod_name.startswith(e.name + ".")):
-            return None
-        raise
-    for _, obj in inspect.getmembers(mod, inspect.isclass):
-        if obj.__module__ != mod.__name__:
-            continue
-        if not issubclass(obj, base_cls):
-            continue
-        if obj is base_cls:
-            continue
-        return obj
-    return None
+def ordered_operations() -> list[OperationInfo]:
+    """Catalog entries in doc display order; fails loudly on any name mismatch."""
+    infos = {info.name: info for info in DataOperationsCatalog.list()}
+    missing = sorted(name for name in OPERATIONS if name not in infos)
+    extra = sorted(name for name in infos if name not in OPERATIONS)
+    if missing or extra:
+        raise RuntimeError(f"OPERATIONS is out of sync with DataOperationsCatalog: missing={missing} extra={extra}")
+    return [infos[name] for name in OPERATIONS]
 
 
-def supported_set(cls: type, extractor: Any = None) -> tuple[str | None, set[str] | None]:
-    """Return (method_name, set) for the support set on *cls*.
-
-    If *extractor* is provided it overrides the default ``supported_*`` lookup
-    (used by frame_aggregate to combine ``supported_frame_types`` and
-    ``supported_time_units`` into compound subtypes).
-    """
-    if extractor is not None:
-        try:
-            return extractor.__name__, set(extractor(cls))
-        except Exception:  # pragma: no cover - defensive
-            return extractor.__name__, None
-    for attr in SUPPORT_METHODS:
-        method = getattr(cls, attr, None)
-        if method is None:
-            continue
-        try:
-            return attr, set(method())
-        except Exception:  # pragma: no cover - defensive
-            return attr, None
-    return None, None
+def _framework_supported(info: OperationInfo, fw_key: str) -> frozenset[str] | None:
+    """The catalog's supported-subtype set for *fw_key*, or None when absent or subtype-less."""
+    return info.frameworks.get(FRAMEWORK_CATALOG_KEYS[fw_key])
 
 
-def discover_uncovered_tests_packages() -> list[str]:
-    """Return tests-package dotted paths that contain ``test_<framework>.py``
-    files but are not referenced by any :data:`OPERATIONS` entry.
-
-    Guards against silent incompleteness when a new data operation is added but
-    nobody remembers to extend :data:`OPERATIONS`.
-    """
-    if not DATA_OPERATIONS_ROOT.exists():
-        return []
-    covered = {op.tests_pkg for op in OPERATIONS}
-    framework_keys = {fw_key for fw_key, _ in FRAMEWORKS}
-    missing: list[str] = []
-    for tests_dir in DATA_OPERATIONS_ROOT.rglob("tests"):
-        if not tests_dir.is_dir():
-            continue
-        if not any((tests_dir / f"test_{fw}.py").exists() for fw in framework_keys):
-            continue
-        rel = tests_dir.relative_to(REPO_ROOT)
-        pkg = ".".join(rel.parts)
-        if pkg not in covered:
-            missing.append(pkg)
-    return sorted(missing)
-
-
-def sort_subtypes(items: Iterable[str], order_hint: tuple[str, ...]) -> list[str]:
-    items = list(items)
-    index = {name: pos for pos, name in enumerate(order_hint)}
-    items.sort(key=lambda name: (index.get(name, len(order_hint)), name))
-    return items
-
-
-def collect_operation(op: OperationSpec) -> dict[str, Any]:
-    base_mod = importlib.import_module(op.base_module)
-    base_cls = getattr(base_mod, op.base_class)
-
-    # Resolve the framework-level data.
-    per_framework: dict[str, dict[str, Any]] = {}
-    union_subtypes: set[str] = set()
-    method_name: str | None = None
-
-    for fw_key, _fw_label in FRAMEWORKS:
-        cls = import_test_class(op.tests_pkg, fw_key, base_cls)
-        if cls is None:
-            per_framework[fw_key] = {"present": False, "subtypes": None, "method": None}
-            continue
-        attr, support = supported_set(cls, op.subtype_extractor)
-        per_framework[fw_key] = {"present": True, "subtypes": support, "method": attr}
-        if support is not None:
-            union_subtypes.update(support)
-            if method_name is None:
-                method_name = attr
-
-    if not union_subtypes:
-        # Operations with no supported_*() method (datetime, percentile,
-        # frame_aggregate) report at operation-level granularity only.
-        subtypes: list[str] | None = None
-    else:
-        subtypes = sort_subtypes(union_subtypes, op.order_hint)
-
-    return {
-        "op": op,
-        "method": method_name,
-        "subtypes": subtypes,
-        "frameworks": per_framework,
-    }
-
-
-def render_summary_table(collected: list[dict[str, Any]]) -> list[str]:
+def render_summary_table(infos: list[OperationInfo]) -> list[str]:
     header = "| Operation | " + " | ".join(label for _, label in FRAMEWORKS) + " |"
     sep = "|" + "|".join(["---"] * (len(FRAMEWORKS) + 1)) + "|"
     lines = [header, sep]
-    for item in collected:
-        op = item["op"]
-        subtypes = item["subtypes"]
-        cells: list[str] = [op.display]
+    for info in infos:
+        cells: list[str] = [info.name]
         for fw_key, _label in FRAMEWORKS:
-            fw = item["frameworks"][fw_key]
-            if not fw["present"]:
+            if FRAMEWORK_CATALOG_KEYS[fw_key] not in info.frameworks:
                 cells.append("--")
-            elif subtypes is None:
-                cells.append("full")
-            elif fw["subtypes"] is None or set(fw["subtypes"]) == set(subtypes):
+                continue
+            supported = _framework_supported(info, fw_key)
+            if info.subtypes is None or supported is None or set(supported) == set(info.subtypes):
                 cells.append("full")
             else:
-                count = len(fw["subtypes"])
-                total = len(subtypes)
-                cells.append(f"partial ({count}/{total})")
+                cells.append(f"partial ({len(supported)}/{len(info.subtypes)})")
         lines.append("| " + " | ".join(cells) + " |")
     return lines
 
 
-def render_detail_table(item: dict[str, Any]) -> list[str]:
-    op: OperationSpec = item["op"]
-    subtypes = item["subtypes"]
-    header_cells = [op.subtype_label.capitalize()] + [label for _, label in FRAMEWORKS]
+def render_detail_table(info: OperationInfo) -> list[str]:
+    header_cells = [info.subtype_label.capitalize()] + [label for _, label in FRAMEWORKS]
     header = "| " + " | ".join(header_cells) + " |"
     sep = "|" + "|".join(["---"] * len(header_cells)) + "|"
-    lines = [f"### {op.display}", ""]
+    lines = [f"### {info.name}", ""]
 
-    if subtypes is None:
-        # Single-row table: either the framework has a test class or it does not.
-        # Use the same "--" glyph as the summary so the legend stays consistent
-        # ("--" = no test class, "\u2717" = excluded subtype).
+    if info.subtypes is None:
+        # Single-row table: either the framework ships an implementation or it does not.
         row = ["(all)"]
         for fw_key, _label in FRAMEWORKS:
-            fw = item["frameworks"][fw_key]
-            row.append("\u2713" if fw["present"] else "--")
+            row.append("✓" if FRAMEWORK_CATALOG_KEYS[fw_key] in info.frameworks else "--")
         lines += [header, sep, "| " + " | ".join(row) + " |"]
         return lines
 
     lines += [header, sep]
-    for subtype in subtypes:
+    for subtype in info.subtypes:
         row = [f"`{subtype}`"]
         for fw_key, _label in FRAMEWORKS:
-            fw = item["frameworks"][fw_key]
-            if not fw["present"]:
+            if FRAMEWORK_CATALOG_KEYS[fw_key] not in info.frameworks:
                 row.append("--")
                 continue
-            if fw["subtypes"] is None:
-                row.append("\u2713")
-                continue
-            row.append("\u2713" if subtype in fw["subtypes"] else "\u2717")
+            supported = _framework_supported(info, fw_key)
+            row.append("✓" if supported is None or subtype in supported else "✗")
         lines.append("| " + " | ".join(row) + " |")
     return lines
 
 
-def render_generated_block(collected: list[dict[str, Any]]) -> str:
+def render_generated_block(infos: list[OperationInfo]) -> str:
     out: list[str] = [BEGIN_MARKER, ""]
     out.append("## Summary")
     out.append("")
     out.append(
-        "`full` means every subtype listed in the per-operation table below is supported. "
-        "`partial (k/n)` means the framework's test class restricts `supported_*()` to "
-        "k of the n subtypes this operation defines. `--` means the framework has no test "
-        "class for this operation (typically because no production implementation exists)."
+        "Cells reflect the production capability declarations (`compute_framework_rule`, the "
+        "`supports_compute_framework` hook, and match-time restrictions), queryable via "
+        "`DataOperationsCatalog`. `full` means the framework's production implementation declares "
+        "support for every subtype this operation defines. `partial (k/n)` means it declares k of "
+        "the n subtypes and rejects the rest. `--` means no implementation ships for this framework."
     )
     out.append("")
-    out.extend(render_summary_table(collected))
+    out.extend(render_summary_table(infos))
     out.append("")
     out.append("## Per-operation detail")
     out.append("")
     out.append(
-        "\u2713 = the framework's test-class `supported_*()` includes this subtype. "
-        "\u2717 = excluded. `--` = no test class for this framework."
+        "✓ = the framework's production implementation declares support for this subtype. "
+        "✗ = the implementation rejects it. `--` = no implementation ships for this framework."
     )
     out.append("")
-    for item in collected:
-        out.extend(render_detail_table(item))
+    for info in infos:
+        out.extend(render_detail_table(info))
         out.append("")
     out.append(END_MARKER)
     return "\n".join(out) + "\n"
@@ -514,28 +161,51 @@ def splice_into_doc(doc_text: str, generated: str) -> str:
     return doc_text[:begin] + generated.rstrip("\n") + trailing
 
 
+def discover_operation_dirs_on_disk() -> set[str]:
+    """Operation directory names that carry per-framework twin test modules.
+
+    A directory counts when its ``tests`` subpackage contains at least one
+    ``test_<framework>.py`` file. Guards against a new data operation landing
+    on disk without a catalog entry.
+    """
+    ops: set[str] = set()
+    if not DATA_OPERATIONS_ROOT.exists():
+        return ops
+    for tests_dir in DATA_OPERATIONS_ROOT.rglob("tests"):
+        if not tests_dir.is_dir():
+            continue
+        if not any((tests_dir / f"test_{fw_key}.py").exists() for fw_key, _label in FRAMEWORKS):
+            continue
+        ops.add(tests_dir.parent.name)
+    return ops
+
+
 _REGENERATION_HINT = (
     "Regenerate the block between the `BEGIN GENERATED` / `END GENERATED` markers in\n"
     f"{DOC_PATH.relative_to(REPO_ROOT)}\n"
-    "with a coding agent so it matches what this test produces, then rerun."
+    "so it matches render_generated_block(ordered_operations()) from this module, then rerun."
 )
 
 
 def test_framework_support_matrix_is_in_sync() -> None:
-    collected = [collect_operation(op) for op in OPERATIONS]
-    generated = render_generated_block(collected)
+    generated = render_generated_block(ordered_operations())
 
     current = DOC_PATH.read_text()
     expected = splice_into_doc(current, generated)
 
     assert expected == current, (
-        "framework-support-matrix.md is out of sync with supported_*() sets.\n" + _REGENERATION_HINT
+        "framework-support-matrix.md is out of sync with DataOperationsCatalog.\n" + _REGENERATION_HINT
     )
 
 
 def test_operations_list_covers_every_data_operation_on_disk() -> None:
-    uncovered = discover_uncovered_tests_packages()
+    catalog_names = {info.name for info in DataOperationsCatalog.list()}
+    assert sorted(OPERATIONS) == sorted(catalog_names), (
+        f"OPERATIONS does not match DataOperationsCatalog.list() names: "
+        f"missing={sorted(catalog_names - set(OPERATIONS))} extra={sorted(set(OPERATIONS) - catalog_names)}"
+    )
+    uncovered = sorted(discover_operation_dirs_on_disk() - catalog_names)
     assert uncovered == [], (
-        "OPERATIONS in this test module is missing entries for these tests packages "
-        "(each has test_<framework>.py files):\n  " + "\n  ".join(uncovered)
+        "DataOperationsCatalog is missing entries for these data-operation directories "
+        "(each has test_<framework>.py twin files):\n  " + "\n  ".join(uncovered)
     )

--- a/mloda/community/feature_groups/data_operations/tests/test_known_divergences.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_known_divergences.py
@@ -67,7 +67,7 @@ DOC_PATH = REPO_ROOT / "docs" / "guides" / "data-operation-patterns" / "known-di
 # the machine block's ``framework`` and ``operation`` fields against these turns a typo
 # or a stale name into a failure instead of letting those fields hold arbitrary text.
 KNOWN_FRAMEWORKS: frozenset[str] = frozenset(key for key, _label in FRAMEWORKS)
-KNOWN_OPERATIONS: frozenset[str] = frozenset(op.key for op in OPERATIONS)
+KNOWN_OPERATIONS: frozenset[str] = frozenset(OPERATIONS)
 
 ENTRIES_HEADING = "## Entries"
 BLOCK_BEGIN = "<!-- machine-checked"

--- a/mloda/community/feature_groups/data_operations/tests/test_twin_catalog_consistency.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_twin_catalog_consistency.py
@@ -1,0 +1,238 @@
+"""Consistency check: twin ``supported_*()`` sets must mirror DataOperationsCatalog.
+
+The per-framework test classes (``{op}/tests/test_{framework}.py``) restrict which
+subtypes their inherited reference tests run via ``supported_*()`` overrides. The
+production capability is declared on the concrete classes and queried via
+``DataOperationsCatalog``. These tests pin the twins to the catalog: a twin class
+must exist exactly for the frameworks the catalog lists, and its supported set
+must equal the catalog's frozenset (a twin without a ``supported_*()`` method
+implicitly claims the full subtype universe). ``frame_aggregate`` is compared on
+the flattened compound set (frame types plus ``time:<unit>``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from dataclasses import dataclass
+
+from mloda.community.feature_groups.data_operations import DataOperationsCatalog
+from mloda.community.feature_groups.data_operations.tests.test_framework_support_matrix import (
+    FRAMEWORK_CATALOG_KEYS,
+    FRAMEWORKS,
+)
+
+_COMMUNITY = "mloda.community.feature_groups.data_operations"
+_TESTING = "mloda.testing.feature_groups.data_operations"
+
+SUPPORT_METHODS: tuple[str, ...] = (
+    "supported_agg_types",
+    "supported_ops",
+    "supported_frame_types",
+    "supported_offset_types",
+    "supported_rank_types",
+)
+
+
+@dataclass(frozen=True)
+class TwinSpec:
+    """Where to find an operation's twin test classes."""
+
+    tests_pkg: str
+    base_module: str
+    base_class: str
+
+
+TWIN_SPECS: dict[str, TwinSpec] = {
+    "aggregation": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.aggregation.tests",
+        base_module=f"{_TESTING}.aggregation.aggregation",
+        base_class="AggregationTestBase",
+    ),
+    "binning": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.binning.tests",
+        base_module=f"{_TESTING}.row_preserving.binning.binning",
+        base_class="BinningTestBase",
+    ),
+    "datetime": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.datetime.tests",
+        base_module=f"{_TESTING}.row_preserving.datetime.datetime",
+        base_class="DateTimeTestBase",
+    ),
+    "ema": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.ema.tests",
+        base_module=f"{_TESTING}.row_preserving.ema.ema",
+        base_class="EmaTestBase",
+    ),
+    "ffill": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.ffill.tests",
+        base_module=f"{_TESTING}.row_preserving.ffill.ffill",
+        base_class="FfillTestBase",
+    ),
+    "frame_aggregate": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.frame_aggregate.tests",
+        base_module=f"{_TESTING}.row_preserving.frame_aggregate.frame_aggregate",
+        base_class="FrameAggregateTestBase",
+    ),
+    "offset": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.offset.tests",
+        base_module=f"{_TESTING}.row_preserving.offset.offset",
+        base_class="OffsetTestBase",
+    ),
+    "percentile": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.percentile.tests",
+        base_module=f"{_TESTING}.row_preserving.percentile.percentile",
+        base_class="PercentileTestBase",
+    ),
+    "point_arithmetic": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.point_arithmetic.tests",
+        base_module=f"{_TESTING}.row_preserving.point_arithmetic.point_arithmetic",
+        base_class="PointArithmeticTestBase",
+    ),
+    "rank": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.rank.tests",
+        base_module=f"{_TESTING}.row_preserving.rank.rank",
+        base_class="RankTestBase",
+    ),
+    "resample": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_changing.resample.tests",
+        base_module=f"{_TESTING}.row_changing.resample.resample",
+        base_class="ResampleTestBase",
+    ),
+    "scalar_aggregate": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.scalar_aggregate.tests",
+        base_module=f"{_TESTING}.row_preserving.scalar_aggregate.scalar_aggregate",
+        base_class="ScalarAggregateTestBase",
+    ),
+    "scalar_arithmetic": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.scalar_arithmetic.tests",
+        base_module=f"{_TESTING}.row_preserving.scalar_arithmetic.scalar_arithmetic",
+        base_class="ScalarArithmeticTestBase",
+    ),
+    "sessionization": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.sessionization.tests",
+        base_module=f"{_TESTING}.row_preserving.sessionization.sessionization",
+        base_class="SessionizationTestBase",
+    ),
+    "string": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.string.tests",
+        base_module=f"{_TESTING}.string.string",
+        base_class="StringTestBase",
+    ),
+    "time_bucketization": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.time_bucketization.tests",
+        base_module=f"{_TESTING}.row_preserving.time_bucketization.time_bucketization",
+        base_class="TimeBucketizationTestBase",
+    ),
+    "window_aggregation": TwinSpec(
+        tests_pkg=f"{_COMMUNITY}.row_preserving.window_aggregation.tests",
+        base_module=f"{_TESTING}.row_preserving.window_aggregation.window_aggregation",
+        base_class="WindowAggregationTestBase",
+    ),
+}
+
+
+def import_test_class(tests_pkg: str, framework: str, base_cls: type) -> type | None:
+    """Import test_{framework}.py under *tests_pkg* and return the concrete test class.
+
+    The concrete class is the one module-local subclass of *base_cls* (or ``None``
+    if the module does not exist)."""
+    mod_name = f"{tests_pkg}.test_{framework}"
+    try:
+        mod = importlib.import_module(mod_name)
+    except ModuleNotFoundError as e:
+        # Only treat the test module (or a missing parent tests package) as
+        # "framework absent". Broken imports *inside* an existing test module
+        # name a different module in ``e.name`` and must surface loudly.
+        if e.name and (e.name == mod_name or mod_name.startswith(e.name + ".")):
+            return None
+        raise
+    for _, obj in inspect.getmembers(mod, inspect.isclass):
+        if obj.__module__ != mod.__name__:
+            continue
+        if not issubclass(obj, base_cls):
+            continue
+        if obj is base_cls:
+            continue
+        return obj
+    return None
+
+
+def _twin_base_class(op_name: str) -> type:
+    spec = TWIN_SPECS[op_name]
+    base_cls: type = getattr(importlib.import_module(spec.base_module), spec.base_class)
+    return base_cls
+
+
+def _frame_aggregate_flat(cls: type) -> set[str]:
+    """Flatten frame_aggregate's (frame_type, time_unit) axes into compound subtypes."""
+    frame_types: set[str] = set(cls.supported_frame_types())  # type: ignore[attr-defined]
+    time_units: set[str] = set(cls.supported_time_units())  # type: ignore[attr-defined]
+    out: set[str] = set()
+    for frame_type in frame_types:
+        if frame_type == "time":
+            out.update(f"time:{unit}" for unit in time_units)
+        else:
+            out.add(frame_type)
+    return out
+
+
+def twin_supported_set(op_name: str, cls: type, universe: tuple[str, ...]) -> set[str]:
+    """The subtype set a twin class claims; no ``supported_*()`` method means the full universe."""
+    if op_name == "frame_aggregate":
+        return _frame_aggregate_flat(cls)
+    for attr in SUPPORT_METHODS:
+        method = getattr(cls, attr, None)
+        if method is not None:
+            return {str(item) for item in method()}
+    return set(universe)
+
+
+def test_twin_specs_cover_catalog() -> None:
+    """TWIN_SPECS keys must be exactly the catalog operation names."""
+    catalog_names = {info.name for info in DataOperationsCatalog.list()}
+    assert set(TWIN_SPECS) == catalog_names, (
+        f"TWIN_SPECS out of sync with DataOperationsCatalog: "
+        f"missing={sorted(catalog_names - set(TWIN_SPECS))} extra={sorted(set(TWIN_SPECS) - catalog_names)}"
+    )
+
+
+def test_twin_classes_exist_exactly_for_catalog_frameworks() -> None:
+    """Per operation, a twin test class exists iff the catalog lists the framework."""
+    problems: list[str] = []
+    for info in DataOperationsCatalog.list():
+        spec = TWIN_SPECS[info.name]
+        base_cls = _twin_base_class(info.name)
+        present = {
+            FRAMEWORK_CATALOG_KEYS[fw_key]
+            for fw_key, _label in FRAMEWORKS
+            if import_test_class(spec.tests_pkg, fw_key, base_cls) is not None
+        }
+        if present != set(info.frameworks):
+            problems.append(
+                f"{info.name}: twin classes for {sorted(present)} != catalog frameworks {sorted(info.frameworks)}"
+            )
+    assert problems == [], "twin presence diverges from DataOperationsCatalog:\n  " + "\n  ".join(problems)
+
+
+def test_twin_supported_sets_equal_catalog() -> None:
+    """Per operation and framework, the twin's supported set equals the catalog's frozenset."""
+    problems: list[str] = []
+    for info in DataOperationsCatalog.list():
+        if info.subtypes is None:
+            continue
+        spec = TWIN_SPECS[info.name]
+        base_cls = _twin_base_class(info.name)
+        for fw_key, _label in FRAMEWORKS:
+            supported = info.frameworks.get(FRAMEWORK_CATALOG_KEYS[fw_key])
+            cls = import_test_class(spec.tests_pkg, fw_key, base_cls)
+            if cls is None or supported is None:
+                # Presence mismatches are covered by the twin-presence test.
+                continue
+            twin = twin_supported_set(info.name, cls, info.subtypes)
+            if twin != set(supported):
+                problems.append(
+                    f"{info.name}/{FRAMEWORK_CATALOG_KEYS[fw_key]}: "
+                    f"twin-only={sorted(twin - set(supported))} catalog-only={sorted(set(supported) - twin)}"
+                )
+    assert problems == [], "twin supported_*() sets diverge from DataOperationsCatalog:\n  " + "\n  ".join(problems)

--- a/mloda/testing/feature_groups/data_operations/aggregation/aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/aggregation/aggregation.py
@@ -307,6 +307,11 @@ class AggregationTestBase(MaskTestMixin, DataOpsTestBase):
         """Avg must match reference."""
         self._compare_agg_with_reference("value_int__avg_agg", ["region"], use_approx=True)
 
+    def test_cross_framework_mean(self) -> None:
+        """Mean (avg alias) must match reference."""
+        self._skip_if_unsupported("mean")
+        self._compare_agg_with_reference("value_int__mean_agg", ["region"], use_approx=True)
+
     def test_cross_framework_count(self) -> None:
         """Count must match reference."""
         self._compare_agg_with_reference("value_int__count_agg", ["region"])

--- a/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
@@ -25,6 +25,8 @@ import pyarrow as pa
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
 
+from mloda.community.feature_groups.data_operations.row_preserving.rank.base import RankFeatureGroup
+
 
 # ---------------------------------------------------------------------------
 # Expected values (module-level constants)
@@ -77,7 +79,7 @@ class RankTestBase(DataOpsTestBase):
     to wire up their framework, then inherit concrete test methods for free.
     """
 
-    ALL_RANK_TYPES = {"row_number", "rank", "dense_rank", "percent_rank"}
+    ALL_RANK_TYPES = set(RankFeatureGroup.RANK_TYPES) | set(RankFeatureGroup.PARAMETRIC_RANK_FAMILIES)
 
     @classmethod
     def supported_rank_types(cls) -> set[str]:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -258,6 +258,11 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
         """Avg must match reference."""
         self._compare_with_reference("value_int__avg_window", partition_by=["region"], use_approx=True)
 
+    def test_cross_framework_mean(self) -> None:
+        """Mean (avg alias) must match reference."""
+        self._skip_if_unsupported("mean")
+        self._compare_with_reference("value_int__mean_window", partition_by=["region"], use_approx=True)
+
     def test_cross_framework_count(self) -> None:
         """Count must match reference."""
         self._compare_with_reference("value_int__count_window", partition_by=["region"])


### PR DESCRIPTION
Closes #247.

## What

Exposes the data operations and their framework-support matrix as a runtime API, derived from the mloda 0.9.0 match-time capability hook (per the re-scope in the issue thread):

- **Capability hook adoption**: `AggregationFeatureGroupBase` (aggregation, window_aggregation, scalar_aggregate), `RankFeatureGroup`, and `FrameAggregateFeatureGroup` now override `supports_compute_framework`, backed by `supported_agg_types()` / `supported_rank_types()` declarations on the restricted backends (derived from the existing implementation dicts, no new hand-written lists). Unsupported op/framework combos (e.g. `median` on SQLite) are now rejected at match time with core's capability message instead of failing at compute time.
- **`DataOperationsCatalog`** (new `catalog.py`, re-exported from the shared `data_operations` package init): `list()`, `get(name)`, and `is_supported(operation, subtype=None, framework=None)`. Per operation it reports the `PREFIX_PATTERN`, the subtype universe, and per-framework supported sets, derived by probing each concrete backend with `match_feature_group_criteria` + `supports_compute_framework` (the same decision the engine makes). Op modules import lazily, so missing per-op packages or framework deps degrade to absence.
- **Single source, no third copy**: `framework-support-matrix.md` is now rendered from the catalog (drift-checked as before), and the test-twin `supported_*()` sets are checked mirrors enforced by a new twin-vs-catalog consistency test.
- **Guide**: new "Querying capabilities at runtime" section in the matrix page plus a pointer from the overview; all snippets verified against the real API.

## Notable capability corrections found by deriving from production

- `mean` (avg alias) is genuinely supported on Pandas/Polars/DuckDB/SQLite aggregation and window_aggregation; the twins and matrix wrongly excluded it. Twins gained `mean` and new cross-framework mean reference tests run on all five frameworks.
- Pandas rank `percent_rank` is implemented with SQL semantics; an interim restriction was caught and reverted during review.
- Rank's parametric families (`ntile`, `top`, `bottom`) are now part of the catalog universe via a canonical `PARAMETRIC_RANK_FAMILIES` constant, mirroring the offset precedent.

## Review

Two independent deep reviews (Claude Opus subagent + codex) gated this PR. Accepted: parametric rank families in the catalog, immutable `frameworks` mapping (`MappingProxyType`), public `unsupported_subtype_error` wrapper, minor `get()` cleanup. Deferred with a follow-up issue: extending the frame_aggregate hook to also reject unsupported agg types at match time (pre-existing compute-time behavior, outside the matrix's documented axes).

## Testing

`tox` gate fully green: 4198 tests passed, 141 skipped; ruff format/check, mypy --strict, bandit clean.
