### PR TITLE
docs: correct match_guard / element_validator semantics for mloda 0.10.0 (#305)

### DIFF
--- a/docs/guides/feature-group-patterns/03-chained-features.md
+++ b/docs/guides/feature-group-patterns/03-chained-features.md
@@ -103,10 +103,10 @@ PROPERTY_MAPPING supports additional capabilities that reduce boilerplate in `ma
 
 - **`allowed_values`**: Declare the accepted value space in its own key; a spec dict rejects any key outside the schema. Build it with `property_spec` for construction-time validation. See [Options: PROPERTY_MAPPING value space](11-options.md#property_mapping-value-space).
 - **`required_when`**: Declare options that are only required under certain conditions via a predicate callable.
-- **`match_guard`**: Validate raw option values with a callable (e.g., check that a value is a list of strings). Does not require `strict_validation`.
-- **`element_validator`**: Validate individual parsed values when `strict_validation` is enabled (e.g., check that a value is a positive integer).
+- **`match_guard`**: Check the raw option value with a callable (e.g., that it is a list of strings). Does not require `strict_validation`; a falsy return is a non-match, not an error.
+- **`element_validator`**: Validate each parsed element when `strict_validation` is enabled (e.g., that it is a positive integer). A falsy return raises `ValueError`.
 
-See [Feature Matching: Conditional Requirements](14-feature-matching.md#conditional-requirements-with-required_when) for full details, examples, and a comparison table.
+See [Feature Matching: Conditional Requirements](14-feature-matching.md#conditional-requirements-with-required_when) for full details, examples, and a comparison table, and [PROPERTY_MAPPING Configuration](https://mloda-ai.github.io/mloda/in_depth/property-mapping/) for the precedence and lifecycle rules.
 
 ## Test
 

--- a/docs/guides/feature-group-patterns/03-chained-features.md
+++ b/docs/guides/feature-group-patterns/03-chained-features.md
@@ -104,9 +104,9 @@ PROPERTY_MAPPING supports additional capabilities that reduce boilerplate in `ma
 - **`allowed_values`**: Declare the accepted value space in its own key; a spec dict rejects any key outside the schema. Build it with `property_spec` for construction-time validation. See [Options: PROPERTY_MAPPING value space](11-options.md#property_mapping-value-space).
 - **`required_when`**: Declare options that are only required under certain conditions via a predicate callable.
 - **`match_guard`**: Check the raw option value with a callable (e.g., that it is a list of strings). Does not require `strict_validation`; a falsy return is a non-match, not an error.
-- **`element_validator`**: Validate each parsed element when `strict_validation` is enabled (e.g., that it is a positive integer). A falsy return raises `ValueError`.
+- **`element_validator`**: Validate each parsed element when `strict_validation` is enabled (e.g., that it is a positive integer). A falsy return raises `ValueError`, which the mixin turns into a non-match plus a rejection reason in the resolution error.
 
-See [Feature Matching: Conditional Requirements](14-feature-matching.md#conditional-requirements-with-required_when) for full details, examples, and a comparison table, and [PROPERTY_MAPPING Configuration](https://mloda-ai.github.io/mloda/in_depth/property-mapping/) for the precedence and lifecycle rules.
+See [Feature Matching: Key Differences](14-feature-matching.md#key-differences-from-element_validator) for the comparison table and examples, and [PROPERTY_MAPPING Configuration](https://mloda-ai.github.io/mloda/in_depth/property-mapping/) for the precedence and lifecycle rules.
 
 ## Test
 

--- a/docs/guides/feature-group-patterns/11-options.md
+++ b/docs/guides/feature-group-patterns/11-options.md
@@ -56,7 +56,7 @@ feature = Feature("price__scaled", Options(
 | Default (no propagation) | Context stays local to the feature where it's defined |
 | With `propagate_context_keys` | Listed keys are passed to all input features in the chain |
 
-Use propagation sparingly—most context should remain local. Common use cases include trace IDs for debugging, tenant identifiers, or configuration that genuinely needs to flow through the entire pipeline.
+Use propagation sparingly; most context should remain local. Common use cases include trace IDs for debugging, tenant identifiers, or configuration that genuinely needs to flow through the entire pipeline.
 
 ## PROPERTY_MAPPING value space
 
@@ -108,14 +108,14 @@ Since mloda 0.9.0, defining a `FeatureGroup` whose `PROPERTY_MAPPING` declares a
 
 When using `PROPERTY_MAPPING` with `FeatureChainParserMixin`, you can declare validation rules and conditional requirements directly on option entries:
 
-- **`element_validator`**: Validate each parsed element with a callable (requires `strict_validation: True`). A falsy return raises `ValueError`, surfaced to the end user as a rejection reason.
-- **`match_guard`**: Check the raw option value with a callable (no `strict_validation` needed). Useful for composite types like lists or dicts. A falsy return is a plain non-match, so another feature group can still take the feature.
+- **`element_validator`**: Validate each parsed element with a callable (requires `strict_validation: True`). A falsy return raises `ValueError`, which the mixin turns into a non-match plus a rejection reason in the resolution error.
+- **`match_guard`**: Check the raw option value with a callable (no `strict_validation` needed). Useful for composite types like lists or dicts. A falsy return is a plain non-match, with no reason reported.
 - **`required_when`**: Make an option conditionally required based on a predicate callable.
 
-The spec declares the arity: `list`, `tuple`, `set` and `frozenset` unpack element-wise and identically, a `str` stays a scalar, and a `dict` is one composite value.
+For `element_validator` and membership, the spec declares the arity: `list`, `tuple`, `set` and `frozenset` unpack element-wise and identically, a `str` stays a scalar, and a `dict` is one composite value. `match_guard` still sees the raw value with its original container type.
 
-See [Feature Matching: Conditional Requirements](14-feature-matching.md#conditional-requirements-with-required_when) for full details, examples, and a comparison table.
+See [Feature Matching: Key Differences](14-feature-matching.md#key-differences-from-element_validator) for the comparison table and [Conditional Requirements](14-feature-matching.md#conditional-requirements-with-required_when) for `required_when`.
 
 ## Full Documentation
 
-See [Options API](https://mloda-ai.github.io/mloda/in_depth/options/) for detailed patterns and [PROPERTY_MAPPING Configuration](https://mloda-ai.github.io/mloda/in_depth/property-mapping/) for the full spec reference.
+See [Feature Configuration](https://mloda-ai.github.io/mloda/in_depth/feature-config/) for detailed patterns and [PROPERTY_MAPPING Configuration](https://mloda-ai.github.io/mloda/in_depth/property-mapping/) for the full spec reference.

--- a/docs/guides/feature-group-patterns/11-options.md
+++ b/docs/guides/feature-group-patterns/11-options.md
@@ -108,9 +108,11 @@ Since mloda 0.9.0, defining a `FeatureGroup` whose `PROPERTY_MAPPING` declares a
 
 When using `PROPERTY_MAPPING` with `FeatureChainParserMixin`, you can declare validation rules and conditional requirements directly on option entries:
 
-- **`element_validator`**: Validate individual parsed option values with a callable (requires `strict_validation: True`).
-- **`match_guard`**: Validate the raw option value with a callable (no `strict_validation` needed). Useful for composite types like lists or dicts.
+- **`element_validator`**: Validate each parsed element with a callable (requires `strict_validation: True`). A falsy return raises `ValueError`, surfaced to the end user as a rejection reason.
+- **`match_guard`**: Check the raw option value with a callable (no `strict_validation` needed). Useful for composite types like lists or dicts. A falsy return is a plain non-match, so another feature group can still take the feature.
 - **`required_when`**: Make an option conditionally required based on a predicate callable.
+
+The spec declares the arity: `list`, `tuple`, `set` and `frozenset` unpack element-wise and identically, a `str` stays a scalar, and a `dict` is one composite value.
 
 See [Feature Matching: Conditional Requirements](14-feature-matching.md#conditional-requirements-with-required_when) for full details, examples, and a comparison table.
 

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -228,11 +228,11 @@ PROPERTY_MAPPING = {
 
 ---
 
-## Type Validation with `match_guard`
+## Whole-Value Guards with `match_guard`
 
-Use `DefaultOptionKeys.match_guard` to validate the raw option value with a callable. Unlike `element_validator`, this does not require `strict_validation` and operates on the whole option value before any unpacking.
+Use `DefaultOptionKeys.match_guard` to check the raw option value with a callable. Despite the name, a guard is not a type assertion: a falsy return means "not my feature group", not "the user made a mistake". Unlike `element_validator`, it does not require `strict_validation` and it sees the whole value, before any unpacking.
 
-After basic matching and `required_when` checks succeed, `match_feature_group_criteria` calls each `match_guard`. If the guard returns a falsy value, matching returns `False`. If the guard raises `TypeError`, `ValueError`, or `AttributeError`, the value is treated as invalid.
+After basic matching and `required_when` checks succeed, `match_feature_group_criteria` calls each `match_guard`. A falsy return is a plain non-match (`False`, debug log, no error), so resolution moves on and another candidate may still take the feature. A guard that raises `TypeError`, `ValueError`, or `AttributeError` is treated the same way.
 
 ```python
 from mloda.provider import DefaultOptionKeys
@@ -264,19 +264,19 @@ A `match_guard` is also the way to reject a composite value for a key that other
 |--------|-----------------|----------------------|
 | Requires `strict_validation` | No | Yes |
 | Validates | Raw option value (whole) | Individual parsed elements |
-| Failure mode | Returns `False` (soft rejection) | Raises `ValueError` |
+| Failure mode | Non-match (`False`), no error | Raises `ValueError` |
 | Runs during | `match_feature_group_criteria` (after basic match) | Base parser property validation |
-| Use case | Composite types (lists, dicts, ranges) | Membership-style checks on single values |
+| Use case | Composite types (lists, dicts, ranges) | Per-element rules on single values |
 
-When both are present on the same entry, `element_validator` runs first (during base parsing), then `match_guard` runs second (during mixin matching).
+Precedence, the full lifecycle, and what each failure produces live in core: [PROPERTY_MAPPING Configuration](https://mloda-ai.github.io/mloda/in_depth/property-mapping/).
 
 ---
 
-## Custom Validation with `element_validator`
+## Element Validation with `element_validator`
 
-Use `DefaultOptionKeys.element_validator` to validate individual option values with a callable instead of checking membership against a fixed set of allowed values. This requires `strict_validation: True`.
+Use `DefaultOptionKeys.element_validator` to validate option values with a callable instead of checking membership against a fixed set of allowed values. This requires `strict_validation: True`.
 
-When the element validator is present, it is called instead of checking whether the value exists in `allowed_values`. The function receives each individual parsed value and must return `True` if valid. Returning `False` raises a `ValueError`, which the mixin catches and converts to a `False` match result.
+When an element validator is present, it **replaces** the `allowed_values` membership check rather than adding to it. It receives each parsed element and must return `True` if valid. A falsy return raises `ValueError`; the mixin catches it and returns `False`, and the reason is collected into the end user's "No feature groups found" error. So an `element_validator` rejection tells the user their value was wrong, whereas a `match_guard` rejection quietly hands the feature to another candidate.
 
 ```python
 from mloda.provider import DefaultOptionKeys
@@ -297,13 +297,26 @@ PROPERTY_MAPPING = {
 }
 ```
 
+### What a Validator Receives
+
+The spec declares the arity, not the caller. For membership and `element_validator`, `list`, `tuple`, `set` and `frozenset` all unpack element-wise and identically, so container syntax never changes what the validator sees:
+
+- Elements keep their real type: `[1, 2]` hands the validator `1`, never `"1"`.
+- A `str` is a scalar, not a sequence of characters: `"abc"` is the single element `"abc"`.
+- A `dict` is one composite value, not a sequence of its keys. Validating its shape is `match_guard`'s job.
+- An empty container is present and vacuously valid: no element runs, and it still satisfies the required-presence check.
+
+`match_guard` is unaffected: it always receives the raw value with its original container type.
+
+Before mloda 0.10.0 a sequence was stringified, so a validator received `"('a', 'b')"` and behavior depended on whether the caller happened to type a list or a tuple. An `element_validator` written to inspect a whole container (`isinstance(x, list) and all(...)`) must become a per-element rule, or move to `match_guard` if it genuinely is a whole-value check.
+
 ### When to Use Each Validation Approach
 
 | Approach | Use When | Example |
 |----------|----------|---------|
 | Enumerated values | Fixed set of valid string values | `"sum"`, `"avg"`, `"min"` |
-| `element_validator` | Open-ended single values, `strict_validation` is `True` | positive integers, float ranges |
-| `match_guard` | Composite types, no `strict_validation` needed | list of strings, nested dicts |
+| `element_validator` | Per-element rules you cannot enumerate, `strict_validation` is `True` | positive integers, float ranges |
+| `match_guard` | Whole-value shape, no `strict_validation` needed | list of strings, nested dicts |
 | `required_when` | Option is conditionally required | `order_by` only when aggregation is `first` |
 
 ---

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -154,7 +154,7 @@ Use `DefaultOptionKeys.required_when` to attach a predicate callable to a mappin
 
 ```python
 from mloda.user import Options
-from mloda_plugins.feature_group.experimental.default_options_key import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys
 
 _ORDER_DEPENDENT = {"first", "last"}
 
@@ -256,7 +256,7 @@ PROPERTY_MAPPING = {
 }
 ```
 
-A `match_guard` is also the way to reject a composite value for a key that otherwise accepts a single token: the element-wise check unpacks a list and validates each element, so a list of two valid operations would pass without a guard such as `lambda v: isinstance(v, str)`.
+A `match_guard` is also the way to reject a composite value for a key that otherwise accepts a single token: the element-wise check unpacks a container and validates each element, so `["sum", "max"]` passes membership on both elements and matches. Guard the arity, not the Python syntax: core unwraps a single-element container when it reads a property value, so `("sum",)` is valid caller syntax for one token and a naive `lambda v: isinstance(v, str)` would wrongly reject it. See the shared `is_op_token` guard in `mloda/community/feature_groups/data_operations/base.py`.
 
 ### Key Differences from `element_validator`
 
@@ -274,9 +274,11 @@ Precedence, the full lifecycle, and what each failure produces live in core: [PR
 
 ## Element Validation with `element_validator`
 
-Use `DefaultOptionKeys.element_validator` to validate option values with a callable instead of checking membership against a fixed set of allowed values. This requires `strict_validation: True`.
+Use `DefaultOptionKeys.element_validator` to validate option values with a callable instead of checking membership against a fixed set of allowed values. It requires `strict_validation: True`: without it, a hand-written spec silently ignores the validator (only `property_spec` rejects that combination).
 
-When an element validator is present, it **replaces** the `allowed_values` membership check rather than adding to it. It receives each parsed element and must return `True` if valid. A falsy return raises `ValueError`; the mixin catches it and returns `False`, and the reason is collected into the end user's "No feature groups found" error. So an `element_validator` rejection tells the user their value was wrong, whereas a `match_guard` rejection quietly hands the feature to another candidate.
+When an element validator is present, it **replaces** the `allowed_values` membership check rather than adding to it. It receives each parsed element and must return `True` if valid.
+
+A falsy return raises `ValueError`, but the mixin catches it and returns `False`, so both mechanisms end in a non-match and another candidate can still take the feature. The difference is diagnostics: if nothing matches, an `element_validator` rejection is listed as a reason in the end user's "No feature groups found" error, while a `match_guard` rejection leaves only a debug log.
 
 ```python
 from mloda.provider import DefaultOptionKeys
@@ -301,14 +303,13 @@ PROPERTY_MAPPING = {
 
 The spec declares the arity, not the caller. For membership and `element_validator`, `list`, `tuple`, `set` and `frozenset` all unpack element-wise and identically, so container syntax never changes what the validator sees:
 
-- Elements keep their real type: `[1, 2]` hands the validator `1`, never `"1"`.
+- Elements keep their real type: `[1, 2]` hands the validator `1`, never `"1"`. The one normalization is a `Feature`, which arrives as its `FeatureName`.
 - A `str` is a scalar, not a sequence of characters: `"abc"` is the single element `"abc"`.
 - A `dict` is one composite value, not a sequence of its keys. Validating its shape is `match_guard`'s job.
 - An empty container is present and vacuously valid: no element runs, and it still satisfies the required-presence check.
+- Both only see values in `Options`. A `PREFIX_PATTERN` match short-circuits property validation, so membership and `element_validator` never run on a name-parsed value, and `match_guard` is skipped when the option is absent. Constrain the string path with the regex itself (see [Return Data Type Rule](../data-operation-patterns/16-return-data-type-rule.md)).
 
-`match_guard` is unaffected: it always receives the raw value with its original container type.
-
-Before mloda 0.10.0 a sequence was stringified, so a validator received `"('a', 'b')"` and behavior depended on whether the caller happened to type a list or a tuple. An `element_validator` written to inspect a whole container (`isinstance(x, list) and all(...)`) must become a per-element rule, or move to `match_guard` if it genuinely is a whole-value check.
+Migration: before mloda 0.10.0 a sequence was stringified, so a validator received `"('a', 'b')"` and behavior depended on whether the caller typed a list or a tuple. An `element_validator` that inspects a whole container (`isinstance(x, list) and all(...)`) must become a per-element rule, or move to `match_guard` if it genuinely is a whole-value check.
 
 ### When to Use Each Validation Approach
 

--- a/docs/guides/feature-group-patterns/26-input-feature-forwarding.md
+++ b/docs/guides/feature-group-patterns/26-input-feature-forwarding.md
@@ -129,7 +129,7 @@ def test_connector_carves_local_key_and_pulls_context():
 |------|-------------|
 | [test_input_features_forward_group_defaults.py](https://github.com/mloda-ai/mloda/blob/0.9.0/tests/test_plugins/feature_group/experimental/test_input_features_forward_group_defaults.py) | Plugin `input_features()` leaving children at the default sentinel; explicit directives preserved |
 | [test_feature_collection_forwarding.py](https://github.com/mloda-ai/mloda/blob/0.9.0/tests/test_core/test_abstract_plugins/test_components/test_feature_collection_forwarding.py) | `forward_group` / `forward_group_exclude` allowlist and carve-out semantics |
-| [Options API](https://mloda-ai.github.io/mloda/in_depth/options/) | Group vs context, propagation |
+| [Feature Configuration](https://mloda-ai.github.io/mloda/in_depth/feature-config/) | Group vs context, propagation |
 
 ## Combines With
 


### PR DESCRIPTION
Closes #305.

## What was already done

The code half of #305 landed with the version bump (6ab0a75): `offset/base.py` uses `DefaultOptionKeys.match_guard`, and `config/shared.toml` pins `mloda>=0.10.0`. Nothing in the repo references the removed names. This PR finishes the guide half.

## What this changes

`14-feature-matching.md` still called `match_guard` **"Type Validation"**, which is the exact misreading the rename set out to kill: a falsy return is a non-match that lets another candidate win, not an error the user sees. The two keys are now described by what a falsy return actually does, and the precedence and lifecycle rules link out to core's unified PROPERTY_MAPPING page instead of being restated.

It also documents the sequence handling that 0.10.0 fixed, which the guides previously described as *intended* rather than *implemented*: the spec declares the arity, so `list`, `tuple`, `set` and `frozenset` unpack element-wise and identically, elements keep their real type, a `str` stays a scalar, and a `dict` is one composite value.

Every claim was verified against the installed mloda 0.10.0 rather than transcribed from core's docs. That surfaced three things the guides got wrong:

- **The failure-mode contrast was overstated.** An `element_validator` rejection does not tell the user their value was wrong at match time; the mixin catches the `ValueError` and returns `False`, exactly like a guard. The difference is diagnostic: its reason is listed only if *nothing* matched.
- **The composite-guard example was actively harmful.** It told authors to write `lambda v: isinstance(v, str)`, which rejects `("sum",)`. Core unwraps a single-element container when reading a property, so that is valid caller syntax for one token, which is why the shared `is_op_token` guard checks arity rather than Python syntax.
- **A `PREFIX_PATTERN` match short-circuits property validation.** Membership and `element_validator` never run on a name-parsed value (confirmed: a name-matched feature with a bogus option value still matches). The string path must be constrained by the regex itself.

## Drive-bys in the touched files

- A snippet imported `DefaultOptionKeys` from `mloda_plugins...`, which raises `ModuleNotFoundError` on 0.10.0.
- The "Options API" link in guides 11 and 26 was a 404; the page is Feature Configuration. The docs linter only checks relative links, so it did not catch this.
- The comparison table was linked via the `required_when` anchor, landing readers in the wrong section.

## Testing

`tox` green (4293 passed, 149 skipped; ruff, mypy --strict, bandit clean) and `scripts/lint_docs.py` clean. Reviewed independently by a Claude Opus agent and codex; two codex findings were rejected after empirical checks (a guard *does* see the raw container, and a `dict` *does* reach the guard, the `TypeError` it cited is specific to the reserved `in_features` key).