### PR TITLE
docs: guide for sibling-reader selection and non-file / HTTP readers

### DIFF
--- a/.claude/skills/mloda-plugins/SKILL.md
+++ b/.claude/skills/mloda-plugins/SKILL.md
@@ -100,7 +100,7 @@ Q22: Need to build the execution plan once at startup and reuse it for repeated 
     YES → See 24-realtime
 
 Q23: Need both plan reuse and incremental per-group delivery?
-    YES → Use session.stream_run() — see 23-streaming and 24-realtime
+    YES → Use session.stream_run(), see 23-streaming and 24-realtime
 
 Q24: Need conditional aggregation that nulls out non-matching values instead of removing rows?
     YES → See 25-masking

--- a/.claude/skills/mloda-plugins/SKILL.md
+++ b/.claude/skills/mloda-plugins/SKILL.md
@@ -104,6 +104,9 @@ Q23: Need both plan reuse and incremental per-group delivery?
 
 Q24: Need conditional aggregation that nulls out non-matching values instead of removing rows?
     YES → See 25-masking
+
+Q25: Several readers under one root group, or a non-file (HTTP/API) source?
+    YES → See 27-input-data-readers
 ```
 
 ### Feature Group Pattern Guides
@@ -137,6 +140,8 @@ Location: `docs/guides/feature-group-patterns/`
 | 23 | `23-streaming.md` | Incremental results with `stream_all` |
 | 24 | `24-realtime.md` | Reuse execution plans with `prepare` + `run` |
 | 25 | `25-masking.md` | Conditional aggregation via FilterMask |
+| 26 | `26-input-feature-forwarding.md` | Consume another group's root feature; option forwarding |
+| 27 | `27-input-data-readers.md` | Sibling reader selection; non-file / HTTP readers |
 
 ---
 

--- a/docs/guides/feature-group-patterns/01-root-features.md
+++ b/docs/guides/feature-group-patterns/01-root-features.md
@@ -90,6 +90,12 @@ Database credentials live in the same collection. Wrap each slot in the typed
 so a single credential dict is never mistaken for a `{handle: value}` registry. See
 [Credentials](17-data-connection-matching.md#credentials).
 
+## Multiple Readers Under One Root Group
+
+Several `BaseInputData` readers can sit under one root FeatureGroup; a feature picks
+one via an Options key equal to the reader's class name. See
+[Input-data readers](27-input-data-readers.md).
+
 ## Real Implementations
 
 | File | Description |

--- a/docs/guides/feature-group-patterns/17-data-connection-matching.md
+++ b/docs/guides/feature-group-patterns/17-data-connection-matching.md
@@ -71,7 +71,9 @@ def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], 
     ...
 ```
 
-The `options` parameter is required.
+The `options` parameter is required. For the full reader-selection contract
+(class-name option keys, sibling readers, non-file / HTTP sources), see
+[Input-data readers](27-input-data-readers.md).
 
 ## Named Handles and Multi-Source Disambiguation
 

--- a/docs/guides/feature-group-patterns/27-input-data-readers.md
+++ b/docs/guides/feature-group-patterns/27-input-data-readers.md
@@ -23,15 +23,15 @@ The reader class itself also works as the key. It is normalized to the class-nam
 Feature("pm10_value", options={UbaAirReader: "https://api.example.org/airdata/v4"})
 ```
 
-Because class names are unique per class, sibling readers never collide: each feature's option key routes to exactly one reader. A key that names no known reader simply matches nothing.
+As long as sibling readers have distinct class names, they cannot collide: each feature's option key routes to exactly one reader. Two readers sharing a `__name__` across modules are unsupported. A key that names no known reader simply matches nothing.
 
 ### The reserved "BaseInputData" key
 
-When a reader matches, the `(ReaderClass, data_access)` pair is stored under the reserved `"BaseInputData"` options key and consumed by `init_reader` at load time. Do not set this key yourself; setting it twice with different values raises `ValueError`.
+When a reader matches, the `(ReaderClass, data_access)` pair is stored under the reserved `"BaseInputData"` options key and consumed by `init_reader` at load time. The class-name option key is the normal way to select a reader; advanced callers and tests may preseed the reserved key directly. Setting it twice with different values raises `ValueError`.
 
 ## Sibling Readers Under One Root FeatureGroup
 
-Each reader decides for itself whether a given data access belongs to it by overriding `match_subclass_data_access`. Return the data access to claim it, `None` to decline:
+The option key selects the reader; the selected reader then confirms the data access via `match_subclass_data_access`. Return the data access to claim it, `None` to decline:
 
 ```python
 from typing import Any
@@ -68,7 +68,7 @@ class UbaAirReader(ReadFile):
         ...  # HTTP GET, normalize JSON, return the table
 ```
 
-Both are siblings under the stock `ReadFileFeature` root group; no extra FeatureGroup is needed. The user routes per feature:
+Both are siblings under the stock `ReadFileFeature` root group; no extra FeatureGroup is needed. The user routes per feature (snippets on this page build on each other):
 
 ```python
 features = [
@@ -106,7 +106,7 @@ End to end, run the feature through `mloda.run_all` with `PluginCollector.enable
 
 | File | Description |
 |------|-------------|
-| [base_input_data.py](https://github.com/mloda-ai/mloda/blob/main/mloda/core/abstract_plugins/components/input_data/base_input_data.py) | `feature_scope_data_access`, key normalization, `init_reader` |
+| [base_input_data.py](https://github.com/mloda-ai/mloda/blob/main/mloda/core/abstract_plugins/components/input_data/base_input_data.py) | `feature_scope_data_access`, class-or-string key helper, `init_reader` |
 | [read_file.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/feature_group/input_data/read_file.py) | `ReadFile` base, `match_subclass_data_access` seam |
 | [test_sibling_reader_selection.py](https://github.com/mloda-ai/mloda/blob/main/tests/test_plugins/feature_group/input_data/test_sibling_reader_selection.py) | The pinned selection contract |
 

--- a/docs/guides/feature-group-patterns/27-input-data-readers.md
+++ b/docs/guides/feature-group-patterns/27-input-data-readers.md
@@ -1,0 +1,119 @@
+# Input-Data Readers: Sibling Selection and Non-File Sources
+
+How to run several `BaseInputData` readers under one root FeatureGroup and point each feature at the right one, including readers for non-file (HTTP/API) sources.
+
+**What**: Select a specific reader per feature via an Options key equal to the reader's class name; build non-file readers by subclassing `ReadFile`.
+**When**: One root FeatureGroup fronts multiple data sources (CSV file, CSV URL, JSON REST endpoint), each with its own reader.
+**Why**: Reader selection is contract-driven, not guesswork; knowing the contract avoids reading mloda core source.
+**Where**: Connector plugins with several readers (e.g. a CKAN CSV reader, a direct-URL CSV reader, and a REST JSON reader side by side).
+
+## The Selection Contract
+
+A feature selects a reader with an Option whose **key equals the reader's class name** (`BaseInputData.data_access_name()`, i.e. `cls.__name__`). The value is the data access the reader receives (a path, URL, or any object the reader understands):
+
+```python
+from mloda.user import Feature
+
+Feature("pm10_value", options={UbaAirReader.__name__: "https://api.example.org/airdata/v4"})
+```
+
+The reader class itself also works as the key. It is normalized to the class-name string when the `Options` object is constructed, so both spellings are one identity (equal, same hash, same lookup):
+
+```python
+Feature("pm10_value", options={UbaAirReader: "https://api.example.org/airdata/v4"})
+```
+
+Because class names are unique per class, sibling readers never collide: each feature's option key routes to exactly one reader. A key that names no known reader simply matches nothing.
+
+### The reserved "BaseInputData" key
+
+When a reader matches, the `(ReaderClass, data_access)` pair is stored under the reserved `"BaseInputData"` options key and consumed by `init_reader` at load time. Do not set this key yourself; setting it twice with different values raises `ValueError`.
+
+## Sibling Readers Under One Root FeatureGroup
+
+Each reader decides for itself whether a given data access belongs to it by overriding `match_subclass_data_access`. Return the data access to claim it, `None` to decline:
+
+```python
+from typing import Any
+from mloda.provider import FeatureSet
+from mloda.user import Options
+from mloda_plugins.feature_group.input_data.read_file import ReadFile
+
+
+class GovDataReader(ReadFile):
+    """CKAN-hosted CSV."""
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
+        if isinstance(data_access, str) and "ckan" in data_access:
+            return data_access
+        return None
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        ...  # fetch and parse, return the table
+
+
+class UbaAirReader(ReadFile):
+    """REST JSON endpoint."""
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
+        if isinstance(data_access, str) and data_access.startswith("https://api."):
+            return data_access
+        return None
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        ...  # HTTP GET, normalize JSON, return the table
+```
+
+Both are siblings under the stock `ReadFileFeature` root group; no extra FeatureGroup is needed. The user routes per feature:
+
+```python
+features = [
+    Feature("population", options={GovDataReader.__name__: ckan_url}),
+    Feature("pm10_value", options={UbaAirReader: api_url}),
+]
+```
+
+## Non-File / HTTP Sources
+
+`ReadFile`'s default matching (`match_read_file_data_access`) is file-suffix and directory shaped. For a non-file source (an HTTP endpoint returning JSON), the sanctioned recipe is: subclass `ReadFile`, override `match_subclass_data_access` and `load_data` wholesale. On that path `suffix()` is never consulted (it is inert), so you do not implement it.
+
+`ApiInputData` is not the tool for this despite its name: it injects in-memory data passed through the API request and is not an HTTP client.
+
+A reader that overrides `load_data` wholesale is classified as a final reader structurally; no reader code runs during classification.
+
+## Test
+
+Follow the contract at unit level, then end to end:
+
+```python
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.user import Options
+
+
+def test_option_key_routes_to_reader() -> None:
+    options = Options({UbaAirReader.__name__: "https://api.example.org/airdata/v4"})
+    assert BaseInputData.feature_scope_data_access(options, "pm10_value") is True
+    assert options.get("BaseInputData")[0] is UbaAirReader
+```
+
+End to end, run the feature through `mloda.run_all` with `PluginCollector.enabled_feature_groups({ReadFileFeature})`. mloda core pins the full contract in [test_sibling_reader_selection.py](https://github.com/mloda-ai/mloda/blob/main/tests/test_plugins/feature_group/input_data/test_sibling_reader_selection.py); mirror its isolation trick (a unique marker option key checked in `match_subclass_data_access`) so test readers never hijack matching in unrelated tests.
+
+## Real Implementations
+
+| File | Description |
+|------|-------------|
+| [base_input_data.py](https://github.com/mloda-ai/mloda/blob/main/mloda/core/abstract_plugins/components/input_data/base_input_data.py) | `feature_scope_data_access`, key normalization, `init_reader` |
+| [read_file.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/feature_group/input_data/read_file.py) | `ReadFile` base, `match_subclass_data_access` seam |
+| [test_sibling_reader_selection.py](https://github.com/mloda-ai/mloda/blob/main/tests/test_plugins/feature_group/input_data/test_sibling_reader_selection.py) | The pinned selection contract |
+
+See also [Data Access Patterns](https://mloda-ai.github.io/mloda/in_depth/data-access-patterns/) for the underlying model.
+
+## Combines With
+
+- **Pattern 1 (Root features)**: readers are the `input_data()` of root features
+- **Pattern 17 (Data connection matching)**: `DataAccessCollection` and handles for connection-shaped sources
+- **Pattern 11 (Options)**: option keys and context vs group semantics

--- a/docs/guides/feature-group-patterns/27-input-data-readers.md
+++ b/docs/guides/feature-group-patterns/27-input-data-readers.md
@@ -90,7 +90,7 @@ A reader that overrides `load_data` wholesale is classified as a final reader st
 Follow the contract at unit level, then end to end:
 
 ```python
-from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.provider import BaseInputData
 from mloda.user import Options
 
 

--- a/docs/guides/feature-group-patterns/index.md
+++ b/docs/guides/feature-group-patterns/index.md
@@ -32,6 +32,7 @@ See also: [Create a feature group](../09-create-feature-group.md)
 24. [Realtime Execution](24-realtime.md) - Realtime feature computation and serving
 25. [Masking](25-masking.md) - Feature masking and sensitive data handling
 26. [Input-feature forwarding](26-input-feature-forwarding.md) - Consuming another group's root feature and controlling which options forward upstream
+27. [Input-data readers](27-input-data-readers.md) - Selecting among sibling readers and building non-file / HTTP readers
 
 ## Related Guides
 


### PR DESCRIPTION
Adds feature-group-patterns guide 27, the remaining DoD item of mloda-ai/mloda#565.

Covers:
- selecting among sibling BaseInputData readers under one root FeatureGroup via an Options key equal to the reader class name (string form and class-as-key, normalized to one identity)
- the reserved BaseInputData options key consumed by init_reader
- the sanctioned non-file / HTTP recipe: subclass ReadFile, override match_subclass_data_access and load_data; suffix() is inert on that path; ApiInputData is not an HTTP client
- test guidance mirroring the pinned core contract (test_sibling_reader_selection.py)

Also: index entry, cross-links from guides 01 and 17, and the mloda-plugins skill table gains rows for guides 26 (previously missing) and 27 plus decision-tree question Q25.

Coordination with mloda-ai/mloda#601: the guides were grepped for stale reader-authoring claims (supports_scoped_data_access, load_data classification); none exist, so this page only adds new guidance and does not preempt that audit.

Docs-only change; the tox gate exercises Python sources and is unaffected.

Reviewed by two independent deep reviews; findings (overstated no-collision claim, too-strict reserved-key wording, snippet self-containment) are addressed in the second commit.