### PR TITLE
docs(guides): document provides_column_semantics opt-in for merge and filter engines (#279)

### DIFF
--- a/docs/guides/10-create-compute-framework.md
+++ b/docs/guides/10-create-compute-framework.md
@@ -65,25 +65,28 @@ Q11: Ready to test your implementation?
 | [09-testing-guide](compute-framework-patterns/09-testing-guide.md) | Testing your implementation |
 | [10-data-type-extraction](compute-framework-patterns/10-data-type-extraction.md) | Mapping native column types to mloda `DataType` |
 
-## Timezone / Unit Validation (Opt-In)
+## Timezone Validation (Opt-In)
 
-Since mloda 0.9.0, merge and filter engines can opt in to a timezone/unit guard that turns
+Since mloda 0.9.0, merge and filter engines can opt in to a timezone guard that turns
 silent-wrongness bugs (for example joining a timezone-aware column against a timezone-naive one)
 into a clear `ValueError`.
 
 - Opt in by setting `provides_column_semantics = True` on your `BaseMergeEngine` or
   `BaseFilterEngine` subclass and implementing `_column_semantics(data, column)`, which reports the
   column's framework-native semantics as a `ColumnSemantics` value (`is_ordered`, `is_temporal`,
-  `is_numeric`, `unit`, `is_tz_aware`).
+  `is_numeric`, `unit`, `is_tz_aware`). Only timezone-awareness is enforced today; `unit` is
+  reported for forward compatibility with the comparison contract but not yet validated by these
+  guards.
 - The flag defaults to `False`: the guard is skipped entirely, so a framework with no temporal
   intent never has to implement the hook.
 - An engine that opts in but forgets the hook fails loudly (`NotImplementedError`) instead of
   silently skipping validation.
-- As-of caveat: as-of joins call `_column_semantics` regardless of the flag, so an engine that
-  implements `merge_asof()` must implement the hook either way.
+- As-of caveat: as-of joins validate their time columns through `_column_semantics` (via
+  `validate_asof_time_columns()`) regardless of the flag, so an engine that implements
+  `merge_asof()` must implement the hook either way.
 
-See [06-merge-engine](compute-framework-patterns/06-merge-engine.md#timezone--unit-validation-opt-in)
-and [07-filter-engine](compute-framework-patterns/07-filter-engine.md#timezone--unit-validation-opt-in)
+See [06-merge-engine](compute-framework-patterns/06-merge-engine.md#timezone-validation-opt-in)
+and [07-filter-engine](compute-framework-patterns/07-filter-engine.md#timezone-validation-opt-in)
 for what each guard checks, and the upstream
 [comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md)
 doc for the full model.

--- a/docs/guides/10-create-compute-framework.md
+++ b/docs/guides/10-create-compute-framework.md
@@ -67,8 +67,8 @@ Q11: Ready to test your implementation?
 
 ## Timezone Validation (Opt-In)
 
-Since mloda 0.9.0, merge and filter engines can opt in to a timezone guard that turns silent
-tz-aware vs tz-naive mismatches into a clear `ValueError`.
+Merge and filter engines can opt in to a timezone guard that turns silent tz-aware vs tz-naive
+mismatches into a clear `ValueError`.
 
 - Opt in: set `provides_column_semantics = True` on your `BaseMergeEngine` / `BaseFilterEngine`
   subclass and implement `_column_semantics(data, column)` returning a `ColumnSemantics`.

--- a/docs/guides/10-create-compute-framework.md
+++ b/docs/guides/10-create-compute-framework.md
@@ -67,26 +67,17 @@ Q11: Ready to test your implementation?
 
 ## Timezone Validation (Opt-In)
 
-Since mloda 0.9.0, merge and filter engines can opt in to a timezone guard that turns
-silent-wrongness bugs (for example joining a timezone-aware column against a timezone-naive one)
-into a clear `ValueError`.
+Since mloda 0.9.0, merge and filter engines can opt in to a timezone guard that turns silent
+tz-aware vs tz-naive mismatches into a clear `ValueError`.
 
-- Opt in by setting `provides_column_semantics = True` on your `BaseMergeEngine` or
-  `BaseFilterEngine` subclass and implementing `_column_semantics(data, column)`, which reports the
-  column's framework-native semantics as a `ColumnSemantics` value (`is_ordered`, `is_temporal`,
-  `is_numeric`, `unit`, `is_tz_aware`). Only timezone-awareness is enforced today; `unit` is
-  reported for forward compatibility with the comparison contract but not yet validated by these
-  guards.
-- The flag defaults to `False`: the guard is skipped entirely, so a framework with no temporal
-  intent never has to implement the hook.
-- An engine that opts in but forgets the hook fails loudly (`NotImplementedError`) instead of
-  silently skipping validation.
-- As-of caveat: as-of joins validate their time columns through `_column_semantics` (via
-  `validate_asof_time_columns()`) regardless of the flag, so an engine that implements
-  `merge_asof()` must implement the hook either way.
+- Opt in: set `provides_column_semantics = True` on your `BaseMergeEngine` / `BaseFilterEngine`
+  subclass and implement `_column_semantics(data, column)` returning a `ColumnSemantics`.
+- Default `False`: guard skipped, hook never required.
+- Opted in without the hook: `NotImplementedError`.
+- As-of joins require the hook regardless of the flag.
 
 See [06-merge-engine](compute-framework-patterns/06-merge-engine.md#timezone-validation-opt-in)
 and [07-filter-engine](compute-framework-patterns/07-filter-engine.md#timezone-validation-opt-in)
-for what each guard checks, and the upstream
+for details, and the upstream
 [comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md)
-doc for the full model.
+for the full model.

--- a/docs/guides/10-create-compute-framework.md
+++ b/docs/guides/10-create-compute-framework.md
@@ -64,3 +64,26 @@ Q11: Ready to test your implementation?
 | [08-framework-transformer](compute-framework-patterns/08-framework-transformer.md) | Cross-framework conversion (PyArrow as hub) |
 | [09-testing-guide](compute-framework-patterns/09-testing-guide.md) | Testing your implementation |
 | [10-data-type-extraction](compute-framework-patterns/10-data-type-extraction.md) | Mapping native column types to mloda `DataType` |
+
+## Timezone / Unit Validation (Opt-In)
+
+Since mloda 0.9.0, merge and filter engines can opt in to a timezone/unit guard that turns
+silent-wrongness bugs (for example joining a timezone-aware column against a timezone-naive one)
+into a clear `ValueError`.
+
+- Opt in by setting `provides_column_semantics = True` on your `BaseMergeEngine` or
+  `BaseFilterEngine` subclass and implementing `_column_semantics(data, column)`, which reports the
+  column's framework-native semantics as a `ColumnSemantics` value (`is_ordered`, `is_temporal`,
+  `is_numeric`, `unit`, `is_tz_aware`).
+- The flag defaults to `False`: the guard is skipped entirely, so a framework with no temporal
+  intent never has to implement the hook.
+- An engine that opts in but forgets the hook fails loudly (`NotImplementedError`) instead of
+  silently skipping validation.
+- As-of caveat: as-of joins call `_column_semantics` regardless of the flag, so an engine that
+  implements `merge_asof()` must implement the hook either way.
+
+See [06-merge-engine](compute-framework-patterns/06-merge-engine.md#timezone--unit-validation-opt-in)
+and [07-filter-engine](compute-framework-patterns/07-filter-engine.md#timezone--unit-validation-opt-in)
+for what each guard checks, and the upstream
+[comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md)
+doc for the full model.

--- a/docs/guides/compute-framework-patterns/06-merge-engine.md
+++ b/docs/guides/compute-framework-patterns/06-merge-engine.md
@@ -95,46 +95,28 @@ def test_merge_engine():
 
 ## Timezone Validation (Opt-In)
 
-Since mloda 0.9.0, `BaseMergeEngine.merge()` can guard equi-joins (inner/left/right/outer) against
-timezone-incompatible key pairs. The guard is opt-in via a class attribute:
+Since mloda 0.9.0, `merge()` can guard equi-joins (inner/left/right/outer) against mixing
+timezone-aware and timezone-naive key columns. Opt in via a class attribute:
 
 ```python
 class MyMergeEngine(BaseMergeEngine):
     provides_column_semantics = True
 
     def _column_semantics(self, data, column) -> "ColumnSemantics":
-        dtype = data[column].dtype
-        return ColumnSemantics(
-            is_ordered=...,   # datetime / numeric / timedelta dtype
-            is_temporal=...,  # datetime-like dtype
-            is_numeric=...,
-            unit=...,         # e.g. "ns", or None if unknown
-            is_tz_aware=...,  # tz-aware datetime dtype
-        )
+        ...  # is_ordered, is_temporal, is_numeric, unit, is_tz_aware
 ```
 
-`ColumnSemantics` is not yet re-exported from `mloda.provider`; import it from the internal
-`comparison_contract` module (see the pandas implementation linked below for the exact path).
+- Default `False`: guard skipped, hook never required.
+- Checks only key pairs where **both** columns are temporal; string/numeric/id keys are unaffected.
+- `unit` is reported but not yet enforced (backends align resolutions natively).
+- Opted in without the hook: `NotImplementedError`.
+- As-of joins validate through the hook regardless of the flag (`validate_asof_time_columns()`,
+  called from your `merge_asof()`).
 
-Behavior:
-
-- `provides_column_semantics` defaults to `False`: the equi-join guard is skipped entirely, so a
-  time-agnostic framework never has to implement `_column_semantics`.
-- When opted in, aligned key pairs are checked only if **both** columns are temporal; string,
-  numeric, or id keys are never affected. Mixing timezone-aware and timezone-naive keys raises a
-  clear `ValueError`. The `unit` field is reported for forward compatibility but not yet enforced:
-  differing resolutions (for example `ns` vs `us`) are aligned natively by the backends.
-- Opting in without implementing the hook raises `NotImplementedError`, so a forgotten override
-  fails loudly.
-- As-of caveat: as-of joins validate their time columns through `_column_semantics` (via
-  `validate_asof_time_columns()`, called from the engine's `merge_asof()` implementation)
-  regardless of the flag, so an engine that implements as-of joins must implement the hook either
-  way.
-
-See the upstream
-[comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md)
-doc for the full model, and [07-filter-engine](07-filter-engine.md#timezone-validation-opt-in)
-for the filter-side guard.
+`ColumnSemantics` is not yet exported from `mloda.provider`; see the pandas implementation below
+for the import. Full model: upstream
+[comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md).
+Filter-side guard: [07-filter-engine](07-filter-engine.md#timezone-validation-opt-in).
 
 ## Stateful Connection
 

--- a/docs/guides/compute-framework-patterns/06-merge-engine.md
+++ b/docs/guides/compute-framework-patterns/06-merge-engine.md
@@ -95,8 +95,8 @@ def test_merge_engine():
 
 ## Timezone Validation (Opt-In)
 
-Since mloda 0.9.0, `merge()` can guard equi-joins (inner/left/right/outer) against mixing
-timezone-aware and timezone-naive key columns. Opt in via a class attribute:
+`merge()` can guard equi-joins (inner/left/right/outer) against mixing timezone-aware and
+timezone-naive key columns. Opt in via a class attribute:
 
 ```python
 class MyMergeEngine(BaseMergeEngine):

--- a/docs/guides/compute-framework-patterns/06-merge-engine.md
+++ b/docs/guides/compute-framework-patterns/06-merge-engine.md
@@ -93,7 +93,7 @@ def test_merge_engine():
     assert len(result) == 1  # Only idx=2 matches
 ```
 
-## Timezone / Unit Validation (Opt-In)
+## Timezone Validation (Opt-In)
 
 Since mloda 0.9.0, `BaseMergeEngine.merge()` can guard equi-joins (inner/left/right/outer) against
 timezone-incompatible key pairs. The guard is opt-in via a class attribute:
@@ -122,15 +122,18 @@ Behavior:
   time-agnostic framework never has to implement `_column_semantics`.
 - When opted in, aligned key pairs are checked only if **both** columns are temporal; string,
   numeric, or id keys are never affected. Mixing timezone-aware and timezone-naive keys raises a
-  clear `ValueError`.
+  clear `ValueError`. The `unit` field is reported for forward compatibility but not yet enforced:
+  differing resolutions (for example `ns` vs `us`) are aligned natively by the backends.
 - Opting in without implementing the hook raises `NotImplementedError`, so a forgotten override
   fails loudly.
-- As-of caveat: `merge_asof()` validates its time columns through `_column_semantics` regardless of
-  the flag, so an engine that implements as-of joins must implement the hook either way.
+- As-of caveat: as-of joins validate their time columns through `_column_semantics` (via
+  `validate_asof_time_columns()`, called from the engine's `merge_asof()` implementation)
+  regardless of the flag, so an engine that implements as-of joins must implement the hook either
+  way.
 
 See the upstream
 [comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md)
-doc for the full model, and [07-filter-engine](07-filter-engine.md#timezone--unit-validation-opt-in)
+doc for the full model, and [07-filter-engine](07-filter-engine.md#timezone-validation-opt-in)
 for the filter-side guard.
 
 ## Stateful Connection

--- a/docs/guides/compute-framework-patterns/06-merge-engine.md
+++ b/docs/guides/compute-framework-patterns/06-merge-engine.md
@@ -93,6 +93,46 @@ def test_merge_engine():
     assert len(result) == 1  # Only idx=2 matches
 ```
 
+## Timezone / Unit Validation (Opt-In)
+
+Since mloda 0.9.0, `BaseMergeEngine.merge()` can guard equi-joins (inner/left/right/outer) against
+timezone-incompatible key pairs. The guard is opt-in via a class attribute:
+
+```python
+class MyMergeEngine(BaseMergeEngine):
+    provides_column_semantics = True
+
+    def _column_semantics(self, data, column) -> "ColumnSemantics":
+        dtype = data[column].dtype
+        return ColumnSemantics(
+            is_ordered=...,   # datetime / numeric / timedelta dtype
+            is_temporal=...,  # datetime-like dtype
+            is_numeric=...,
+            unit=...,         # e.g. "ns", or None if unknown
+            is_tz_aware=...,  # tz-aware datetime dtype
+        )
+```
+
+`ColumnSemantics` is not yet re-exported from `mloda.provider`; import it from the internal
+`comparison_contract` module (see the pandas implementation linked below for the exact path).
+
+Behavior:
+
+- `provides_column_semantics` defaults to `False`: the equi-join guard is skipped entirely, so a
+  time-agnostic framework never has to implement `_column_semantics`.
+- When opted in, aligned key pairs are checked only if **both** columns are temporal; string,
+  numeric, or id keys are never affected. Mixing timezone-aware and timezone-naive keys raises a
+  clear `ValueError`.
+- Opting in without implementing the hook raises `NotImplementedError`, so a forgotten override
+  fails loudly.
+- As-of caveat: `merge_asof()` validates its time columns through `_column_semantics` regardless of
+  the flag, so an engine that implements as-of joins must implement the hook either way.
+
+See the upstream
+[comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md)
+doc for the full model, and [07-filter-engine](07-filter-engine.md#timezone--unit-validation-opt-in)
+for the filter-side guard.
+
 ## Stateful Connection
 
 For frameworks with connections, use `self.framework_connection`:

--- a/docs/guides/compute-framework-patterns/07-filter-engine.md
+++ b/docs/guides/compute-framework-patterns/07-filter-engine.md
@@ -83,9 +83,9 @@ class MyFilterEngine(BaseFilterEngine):
 
 ## Timezone Validation (Opt-In)
 
-Since mloda 0.9.0, range/min/max filters with a native `datetime` bound (pandas `Timestamp`
-counts) can be guarded: bound and column timezone-awareness must match. Opt in via a class
-attribute, mirroring the merge-engine flag:
+Range/min/max filters with a native `datetime` bound (pandas `Timestamp` counts) can be guarded:
+bound and column timezone-awareness must match. Opt in via a class attribute, mirroring the
+merge-engine flag:
 
 ```python
 class MyFilterEngine(BaseFilterEngine):

--- a/docs/guides/compute-framework-patterns/07-filter-engine.md
+++ b/docs/guides/compute-framework-patterns/07-filter-engine.md
@@ -81,7 +81,7 @@ class MyFilterEngine(BaseFilterEngine):
         return [row for row in data if row.get(col) in values]
 ```
 
-## Timezone / Unit Validation (Opt-In)
+## Timezone Validation (Opt-In)
 
 Since mloda 0.9.0, `BaseFilterEngine` can guard range/min/max filters whose bound is a native
 `datetime`: the bound's timezone-awareness must match the filtered column. The guard is opt-in via
@@ -101,11 +101,13 @@ Behavior:
 - `provides_column_semantics` defaults to `False`: the guard is skipped entirely, so a
   time-agnostic filter engine never has to implement `_column_semantics`.
 - When opted in, the hook is only consulted when a filter bound is actually a `datetime`
-  (pandas `Timestamp` counts); numeric and string filters never touch it.
+  (pandas `Timestamp` counts); numeric and string filters never touch it. The check itself only
+  fires when the filtered column is also temporal; a datetime bound against a non-temporal column
+  is not flagged.
 - Opting in without implementing the hook raises `NotImplementedError`, so a forgotten override
   fails loudly.
 
-See [06-merge-engine](06-merge-engine.md#timezone--unit-validation-opt-in) for the hook contract
+See [06-merge-engine](06-merge-engine.md#timezone-validation-opt-in) for the hook contract
 and example, and the upstream
 [comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md)
 doc for the full model.

--- a/docs/guides/compute-framework-patterns/07-filter-engine.md
+++ b/docs/guides/compute-framework-patterns/07-filter-engine.md
@@ -81,6 +81,35 @@ class MyFilterEngine(BaseFilterEngine):
         return [row for row in data if row.get(col) in values]
 ```
 
+## Timezone / Unit Validation (Opt-In)
+
+Since mloda 0.9.0, `BaseFilterEngine` can guard range/min/max filters whose bound is a native
+`datetime`: the bound's timezone-awareness must match the filtered column. The guard is opt-in via
+a class attribute, mirroring the merge-engine flag:
+
+```python
+class MyFilterEngine(BaseFilterEngine):
+    provides_column_semantics = True
+
+    @classmethod
+    def _column_semantics(cls, data, column) -> "ColumnSemantics":
+        ...  # report the column's native semantics, see 06-merge-engine
+```
+
+Behavior:
+
+- `provides_column_semantics` defaults to `False`: the guard is skipped entirely, so a
+  time-agnostic filter engine never has to implement `_column_semantics`.
+- When opted in, the hook is only consulted when a filter bound is actually a `datetime`
+  (pandas `Timestamp` counts); numeric and string filters never touch it.
+- Opting in without implementing the hook raises `NotImplementedError`, so a forgotten override
+  fails loudly.
+
+See [06-merge-engine](06-merge-engine.md#timezone--unit-validation-opt-in) for the hook contract
+and example, and the upstream
+[comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md)
+doc for the full model.
+
 ## FeatureGroup Override
 
 Individual FeatureGroups can override filter behavior per-class by defining `final_filters()` on the FeatureGroup itself. This takes precedence over the FilterEngine's `final_filters()` setting.

--- a/docs/guides/compute-framework-patterns/07-filter-engine.md
+++ b/docs/guides/compute-framework-patterns/07-filter-engine.md
@@ -83,9 +83,9 @@ class MyFilterEngine(BaseFilterEngine):
 
 ## Timezone Validation (Opt-In)
 
-Since mloda 0.9.0, `BaseFilterEngine` can guard range/min/max filters whose bound is a native
-`datetime`: the bound's timezone-awareness must match the filtered column. The guard is opt-in via
-a class attribute, mirroring the merge-engine flag:
+Since mloda 0.9.0, range/min/max filters with a native `datetime` bound (pandas `Timestamp`
+counts) can be guarded: bound and column timezone-awareness must match. Opt in via a class
+attribute, mirroring the merge-engine flag:
 
 ```python
 class MyFilterEngine(BaseFilterEngine):
@@ -93,24 +93,17 @@ class MyFilterEngine(BaseFilterEngine):
 
     @classmethod
     def _column_semantics(cls, data, column) -> "ColumnSemantics":
-        ...  # report the column's native semantics, see 06-merge-engine
+        ...  # see 06-merge-engine
 ```
 
-Behavior:
+- Default `False`: guard skipped, hook never required.
+- Fires only when the bound is a `datetime` and the column is temporal; numeric and string
+  filters are unaffected.
+- Opted in without the hook: `NotImplementedError`.
 
-- `provides_column_semantics` defaults to `False`: the guard is skipped entirely, so a
-  time-agnostic filter engine never has to implement `_column_semantics`.
-- When opted in, the hook is only consulted when a filter bound is actually a `datetime`
-  (pandas `Timestamp` counts); numeric and string filters never touch it. The check itself only
-  fires when the filtered column is also temporal; a datetime bound against a non-temporal column
-  is not flagged.
-- Opting in without implementing the hook raises `NotImplementedError`, so a forgotten override
-  fails loudly.
-
-See [06-merge-engine](06-merge-engine.md#timezone-validation-opt-in) for the hook contract
-and example, and the upstream
-[comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md)
-doc for the full model.
+Hook contract and example: [06-merge-engine](06-merge-engine.md#timezone-validation-opt-in).
+Full model: upstream
+[comparison contract](https://github.com/mloda-ai/mloda/blob/main/docs/docs/in_depth/comparison-contract.md).
 
 ## FeatureGroup Override
 


### PR DESCRIPTION
Closes #279.

Documents the opt-in `provides_column_semantics` flag (mloda 0.9.0, epic mloda#518, PR mloda#581) in the compute-framework authoring guides:

- `docs/guides/10-create-compute-framework.md`: new "Timezone Validation (Opt-In)" section: flag (default `False`), the `_column_semantics(data, column)` hook, loud failure on a forgotten override, as-of caveat.
- `docs/guides/compute-framework-patterns/06-merge-engine.md`: equi-join guard details with hook example; notes `ColumnSemantics` is not yet exported from `mloda.provider`.
- `docs/guides/compute-framework-patterns/07-filter-engine.md`: datetime filter-bound guard, cross-linked to 06.

Upstream links use GitHub blob URLs; the docs site has not rebuilt with the 0.9.0 comparison-contract page yet (site URL 404s).

Review pass (independent Claude Opus + codex) flagged "unit validation" as overstated: 0.9.0 only enforces timezone-awareness, `unit` is carried but not validated. Sections retitled to "Timezone Validation" with a note, plus two precision fixes (as-of path via `validate_asof_time_columns()`, filter guard requires a temporal column).

Definition of done:

- [x] Flag (default `False`), opt-in, hook contract documented
- [x] As-of caveat noted
- [x] Upstream comparison-contract doc linked
- [x] tox and `scripts/lint_docs.py` pass
