### PR TITLE
test(guards): regression guard against named-form string credentials (#267)

### DIFF
--- a/tests/test_end2end/test_no_named_form_string_credentials.py
+++ b/tests/test_end2end/test_no_named_form_string_credentials.py
@@ -1,0 +1,151 @@
+"""Repository guard for GitHub issue #267.
+
+mloda 0.9.0 made "named-form non-mapping credential values" raise
+``ValueError`` at construction: a ``credentials=`` (or ``add_credentials(...)``)
+mapping whose VALUE is a bare scalar/string literal instead of a nested mapping
+``{...}`` or a ``Credential(...)``. So ``credentials={'prod': 'dsn-string'}``
+now raises, while ``credentials={'prod': {'dsn': 'dsn-string'}}``,
+``credentials={'pg-prod': Credential(host='h')}``,
+``credentials=Credential(dsn='dsn-string')`` and list forms stay valid. This
+guard flags the offending named-string shape. The registry is currently clean;
+this trips loudly if such a usage ever reappears.
+
+This is a best-effort text/proximity heuristic and can miss a reintroduction
+split across lines or bound to an intermediate variable.
+"""
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+_SKIP_DIRS = {"__pycache__", "site-packages", "node_modules"}
+
+# Named-form mapping opened right after a credentials marker whose first value is a
+# bare quoted literal: ``credentials={'k': '...`` or ``add_credentials({'k': '...``.
+# Anchoring to the marker avoids matching a nested inner mapping value.
+_NAMED_FORM_STRING_RE = re.compile(r"(?:credentials\s*=|add_credentials\s*\()\s*\{\s*['\"][^'\"]*['\"]\s*:\s*['\"]")
+
+
+def _in_scope_indices(path: Path, lines: list[str]) -> set[int]:
+    """Return the set of line indices whose content is in scope for marker matching.
+
+    For ``.py`` files every line is in scope. For ``.md`` files only lines inside
+    triple-backtick fenced code blocks count (prose is ignored); the fence
+    delimiter lines themselves are excluded. Mirrors scripts/lint_docs.py.
+    """
+    if path.suffix != ".md":
+        return set(range(len(lines)))
+    scope: set[int] = set()
+    in_block = False
+    for i, line in enumerate(lines):
+        if line.startswith("```"):
+            in_block = not in_block
+            continue
+        if in_block:
+            scope.add(i)
+    return scope
+
+
+def find_named_form_string_credential_usages(root: Path) -> list[str]:
+    """Return "relpath:lineno: line" for every named-form string credential value under root."""
+    hits: list[str] = []
+    for path in list(root.rglob("*.py")) + list(root.rglob("*.md")):
+        rel = path.relative_to(root)
+        if any(part.startswith(".") or part in _SKIP_DIRS for part in rel.parts):
+            continue
+        if path.name == "test_no_named_form_string_credentials.py":
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (UnicodeDecodeError, OSError):
+            continue
+        scope = _in_scope_indices(path, lines)
+        for i, line in enumerate(lines):
+            if i not in scope:
+                continue
+            if _NAMED_FORM_STRING_RE.search(line):
+                hits.append(f"{rel.as_posix()}:{i + 1}: {line.strip()}")
+    return sorted(hits)
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def test_named_form_single_quoted_string_flagged(tmp_path: Path) -> None:
+    """A single-quoted named-form string credential value is flagged."""
+    _write(tmp_path / "m.py", "credentials={'prod': 'dsn-string'}\n")
+    hits = find_named_form_string_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "m.py" in hits[0]
+
+
+def test_named_form_double_quoted_string_flagged(tmp_path: Path) -> None:
+    """A double-quoted named-form string credential value is flagged."""
+    _write(tmp_path / "m.py", 'credentials={"prod": "dsn-string"}\n')
+    hits = find_named_form_string_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "m.py" in hits[0]
+
+
+def test_add_credentials_named_form_string_flagged(tmp_path: Path) -> None:
+    """A named-form string value passed to add_credentials is flagged."""
+    _write(tmp_path / "m.py", "collection.add_credentials({'prod': 'dsn-string'})\n")
+    hits = find_named_form_string_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "m.py" in hits[0]
+
+
+def test_nested_mapping_value_not_flagged(tmp_path: Path) -> None:
+    """A named-form value that is a nested mapping is not flagged."""
+    _write(tmp_path / "m.py", "credentials={'prod': {'dsn': 'dsn-string'}}\n")
+    assert find_named_form_string_credential_usages(tmp_path) == []
+
+
+def test_named_form_credential_object_value_not_flagged(tmp_path: Path) -> None:
+    """A named-form value that is a Credential(...) is not flagged."""
+    _write(tmp_path / "m.py", "credentials={'pg-prod': Credential(host='h')}\n")
+    assert find_named_form_string_credential_usages(tmp_path) == []
+
+
+def test_bare_credential_object_not_flagged(tmp_path: Path) -> None:
+    """A bare auto-named Credential(...) with a string kwarg is not flagged."""
+    _write(tmp_path / "m.py", "credentials=Credential(dsn='dsn-string')\n")
+    assert find_named_form_string_credential_usages(tmp_path) == []
+
+
+def test_list_form_not_flagged(tmp_path: Path) -> None:
+    """A list-form credentials value is not flagged."""
+    _write(tmp_path / "m.py", "credentials=[Credential(host='h'), {'host': 'h2'}]\n")
+    assert find_named_form_string_credential_usages(tmp_path) == []
+
+
+def test_guard_module_self_excluded(tmp_path: Path) -> None:
+    """A file named like this guard module is skipped even with a flaggable pattern."""
+    _write(tmp_path / "test_no_named_form_string_credentials.py", "credentials={'prod': 'dsn-string'}\n")
+    assert find_named_form_string_credential_usages(tmp_path) == []
+
+
+def test_md_fenced_named_form_string_flagged(tmp_path: Path) -> None:
+    """A flaggable named-form string credential line inside a fenced block in .md is flagged."""
+    body = "Migration example:\n\n```python\ncredentials={'prod': 'dsn-string'}\n```\n"
+    _write(tmp_path / "guide.md", body)
+    hits = find_named_form_string_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "guide.md" in hits[0]
+
+
+def test_md_prose_named_form_string_not_flagged(tmp_path: Path) -> None:
+    """A named-form string credential mention only in .md prose (no fenced block) is not flagged."""
+    body = "Previously credentials={'prod': 'dsn-string'} was allowed; now use a nested mapping.\n"
+    _write(tmp_path / "guide.md", body)
+    assert find_named_form_string_credential_usages(tmp_path) == []
+
+
+def test_repo_root_is_clean() -> None:
+    """The real repository must currently have zero named-form string credential usages."""
+    offenders = find_named_form_string_credential_usages(_REPO_ROOT)
+    assert offenders == [], "Named-form string credential usage reappeared:\n" + "\n".join(offenders)

--- a/tests/test_end2end/test_no_named_form_string_credentials.py
+++ b/tests/test_end2end/test_no_named_form_string_credentials.py
@@ -2,16 +2,17 @@
 
 mloda 0.9.0 made "named-form non-mapping credential values" raise
 ``ValueError`` at construction: a ``credentials=`` (or ``add_credentials(...)``)
-mapping whose VALUE is a bare scalar/string literal instead of a nested mapping
+mapping whose VALUE is a bare quoted-string literal instead of a nested mapping
 ``{...}`` or a ``Credential(...)``. So ``credentials={'prod': 'dsn-string'}``
 now raises, while ``credentials={'prod': {'dsn': 'dsn-string'}}``,
 ``credentials={'pg-prod': Credential(host='h')}``,
 ``credentials=Credential(dsn='dsn-string')`` and list forms stay valid. This
-guard flags the offending named-string shape. The registry is currently clean;
-this trips loudly if such a usage ever reappears.
+guard flags a bare quoted-string value at any position of the credentials
+mapping (non-string scalar values such as ints are out of scope). The registry
+is currently clean; this trips loudly if such a usage ever reappears.
 
-This is a best-effort text/proximity heuristic and can miss a reintroduction
-split across lines or bound to an intermediate variable.
+This is a best-effort single-line heuristic and can miss a reintroduction split
+across lines or bound to an intermediate variable.
 """
 
 import re
@@ -22,10 +23,64 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 _SKIP_DIRS = {"__pycache__", "site-packages", "node_modules"}
 
-# Named-form mapping opened right after a credentials marker whose first value is a
-# bare quoted literal: ``credentials={'k': '...`` or ``add_credentials({'k': '...``.
-# Anchoring to the marker avoids matching a nested inner mapping value.
-_NAMED_FORM_STRING_RE = re.compile(r"(?:credentials\s*=|add_credentials\s*\()\s*\{\s*['\"][^'\"]*['\"]\s*:\s*['\"]")
+# A credentials mapping opened right after a marker: ``credentials={`` or
+# ``add_credentials({``. The captured ``{`` opens the mapping at depth 1; a
+# top-level-aware scan then inspects each value for a bare quoted string.
+_MARKER_RE = re.compile(r"(?:credentials\s*=|add_credentials\s*\()\s*\{")
+
+
+def _mapping_has_top_level_string_value(line: str, open_idx: int) -> bool:
+    """Scan the credentials mapping opened at ``line[open_idx] == '{'``.
+
+    Returns True when any top-level (depth-1) value in the mapping is a bare
+    quoted-string literal. Tracks brace/bracket/paren depth and quoted strings
+    so nested ``{...}`` pairs, ``Credential(...)`` and list-form values are
+    ignored, and stops at the matching closing ``}`` of the mapping.
+    """
+    depth = 0
+    quote: str | None = None
+    expect_value = False  # True right after a top-level ':' until its value starts
+    i = open_idx
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if quote is not None:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            if expect_value and depth == 1:
+                return True
+            quote = ch
+            expect_value = False
+        elif ch in "{[(":
+            if expect_value and depth == 1:
+                expect_value = False
+            depth += 1
+        elif ch in "}])":
+            depth -= 1
+            if depth == 0:
+                return False
+        elif ch == ":" and depth == 1:
+            expect_value = True
+        elif ch == "," and depth == 1:
+            expect_value = False
+        elif expect_value and depth == 1 and not ch.isspace():
+            expect_value = False  # value starts with an identifier/number, not a string
+        i += 1
+    return False
+
+
+def _line_flags_named_form_string(line: str) -> bool:
+    """Return True when the line opens a credentials mapping with a bare top-level string value."""
+    for m in _MARKER_RE.finditer(line):
+        if _mapping_has_top_level_string_value(line, m.end() - 1):
+            return True
+    return False
 
 
 def _in_scope_indices(path: Path, lines: list[str]) -> set[int]:
@@ -65,7 +120,7 @@ def find_named_form_string_credential_usages(root: Path) -> list[str]:
         for i, line in enumerate(lines):
             if i not in scope:
                 continue
-            if _NAMED_FORM_STRING_RE.search(line):
+            if _line_flags_named_form_string(line):
                 hits.append(f"{rel.as_posix()}:{i + 1}: {line.strip()}")
     return sorted(hits)
 
@@ -108,6 +163,26 @@ def test_nested_mapping_value_not_flagged(tmp_path: Path) -> None:
 def test_named_form_credential_object_value_not_flagged(tmp_path: Path) -> None:
     """A named-form value that is a Credential(...) is not flagged."""
     _write(tmp_path / "m.py", "credentials={'pg-prod': Credential(host='h')}\n")
+    assert find_named_form_string_credential_usages(tmp_path) == []
+
+
+def test_multi_entry_later_string_value_flagged(tmp_path: Path) -> None:
+    """A multi-entry mapping whose first value is a nested mapping but a later value is a bare string is flagged."""
+    _write(tmp_path / "m.py", "credentials={'prod': {'dsn': 'ok'}, 'staging': 'dsn-string'}\n")
+    hits = find_named_form_string_credential_usages(tmp_path)
+    assert len(hits) == 1
+    assert "m.py" in hits[0]
+
+
+def test_multi_entry_all_mapping_values_not_flagged(tmp_path: Path) -> None:
+    """A multi-entry mapping where every value is a nested mapping is not flagged."""
+    _write(tmp_path / "m.py", "credentials={'prod': {'dsn': 'x'}, 'staging': {'dsn': 'y'}}\n")
+    assert find_named_form_string_credential_usages(tmp_path) == []
+
+
+def test_multi_entry_all_credential_values_not_flagged(tmp_path: Path) -> None:
+    """A multi-entry mapping where every value is a Credential(...) is not flagged."""
+    _write(tmp_path / "m.py", "credentials={'prod': Credential(host='h'), 'staging': Credential(host='h2')}\n")
     assert find_named_form_string_credential_usages(tmp_path) == []
 
 


### PR DESCRIPTION
## What

Adds a repository regression guard for GitHub issue #267 (DoD item 2): registry/enterprise plugins and tests audited for named-form non-mapping credential values, the shape mloda 0.9.0 now rejects.

`tests/test_end2end/test_no_named_form_string_credentials.py` flags the offending shape, a `credentials=` / `add_credentials(...)` mapping whose value is a bare quoted string (e.g. `credentials={'prod': 'dsn-string'}`), which raises `ValueError` at construction in mloda 0.9.0. Valid shapes stay clean: nested-mapping values, `Credential(...)` values, bare `credentials=Credential(...)`, and list forms.

It mirrors the sibling HashableDict guard (`test_no_hashabledict_credentials.py`, #270/#297): same `.md` fenced-block scoping, self-exclusion, and a `test_repo_root_is_clean` that asserts the registry has zero offenders today.

## Why

Closes the remaining open DoD item for #267 the same way its sibling item was closed, as a durable guard rather than a one-time audit. Guides (#291) and the HashableDict guard (#297) already landed; the registry is currently clean of this shape (guide 17 mentions it only as a documented anti-pattern in prose inline-code).

## Detection

A top-level-aware single-line scanner walks the credentials mapping tracking brace/bracket/paren depth and quoted strings, so it flags a bare string value at any position (including multi-entry mappings where a later value is the offender) while ignoring nested `{...}`, `Credential(...)`, and list-form values. Best-effort: does not catch cross-line splits, intermediate variables, or non-string scalar values.

## Review

Two independent deep reviews (fresh Claude Opus agent + codex) ran on the diff. Both found no blockers. The one accepted finding (multi-entry mappings where a later value is the offender were missed by the initial first-pair regex) is fixed in the second commit; the scanner now inspects every top-level value.

## Test

`tox` green: 4277 passed, 141 skipped, ruff format/check clean, mypy --strict clean, bandit clean.
