### PR TITLE
feat(extenders): adopt the mloda 0.10 extender error contract

### DIFF
--- a/docs/guides/11-create-extender.md
+++ b/docs/guides/11-create-extender.md
@@ -24,6 +24,7 @@ Q3: Need state with ParallelizationMode.MULTIPROCESSING?
 | `wraps()` | Yes | Return `Set[ExtenderHook]` of hooks to wrap |
 | `__call__(func, *args, **kwargs)` | Yes | Wrap and execute the function |
 | `priority` | No | Execution order (lower = first, default 100) |
+| `raise_on_error` | No | If `True` (default), a failure of this extender breaks the calculation. Set `False` for warning-only extenders |
 
 ## Available Hooks
 
@@ -40,6 +41,9 @@ from typing import Any
 from mloda.steward import Extender, ExtenderHook
 
 class MyExtender(Extender):
+    def __init__(self, raise_on_error: bool = True) -> None:
+        self.raise_on_error = raise_on_error
+
     def wraps(self) -> set[ExtenderHook]:
         return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
 
@@ -50,9 +54,13 @@ class MyExtender(Extender):
         return result
 ```
 
-## Chaining
+## Chaining and Error Handling
 
-Multiple extenders for the same hook chain automatically (sorted by priority, lower first). If one fails, an error is logged and the chain continues.
+Multiple extenders for the same hook chain automatically (sorted by priority, lower first).
+
+Extender failures are breaking by default, both for a single extender and in a chain: the exception propagates and the calculation fails. An extender opts into warning-only behavior by setting `raise_on_error = False` (commonly a constructor argument). Its failure is then logged as a warning and the wrapped function still runs. Non-critical or observability extenders should pass `False`.
+
+Only the extender's own failure is caught. An exception raised by the wrapped function always propagates, and the wrapped function is never run twice.
 
 ## Pickle Compatibility
 

--- a/mloda/community/extenders/example/community_example_extender.py
+++ b/mloda/community/extenders/example/community_example_extender.py
@@ -8,9 +8,13 @@ from mloda.steward import Extender, ExtenderHook
 class CommunityExampleExtender(Extender):
     """Community Example Extender for demonstrating plugin structure."""
 
+    def __init__(self, raise_on_error: bool = True) -> None:
+        """Set whether a failure of this extender breaks the calculation."""
+        self.raise_on_error = raise_on_error
+
     def wraps(self) -> set[ExtenderHook]:
         """Return the set of hooks this extender wraps."""
-        return set()
+        return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
 
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
         """Execute the wrapped function without modification."""

--- a/mloda/community/extenders/example/tests/test_community_example_extender.py
+++ b/mloda/community/extenders/example/tests/test_community_example_extender.py
@@ -1,6 +1,47 @@
 """Tests for CommunityExampleExtender."""
 
-from mloda.steward import Extender
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from mloda.steward import Extender, ExtenderHook
+from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+from mloda.user import PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+from mloda.community.extenders.example import CommunityExampleExtender
+
+# Canonical value_int column of the shared 12-row test dataset.
+_VALUE_INT = [10, -5, 0, 20, None, 50, 30, 60, 15, 15, 40, -10]
+
+
+class FailingCommunityExampleExtender(CommunityExampleExtender):
+    """Deliberately failing extender: its own code raises before delegating to func."""
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("extender boom")
+
+
+def _run_value_int(extender: Extender) -> list[Any]:
+    """Run the minimal ``value_int`` feature through run_all with one extender."""
+    plugin_collector = PluginCollector.enabled_feature_groups({PyArrowDataOpsTestDataCreator})
+
+    results = mloda.run_all(
+        ["value_int"],
+        compute_frameworks={PyArrowTable},
+        plugin_collector=plugin_collector,
+        function_extender={extender},
+    )
+
+    for table in results:
+        if "value_int" in table.column_names:
+            values: list[Any] = table.to_pydict()["value_int"]
+            return values
+
+    raise AssertionError("No result table with value_int found")
 
 
 class TestCommunityExampleExtenderImport:
@@ -54,3 +95,46 @@ class TestCommunityExampleExtenderBasicFunctionality:
 
         instance = CommunityExampleExtender()
         assert instance is not None
+
+
+class TestCommunityExampleExtenderErrorContract:
+    """raise_on_error, wraps() and the pass-through __call__."""
+
+    def test_raise_on_error_defaults_to_true(self) -> None:
+        """Default is breaking: a failure propagates."""
+        assert CommunityExampleExtender().raise_on_error is True
+
+    def test_raise_on_error_can_be_disabled(self) -> None:
+        """raise_on_error=False marks the extender as warning-only."""
+        assert CommunityExampleExtender(raise_on_error=False).raise_on_error is False
+
+    def test_wraps_calculate_feature_hook(self) -> None:
+        """The extender must hook feature calculation, otherwise it never runs."""
+        assert ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE in CommunityExampleExtender().wraps()
+
+    def test_call_is_pass_through(self) -> None:
+        """__call__ forwards args and returns the wrapped function's result."""
+        assert CommunityExampleExtender()(lambda x, y: x + y, 1, 2) == 3
+
+
+class TestCommunityExampleExtenderRunAll:
+    """End-to-end raise_on_error semantics through mloda.run_all."""
+
+    def test_pass_through_extender_does_not_change_result(self) -> None:
+        """The example extender is a no-op: the feature computes normally."""
+        assert _run_value_int(CommunityExampleExtender()) == _VALUE_INT
+
+    def test_failing_extender_breaks_run_by_default(self) -> None:
+        """raise_on_error=True (default): the extender failure propagates out of run_all."""
+        with pytest.raises(Exception, match="extender boom"):
+            _run_value_int(FailingCommunityExampleExtender())
+
+    def test_failing_extender_warns_only_when_raise_on_error_false(self, caplog: pytest.LogCaptureFixture) -> None:
+        """raise_on_error=False: failure is logged as a warning and the feature still computes."""
+        with caplog.at_level(logging.WARNING):
+            values = _run_value_int(FailingCommunityExampleExtender(raise_on_error=False))
+
+        assert values == _VALUE_INT
+
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("extender boom" in message for message in warnings), warnings

--- a/mloda/community/extenders/example/tests/test_community_example_extender.py
+++ b/mloda/community/extenders/example/tests/test_community_example_extender.py
@@ -7,6 +7,9 @@ from typing import Any
 
 import pytest
 
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
+from mloda.provider import ComputeFramework, FeatureGroup, FeatureSet
 from mloda.steward import Extender, ExtenderHook
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
 from mloda.user import PluginCollector, mloda
@@ -25,15 +28,46 @@ class FailingCommunityExampleExtender(CommunityExampleExtender):
         raise RuntimeError("extender boom")
 
 
-def _run_value_int(extender: Extender) -> list[Any]:
-    """Run the minimal ``value_int`` feature through run_all with one extender."""
+class CountingCommunityExampleExtender(CommunityExampleExtender):
+    """Healthy pass-through extender that records how often it was invoked."""
+
+    def __init__(self, raise_on_error: bool = True) -> None:
+        super().__init__(raise_on_error=raise_on_error)
+        self.calls = 0
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        self.calls += 1
+        return super().__call__(func, *args, **kwargs)
+
+
+class FailingCalculateFeatureGroup(FeatureGroup):
+    """Root feature group whose calculate_feature always raises, counting its invocations."""
+
+    calls = 0
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"boom_feature"})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PyArrowTable}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        cls.calls += 1
+        raise RuntimeError("inner boom")
+
+
+def _run_value_int(*extenders: Extender) -> list[Any]:
+    """Run the minimal ``value_int`` feature through run_all with the given extenders."""
     plugin_collector = PluginCollector.enabled_feature_groups({PyArrowDataOpsTestDataCreator})
 
     results = mloda.run_all(
         ["value_int"],
         compute_frameworks={PyArrowTable},
         plugin_collector=plugin_collector,
-        function_extender={extender},
+        function_extender=set(extenders),
     )
 
     for table in results:
@@ -42,6 +76,18 @@ def _run_value_int(extender: Extender) -> list[Any]:
             return values
 
     raise AssertionError("No result table with value_int found")
+
+
+def _run_boom_feature(*extenders: Extender) -> Any:
+    """Run the always-failing ``boom_feature`` through run_all with the given extenders."""
+    plugin_collector = PluginCollector.enabled_feature_groups({FailingCalculateFeatureGroup})
+
+    return mloda.run_all(
+        ["boom_feature"],
+        compute_frameworks={PyArrowTable},
+        plugin_collector=plugin_collector,
+        function_extender=set(extenders),
+    )
 
 
 class TestCommunityExampleExtenderImport:
@@ -138,3 +184,29 @@ class TestCommunityExampleExtenderRunAll:
 
         warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
         assert any("extender boom" in message for message in warnings), warnings
+
+    def test_warning_only_failure_does_not_stop_other_extender_in_chain(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Chained extenders: a warning-only failure is contained, the healthy one still runs."""
+        healthy = CountingCommunityExampleExtender()
+
+        with caplog.at_level(logging.WARNING):
+            values = _run_value_int(FailingCommunityExampleExtender(raise_on_error=False), healthy)
+
+        assert values == _VALUE_INT
+        assert healthy.calls > 0
+
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("extender boom" in message for message in warnings), warnings
+
+    def test_wrapped_function_failure_propagates_and_runs_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A failure of the wrapped function propagates even for a warning-only extender, without a re-run."""
+        FailingCalculateFeatureGroup.calls = 0
+
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(Exception, match="inner boom"):
+                _run_boom_feature(CommunityExampleExtender(raise_on_error=False))
+
+        assert FailingCalculateFeatureGroup.calls == 1
+
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("inner boom" in message for message in warnings), warnings

--- a/mloda/enterprise/extenders/example/enterprise_example_extender.py
+++ b/mloda/enterprise/extenders/example/enterprise_example_extender.py
@@ -8,9 +8,13 @@ from mloda.steward import Extender, ExtenderHook
 class EnterpriseExampleExtender(Extender):
     """An example enterprise extender that demonstrates the Extender pattern."""
 
+    def __init__(self, raise_on_error: bool = True) -> None:
+        """Set whether a failure of this extender breaks the calculation."""
+        self.raise_on_error = raise_on_error
+
     def wraps(self) -> set[ExtenderHook]:
         """Return the hooks this extender wraps."""
-        return set()
+        return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
 
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
         """Execute the wrapped function."""

--- a/mloda/enterprise/extenders/example/tests/test_enterprise_example_extender.py
+++ b/mloda/enterprise/extenders/example/tests/test_enterprise_example_extender.py
@@ -1,6 +1,47 @@
 """Tests for EnterpriseExampleExtender."""
 
-from mloda.steward import Extender
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from mloda.steward import Extender, ExtenderHook
+from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+from mloda.user import PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+from mloda.enterprise.extenders.example import EnterpriseExampleExtender
+
+# Canonical value_int column of the shared 12-row test dataset.
+_VALUE_INT = [10, -5, 0, 20, None, 50, 30, 60, 15, 15, 40, -10]
+
+
+class FailingEnterpriseExampleExtender(EnterpriseExampleExtender):
+    """Deliberately failing extender: its own code raises before delegating to func."""
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("extender boom")
+
+
+def _run_value_int(extender: Extender) -> list[Any]:
+    """Run the minimal ``value_int`` feature through run_all with one extender."""
+    plugin_collector = PluginCollector.enabled_feature_groups({PyArrowDataOpsTestDataCreator})
+
+    results = mloda.run_all(
+        ["value_int"],
+        compute_frameworks={PyArrowTable},
+        plugin_collector=plugin_collector,
+        function_extender={extender},
+    )
+
+    for table in results:
+        if "value_int" in table.column_names:
+            values: list[Any] = table.to_pydict()["value_int"]
+            return values
+
+    raise AssertionError("No result table with value_int found")
 
 
 class TestEnterpriseExampleExtenderImport:
@@ -54,3 +95,46 @@ class TestEnterpriseExampleExtenderBasicFunctionality:
 
         instance = EnterpriseExampleExtender()
         assert instance is not None
+
+
+class TestEnterpriseExampleExtenderErrorContract:
+    """raise_on_error, wraps() and the pass-through __call__."""
+
+    def test_raise_on_error_defaults_to_true(self) -> None:
+        """Default is breaking: a failure propagates."""
+        assert EnterpriseExampleExtender().raise_on_error is True
+
+    def test_raise_on_error_can_be_disabled(self) -> None:
+        """raise_on_error=False marks the extender as warning-only."""
+        assert EnterpriseExampleExtender(raise_on_error=False).raise_on_error is False
+
+    def test_wraps_calculate_feature_hook(self) -> None:
+        """The extender must hook feature calculation, otherwise it never runs."""
+        assert ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE in EnterpriseExampleExtender().wraps()
+
+    def test_call_is_pass_through(self) -> None:
+        """__call__ forwards args and returns the wrapped function's result."""
+        assert EnterpriseExampleExtender()(lambda x, y: x + y, 1, 2) == 3
+
+
+class TestEnterpriseExampleExtenderRunAll:
+    """End-to-end raise_on_error semantics through mloda.run_all."""
+
+    def test_pass_through_extender_does_not_change_result(self) -> None:
+        """The example extender is a no-op: the feature computes normally."""
+        assert _run_value_int(EnterpriseExampleExtender()) == _VALUE_INT
+
+    def test_failing_extender_breaks_run_by_default(self) -> None:
+        """raise_on_error=True (default): the extender failure propagates out of run_all."""
+        with pytest.raises(Exception, match="extender boom"):
+            _run_value_int(FailingEnterpriseExampleExtender())
+
+    def test_failing_extender_warns_only_when_raise_on_error_false(self, caplog: pytest.LogCaptureFixture) -> None:
+        """raise_on_error=False: failure is logged as a warning and the feature still computes."""
+        with caplog.at_level(logging.WARNING):
+            values = _run_value_int(FailingEnterpriseExampleExtender(raise_on_error=False))
+
+        assert values == _VALUE_INT
+
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("extender boom" in message for message in warnings), warnings


### PR DESCRIPTION
Closes #283.

The upstream contract (mloda-ai/mloda#593, #630) makes extender failures breaking by default on both the single-extender and composite paths. An extender opts into warning-only behavior with `raise_on_error = False`: its failure is logged as a warning and the wrapped function still runs. Only the extender's own failure is caught.

## Changes

- `CommunityExampleExtender` and `EnterpriseExampleExtender` take `raise_on_error: bool = True` as a constructor argument and store it on the base-class property.
- Both now return `{ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}` from `wraps()`. They previously returned an empty set, which meant they were never invoked, so as examples they demonstrated nothing and the contract was not observable.
- `docs/guides/11-create-extender.md` documented the old swallow-and-continue chaining semantics ("if one fails, an error is logged and the chain continues"), which is now wrong. Corrected, with `raise_on_error` added to the methods table and the example.

## Extender sweep

The registry ships exactly two extenders, both pure pass-through examples. Neither is observability or telemetry, so both keep the breaking default of `True` and expose the constructor argument to demonstrate the opt-in. There is no extender here that warrants `raise_on_error = False` as its default.

## Tests

Per package: default is breaking, the constructor sets warning-only, `wraps()` hooks feature calculation, `__call__` stays a pass-through, and both modes end to end through `run_all` (a deliberately failing extender propagates by default; with `raise_on_error=False` the run succeeds with correct values and logs a warning).

Community package additionally covers the two subtler clauses: a warning-only failure in a chain does not stop a healthy extender, and an exception from the wrapped function propagates rather than being downgraded to a warning, with the wrapped function invoked exactly once.

The mloda pin is already `>=0.10.0` on main, so no dependency change was needed.

tox: 4309 passed, ruff format/check, mypy --strict, bandit all clean.

## Review note

A reviewer flagged that a non-empty `wraps()` would make the bundled example extenders globally active via the `mloda.extenders` entry points. That is not the case: entry-point discovery only registers classes (`plugin_loader.py`), and extenders are applied only when instances are passed explicitly as `function_extender=` to `run_all` (`request.py` -> `CfwManager` -> `compute_framework_executor.py`). Registration is not application.