### PR TITLE
test(guards): regression guard against HashableDict credential usage (#270)

### DIFF
--- a/tests/test_end2end/test_no_hashabledict_credentials.py
+++ b/tests/test_end2end/test_no_hashabledict_credentials.py
@@ -8,6 +8,9 @@ tuple, now raises ``ValueError`` (use ``Credential(...)`` or a plain dict).
 so this guard only flags ``HashableDict`` usages near a credential /
 data-access marker. The registry is currently clean; this trips loudly if such
 a usage ever reappears.
+
+This is a best-effort proximity heuristic and can miss a reintroduction where
+``HashableDict`` is bound to an intermediate variable far from the marker.
 """
 
 from pathlib import Path
@@ -16,7 +19,27 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 _SKIP_DIRS = {"__pycache__", "site-packages", "node_modules"}
-_MARKERS = ("credentials", "add_credentials", "DataAccessCollection", "BaseInputData")
+_MARKERS = ("credentials", "DataAccessCollection", "BaseInputData")
+
+
+def _in_scope_indices(path: Path, lines: list[str]) -> set[int]:
+    """Return the set of line indices whose content is in scope for marker matching.
+
+    For ``.py`` files every line is in scope. For ``.md`` files only lines inside
+    triple-backtick fenced code blocks count (prose is ignored); the fence
+    delimiter lines themselves are excluded. Mirrors scripts/lint_docs.py.
+    """
+    if path.suffix != ".md":
+        return set(range(len(lines)))
+    scope: set[int] = set()
+    in_block = False
+    for i, line in enumerate(lines):
+        if line.startswith("```"):
+            in_block = not in_block
+            continue
+        if in_block:
+            scope.add(i)
+    return scope
 
 
 def find_hashabledict_credential_usages(root: Path) -> list[str]:
@@ -32,7 +55,10 @@ def find_hashabledict_credential_usages(root: Path) -> list[str]:
             lines = path.read_text(encoding="utf-8").splitlines()
         except (UnicodeDecodeError, OSError):
             continue
+        scope = _in_scope_indices(path, lines)
         for i, line in enumerate(lines):
+            if i not in scope:
+                continue
             if "HashableDict" not in line:
                 continue
             window = lines[max(0, i - 3) : i + 4]
@@ -95,6 +121,22 @@ def test_hashabledict_far_from_marker_not_flagged(tmp_path: Path) -> None:
 def test_guard_module_self_excluded(tmp_path: Path) -> None:
     """A file named like this guard module is skipped even with a flaggable pattern."""
     _write(tmp_path / "test_no_hashabledict_credentials.py", "credentials=[HashableDict({'host': 'h'})]\n")
+    assert find_hashabledict_credential_usages(tmp_path) == []
+
+
+def test_md_fenced_credential_hashabledict_flagged(tmp_path: Path) -> None:
+    """A flaggable credential HashableDict line inside a fenced python block in .md is flagged."""
+    body = "Migration example:\n\n```python\ncredentials=[HashableDict({'host': 'h'})]\n```\n"
+    _write(tmp_path / "guide.md", body)
+    hits = find_hashabledict_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "guide.md" in hits[0]
+
+
+def test_md_prose_credential_hashabledict_not_flagged(tmp_path: Path) -> None:
+    """A HashableDict + credentials mention only in .md prose (no fenced block) is not flagged."""
+    body = "Previously you passed a HashableDict as credentials; now use Credential.\n"
+    _write(tmp_path / "guide.md", body)
     assert find_hashabledict_credential_usages(tmp_path) == []
 
 

--- a/tests/test_end2end/test_no_hashabledict_credentials.py
+++ b/tests/test_end2end/test_no_hashabledict_credentials.py
@@ -1,0 +1,104 @@
+"""Repository guard for GitHub issue #270.
+
+mloda 0.9.0 dropped ``HashableDict`` acceptance from the credentials /
+DB-reader data-access path: passing a ``HashableDict`` as a credential value to
+``DataAccessCollection`` / ``add_credentials``, or in a ``BaseInputData`` reader
+tuple, now raises ``ValueError`` (use ``Credential(...)`` or a plain dict).
+``HashableDict`` stays valid for other uses (e.g. ``Options`` group hashing),
+so this guard only flags ``HashableDict`` usages near a credential /
+data-access marker. The registry is currently clean; this trips loudly if such
+a usage ever reappears.
+"""
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+_SKIP_DIRS = {"__pycache__", "site-packages", "node_modules"}
+_MARKERS = ("credentials", "add_credentials", "DataAccessCollection", "BaseInputData")
+
+
+def find_hashabledict_credential_usages(root: Path) -> list[str]:
+    """Return "relpath:lineno: line" for every HashableDict usage near a credential/data-access marker under root."""
+    hits: list[str] = []
+    for path in list(root.rglob("*.py")) + list(root.rglob("*.md")):
+        rel = path.relative_to(root)
+        if any(part.startswith(".") or part in _SKIP_DIRS for part in rel.parts):
+            continue
+        if path.name == "test_no_hashabledict_credentials.py":
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for i, line in enumerate(lines):
+            if "HashableDict" not in line:
+                continue
+            window = lines[max(0, i - 3) : i + 4]
+            if any(marker in w for w in window for marker in _MARKERS):
+                hits.append(f"{rel.as_posix()}:{i + 1}: {line.strip()}")
+    return sorted(hits)
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def test_credentials_list_hashabledict_flagged(tmp_path: Path) -> None:
+    """A HashableDict inside a credentials= list on one line is flagged."""
+    _write(tmp_path / "m.py", "credentials=[HashableDict({'host': 'h'})]\n")
+    hits = find_hashabledict_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "m.py" in hits[0]
+
+
+def test_credentials_dict_value_hashabledict_flagged(tmp_path: Path) -> None:
+    """A HashableDict as a credentials dict value is flagged."""
+    _write(tmp_path / "m.py", "credentials={'pg-prod': HashableDict({'host': 'h'})}\n")
+    hits = find_hashabledict_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "m.py" in hits[0]
+
+
+def test_add_credentials_hashabledict_flagged(tmp_path: Path) -> None:
+    """A HashableDict passed to add_credentials is flagged."""
+    _write(tmp_path / "m.py", "collection.add_credentials(HashableDict({'host': 'h'}))\n")
+    hits = find_hashabledict_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "m.py" in hits[0]
+
+
+def test_multiline_baseinputdata_reader_tuple_flagged(tmp_path: Path) -> None:
+    """A HashableDict a couple lines from a BaseInputData marker is flagged."""
+    body = "reader = BaseInputData(\n    source='pg',\n    creds=HashableDict({'host': 'h'}),\n)\n"
+    _write(tmp_path / "m.py", body)
+    hits = find_hashabledict_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "HashableDict" in hits[0]
+
+
+def test_credential_object_not_flagged(tmp_path: Path) -> None:
+    """A credentials= using Credential(...) with no HashableDict is not flagged."""
+    _write(tmp_path / "m.py", "credentials=Credential(host='h')\n")
+    assert find_hashabledict_credential_usages(tmp_path) == []
+
+
+def test_hashabledict_far_from_marker_not_flagged(tmp_path: Path) -> None:
+    """A legitimate HashableDict used for Options hashing (no marker nearby) is not flagged."""
+    body = "options = Options(\n    group={'algorithm': HashableDict({'k': 1})},\n)\n"
+    _write(tmp_path / "m.py", body)
+    assert find_hashabledict_credential_usages(tmp_path) == []
+
+
+def test_guard_module_self_excluded(tmp_path: Path) -> None:
+    """A file named like this guard module is skipped even with a flaggable pattern."""
+    _write(tmp_path / "test_no_hashabledict_credentials.py", "credentials=[HashableDict({'host': 'h'})]\n")
+    assert find_hashabledict_credential_usages(tmp_path) == []
+
+
+def test_repo_root_is_clean() -> None:
+    """The real repository must currently have zero HashableDict credential usages."""
+    offenders = find_hashabledict_credential_usages(_REPO_ROOT)
+    assert offenders == [], "HashableDict credential/data-access usage reappeared:\n" + "\n".join(offenders)


### PR DESCRIPTION
Closes #270.

## What

mloda 0.9.0 dropped `HashableDict` acceptance from the credentials / DB-reader data-access path: passing a `HashableDict` as a credential value to `DataAccessCollection` / `add_credentials`, or in a `BaseInputData` reader tuple, now raises `ValueError` (use `Credential(...)` or a plain dict). `HashableDict` itself stays valid elsewhere (e.g. `Options` group hashing).

An audit found zero `HashableDict` usages in this repo, so no migration was needed. This adds the remaining Definition-of-Done item: a regression guard.

## Change

New `tests/test_end2end/test_no_hashabledict_credentials.py`:

- `find_hashabledict_credential_usages(root)` scans `.py` files (all lines) and `.md` files (fenced code blocks only) for a `HashableDict` occurrence near a credential/data-access marker (`credentials`, `DataAccessCollection`, `BaseInputData`), within a small line window.
- `test_repo_root_is_clean` is the tripwire: it asserts the real repo has zero such usages today and fails loudly if one reappears.
- Legitimate non-credential `HashableDict` (Options hashing) and prose that merely describes the migration are not flagged.

Docs check (DoD item 1): guides `17-data-connection-matching.md` and `14-feature-matching.md` already teach only `Credential(...)` / plain-dict, no change needed.

## Notes

The guard is a best-effort proximity heuristic (documented in the module): it can miss a reintroduction where `HashableDict` is bound to an intermediate variable far from the marker. Reviewed by an independent Claude Opus pass and codex; both false-positive concerns (markdown prose) are addressed by the fenced-code-only scan.

## Test

`tox` green: 4222 passed, 141 skipped; ruff format + check, mypy --strict, bandit all clean.
