### PR TITLE
docs: fix incorrect API claims across the plugin guides

### DIFF
--- a/docs/guides/10-create-compute-framework.md
+++ b/docs/guides/10-create-compute-framework.md
@@ -39,7 +39,7 @@ Q9: Need to understand filter operations?
 
 Q10: Should connections be auto-created or user-provided?
     AUTO  → Add fallback in set_framework_connection_object()
-    USER  → Require via data_connections parameter
+    USER  → Require via data_access_collection parameter
 
 Q11: Ready to test your implementation?
     YES → See 09-testing-guide

--- a/docs/guides/compute-framework-patterns/02-stateless-lazy.md
+++ b/docs/guides/compute-framework-patterns/02-stateless-lazy.md
@@ -22,9 +22,9 @@ Stateless lazy frameworks defer execution until results are explicitly requested
 Only these methods differ from Category 1:
 
 ```python
-def set_column_names(self) -> None:
+def _extract_column_names(self, data: Any) -> set[str]:
     # Get schema WITHOUT executing query
-    self.column_names = set(self.data.collect_schema().names())
+    return set(data.collect_schema().names())
 
 def select_data_by_column_names(self, data, selected_feature_names):
     column_names = set(data.collect_schema().names())

--- a/docs/guides/compute-framework-patterns/03-stateful-connection.md
+++ b/docs/guides/compute-framework-patterns/03-stateful-connection.md
@@ -46,14 +46,14 @@ def transform(self, data: Any, feature_names: set[str]) -> Any:
 
 ## Usage
 
-Pass connections via `data_connections`:
+Pass connections via `data_access_collection`. The engine resolves the connection at setup and calls `set_framework_connection_object()` on the framework for you:
 
 ```python
 conn = duckdb.connect()
 result = mloda.run_all(
     features=[...],
     compute_frameworks=["MyStatefulFramework"],
-    data_connections=[conn],
+    data_access_collection=DataAccessCollection(connections={conn}),
 )
 ```
 

--- a/docs/guides/compute-framework-patterns/04-zero-dependency.md
+++ b/docs/guides/compute-framework-patterns/04-zero-dependency.md
@@ -6,7 +6,7 @@ Zero dependency frameworks use pure Python with no external libraries.
 **When**: Minimal environments, serverless, testing without deps.
 **Why**: Always available; no installation required.
 **Where**: Serverless functions, embedded systems, educational use.
-**How**: Same as Category 1, but skip `is_available()` and use `List[Dict]`.
+**How**: Same as Category 1, but skip `is_available()` and use a columnar `dict[str, list[Any]]`.
 
 ## Key Difference from Category 1
 
@@ -14,15 +14,17 @@ Zero dependency frameworks use pure Python with no external libraries.
 |--------|-------------------|----------------------|
 | Dependencies | External library | **None** |
 | `is_available()` | Check import | Not needed (always True) |
-| Data format | Library-specific | `List[Dict[str, Any]]` |
-| Column access | `data.columns` | Iterate rows for keys |
+| Data format | Library-specific | `dict[str, list[Any]]` (columnar) |
+| Column access | `data.columns` | `data.keys()` |
 
 ## Data Format
 
 ```python
-# Row-based: List[Dict[str, Any]]
-[{"col1": 1, "col2": "a"}, {"col1": 2, "col2": "b"}]
+# Columnar: dict[str, list[Any]] - one key per column, all lists share a length
+{"col1": [1, 2], "col2": ["a", "b"]}
 ```
+
+`{"a": []}` is a valid zero-row frame (one known column). `{}` is the only schema-less value.
 
 ## What's Different
 
@@ -32,25 +34,24 @@ class MyZeroDependencyFramework(ComputeFramework):
 
     @classmethod
     def expected_data_framework(cls) -> Any:
-        return list  # Native Python list
+        return dict  # Native Python dict, columnar
 
-    def set_column_names(self) -> None:
-        # Must iterate rows to get all keys
-        all_columns: set[str] = set()
-        for row in self.data:
-            if isinstance(row, dict):
-                all_columns.update(row.keys())
-        self.column_names = all_columns
-
-    def transform(self, data: Any, feature_names: set[str]) -> list[dict[str, Any]]:
+    def _extract_column_names(self, data: Any) -> set[str]:
         if isinstance(data, dict):
-            # Columnar dict to row-based list
-            if all(isinstance(v, list) for v in data.values()):
-                length = len(next(iter(data.values())))
-                return [{k: data[k][i] for k in data.keys()} for i in range(length)]
-            return [data]  # Single row
-        if isinstance(data, list):
+            return set(data.keys())
+        # Row-wise list[dict] is still an accepted pre-transform shape.
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            return set(data[0].keys())
+        return set()
+
+    def transform(self, data: Any, feature_names: set[str]) -> dict[str, list[Any]]:
+        if isinstance(data, dict):
             return data
+        if isinstance(data, list):
+            # Row-based list to columnar dict
+            if not data:
+                return {}
+            return {k: [row[k] for row in data] for k in data[0].keys()}
         raise ValueError(f"Data type {type(data)} not supported")
 ```
 

--- a/docs/guides/compute-framework-patterns/07-filter-engine.md
+++ b/docs/guides/compute-framework-patterns/07-filter-engine.md
@@ -127,7 +127,7 @@ def test_filter_engine():
     filter_feature = SingleFilter(
         filter_feature=Feature.int32_of("value"),
         filter_type="min",
-        parameter=FilterParameter(value=5),
+        parameter={"value": 5},
     )
     result = MyFilterEngine.do_min_filter(data, filter_feature)
     assert len(result) == 2  # value >= 5

--- a/docs/guides/compute-framework-patterns/08-framework-transformer.md
+++ b/docs/guides/compute-framework-patterns/08-framework-transformer.md
@@ -105,6 +105,6 @@ def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | 
 
 | File | Description |
 |------|-------------|
-| [pandas/pandaspyarrowtransformer.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/compute_framework/base_implementations/pandas/pandaspyarrowtransformer.py) | Pandas ↔ PyArrow |
+| [pandas/pandas_pyarrow_transformer.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/compute_framework/base_implementations/pandas/pandas_pyarrow_transformer.py) | Pandas ↔ PyArrow |
 | [polars/polars_pyarrow_transformer.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/compute_framework/base_implementations/polars/polars_pyarrow_transformer.py) | Polars ↔ PyArrow |
 | [duckdb/duckdb_pyarrow_transformer.py](https://github.com/mloda-ai/mloda/blob/main/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_pyarrow_transformer.py) | DuckDB ↔ PyArrow |

--- a/docs/guides/compute-framework-patterns/09-testing-guide.md
+++ b/docs/guides/compute-framework-patterns/09-testing-guide.md
@@ -42,7 +42,7 @@ class TestMyFilterEngine(FilterEngineTestMixin):
         return result[column].tolist()
 ```
 
-### MultiIndexMergeEngineTestBase (5 tests)
+### MultiIndexMergeEngineTestBase (6 tests)
 
 For merge engine tests with multi-column indexes:
 
@@ -90,24 +90,25 @@ Converts test data to any framework format via PyArrow:
 ```python
 from tests.test_plugins.compute_framework.test_tooling.multi_index.test_data_converter import DataConverter
 
-converter = DataConverter(framework_type=my_lib.DataFrame, connection=None)
-df = converter.convert([{"col": 1}, {"col": 2}])
+converter = DataConverter()
+df = converter.to_framework([{"col": 1}, {"col": 2}], my_lib.DataFrame, connection=None)
 ```
 
 ### SCENARIOS
 
-Framework-agnostic test scenarios for merge operations:
+Framework-agnostic merge scenarios, a `dict[str, MergeScenario]` keyed by scenario name. `MergeScenario` is a `TypedDict` with keys `left`, `right`, `index`, `expected_rows`, `expected_columns`, `description`:
 
 ```python
 from tests.test_plugins.compute_framework.test_tooling.multi_index.test_scenarios import SCENARIOS
 
 # Use in parametrized tests
-@pytest.mark.parametrize("scenario", SCENARIOS)
-def test_merge_scenario(scenario, engine):
-    left = converter.convert(scenario.left_data)
-    right = converter.convert(scenario.right_data)
-    result = engine.merge_inner(left, right, scenario.left_index, scenario.right_index)
-    assert len(result) == scenario.expected_count
+@pytest.mark.parametrize("scenario_key", list(SCENARIOS))
+def test_merge_scenario(scenario_key, converter, engine):
+    scenario = SCENARIOS[scenario_key]
+    left = converter.to_framework(scenario["left"], my_lib.DataFrame)
+    right = converter.to_framework(scenario["right"], my_lib.DataFrame)
+    result = engine.merge_inner(left, right, Index(scenario["index"]), Index(scenario["index"]))
+    assert len(result) == scenario["expected_rows"]
 ```
 
 ## Shared Helpers
@@ -115,7 +116,7 @@ def test_merge_scenario(scenario, engine):
 ### Availability Testing
 
 ```python
-from tests.test_plugins.compute_framework.base_implementations.availability_test_helper import (
+from tests.test_plugins.compute_framework.test_tooling.availability_test_helper import (
     assert_unavailable_when_import_blocked,
 )
 
@@ -128,24 +129,24 @@ def test_unavailable_when_not_installed():
 For testing transformer chains:
 
 ```python
-from tests.test_plugins.compute_framework.base_implementations.shared_compute_frameworks import (
+from tests.test_plugins.compute_framework.test_tooling.shared_compute_frameworks import (
     SecondCfw, ThirdCfw, FourthCfw
 )
 ```
 
 ## Shared Fixtures
 
-Main conftest provides:
+The compute framework conftest provides:
 
 ```python
-# tests/conftest.py
+# tests/test_plugins/compute_framework/base_implementations/conftest.py
 @pytest.fixture
-def index_obj():
-    return Index(("id",))
+def index_obj() -> Any:
+    return Index(("idx",))
 
 @pytest.fixture
-def dict_data():
-    return {"id": [1, 2], "value": ["a", "b"]}
+def dict_data() -> dict[str, list[int]]:
+    return {"column1": [1, 2, 3], "column2": [4, 5, 6]}
 ```
 
 Framework-specific fixtures:

--- a/docs/guides/compute-framework-patterns/10-data-type-extraction.md
+++ b/docs/guides/compute-framework-patterns/10-data-type-extraction.md
@@ -118,7 +118,7 @@ A feature declares `DataType.INT32` and the framework produces a `DOUBLE` column
 
 ```python
 result = mloda.run_all(features)                              # lenient: INT32 vs DOUBLE → OK (both numeric)
-result = mloda.run_all(features, strict_type_enforcement=True)  # strict: DOUBLE is a narrowing of INT32 → DataTypeMismatchError
+result = mloda.run_all(features, strict_type_enforcement=True)  # strict: declared INT32 widens to nothing → DataTypeMismatchError
 ```
 
 Because your hook is the only thing that reports the *actual* produced type, returning an accurate

--- a/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
+++ b/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
@@ -29,7 +29,7 @@ feature = Feature(
 )
 ```
 
-All rows of the same `service` share the same P95 value. Percentiles use the framework's native method (linear interpolation by default in Pandas and PyArrow). Cross-framework tests allow `pytest.approx` tolerance for floating-point comparisons.
+All rows of the same `service` share the same P95 value. Percentiles use the framework's native method (linear interpolation by default in Pandas, DuckDB and Polars; PyArrow is not a supported percentile backend). Cross-framework tests allow `pytest.approx` tolerance for floating-point comparisons.
 
 ---
 

--- a/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
+++ b/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
@@ -33,7 +33,7 @@ Scalar aggregate accepts the `mask` option. Masked rows have their source value 
 
 ## Scalar arithmetic
 
-Pattern: `{col}__{op}_constant` (regex `r"(.+?)__(add|subtract|multiply|divide)_constant$"`).
+Pattern: `{col}__{op}_constant` (regex `r".*__([\w]+)_constant$"`). The regex does not enumerate the ops; the op token is validated separately via `match_guard: is_op_token` plus `allowed_values: ARITHMETIC_OPERATIONS`.
 
 Each row gets `source {op} constant`. Null in the source propagates to the result. Single source column only (`MIN_IN_FEATURES = MAX_IN_FEATURES = 1`).
 

--- a/docs/guides/data-operation-patterns/11-time-bucketization.md
+++ b/docs/guides/data-operation-patterns/11-time-bucketization.md
@@ -107,7 +107,7 @@ The Pandas backend additionally `mask`s the result column to convert `NaT` to `N
 
 Input timezone is preserved on output for every backend. The fixture used by the inherited tests is UTC, but a `pa.timestamp("us", tz="Europe/Berlin")` input flows through unchanged. Pandas' `PeriodIndex` strips tz, so `_calendar_floor` re-localises after `to_timestamp()`.
 
-For SQLite, all timestamps are stored as TEXT in ISO 8601. The cross-framework test contract requires `to_arrow_table()` to return a tz-aware `datetime` column, but SQLite-native `to_arrow_table` infers `pa.string()` for TEXT. The SQLite backend therefore wraps the result in `_TimeBucketizationSqliteResult` (a `SqliteRelation` subclass) that re-parses the listed result columns into `pa.timestamp("us", tz="UTC")` on read.
+For SQLite, all timestamps are stored as TEXT in ISO 8601. The bucketization SQL emits ISO 8601 strings directly (bucket math on the wall-clock portion, timezone suffix reattached), so the result column comes back from `to_arrow_table()` as `pa.string()`, on a plain `SqliteRelation`. There is no Python-side re-parse into `pa.timestamp` and no `SqliteRelation` subclass; see `tests/test_sqlite_result_type.py` for the contract.
 
 ---
 

--- a/docs/guides/feature-group-patterns/04-multi-input-features.md
+++ b/docs/guides/feature-group-patterns/04-multi-input-features.md
@@ -39,7 +39,7 @@ class DiffFeature(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        feature_name = features.name_of_one_feature.name
+        feature_name = str(features.name_of_one_feature)
         base = feature_name.replace("__diff", "")
         a, b = base.split("&")
         return data[a] - data[b]

--- a/docs/guides/feature-group-patterns/05-multi-output-features.md
+++ b/docs/guides/feature-group-patterns/05-multi-output-features.md
@@ -38,7 +38,7 @@ class StatsFeature(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> dict[str, Any]:
-        feature_name = features.name_of_one_feature.name
+        feature_name = str(features.name_of_one_feature)
         source = feature_name.replace("__stats", "")
         col = data[source]
         return {
@@ -51,14 +51,14 @@ class StatsFeature(FeatureGroup):
 
 ```python
 import pandas as pd
+from mloda.user import FeatureName
 
 def test_stats_feature():
     assert StatsFeature.match_feature_group_criteria("value__stats", None)
 
     df = pd.DataFrame({"value": [1, 2, 3, 4, 5]})
     class MockFeatures:
-        class name_of_one_feature:
-            name = "value__stats"
+        name_of_one_feature = FeatureName("value__stats")
     result = StatsFeature.calculate_feature(df, MockFeatures())
     assert "value__stats~mean" in result
     assert "value__stats~std" in result
@@ -69,10 +69,13 @@ def test_stats_feature():
 For 2D array outputs (embeddings, PCA):
 
 ```python
-# Converts 2D array to dict with ~N column names
-embedding = [[0.1, 0.2], [0.3, 0.4]]
+# Converts 2D array to dict with ~N column names.
+# Requires an object with a .shape (e.g. numpy); a plain list of lists returns {}.
+import numpy as np
+
+embedding = np.array([[0.1, 0.2], [0.3, 0.4]])
 result = cls.apply_naming_convention(embedding, "emb")
-# Returns: {"emb~0": [0.1, 0.3], "emb~1": [0.2, 0.4]}
+# Returns: {"emb~0": array([0.1, 0.3]), "emb~1": array([0.2, 0.4])}
 ```
 
 ## Real Implementations
@@ -103,7 +106,7 @@ class SpecificSubColumnConsumer(FeatureGroup):
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         embedding_values = data["embedding~1"]
-        feature_name = features.get_name_of_one_feature().name
+        feature_name = str(features.get_name_of_one_feature())
         return {feature_name: embedding_values * 2}
 ```
 

--- a/docs/guides/feature-group-patterns/06-artifact-features.md
+++ b/docs/guides/feature-group-patterns/06-artifact-features.md
@@ -32,14 +32,14 @@ class ScalerArtifact(BaseArtifact):
 
     @classmethod
     def custom_saver(cls, features: FeatureSet, artifact: Any) -> str | None:
-        path = f"/tmp/scaler_{features.name_of_one_feature.name}.pkl"
+        path = f"/tmp/scaler_{features.name_of_one_feature}.pkl"
         with open(path, "wb") as f:
             pickle.dump(artifact, f)
         return path
 
     @classmethod
     def custom_loader(cls, features: FeatureSet) -> Any | None:
-        path = f"/tmp/scaler_{features.name_of_one_feature.name}.pkl"
+        path = f"/tmp/scaler_{features.name_of_one_feature}.pkl"
         if Path(path).exists():
             with open(path, "rb") as f:
                 return pickle.load(f)
@@ -61,7 +61,7 @@ class StandardScaledFeature(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        feature_name = features.name_of_one_feature.name
+        feature_name = str(features.name_of_one_feature)
         source = feature_name.replace("__standard_scaled", "")
         col = data[source]
 

--- a/docs/guides/feature-group-patterns/07-index-features.md
+++ b/docs/guides/feature-group-patterns/07-index-features.md
@@ -42,7 +42,7 @@ class LagFeature(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        feature_name = features.name_of_one_feature.name
+        feature_name = str(features.name_of_one_feature)
         match = re.match(cls.PREFIX_PATTERN, feature_name)
         lag_n = int(match.group(1))
         source = feature_name.rsplit("__lag_", 1)[0]

--- a/docs/guides/feature-group-patterns/09-framework-specific.md
+++ b/docs/guides/feature-group-patterns/09-framework-specific.md
@@ -13,7 +13,7 @@ Framework-specific features restrict computation to certain frameworks.
 | Method | Behavior |
 |--------|----------|
 | `compute_framework_rule()` | Returns `set[type[ComputeFramework]] | None` |
-| Default | `True` = any framework allowed |
+| Default | `None` = any framework allowed |
 
 ## Complete Example
 

--- a/docs/guides/feature-group-patterns/20-versioning.md
+++ b/docs/guides/feature-group-patterns/20-versioning.md
@@ -25,19 +25,17 @@ This means the version changes automatically when:
 ```python
 # Get version of any FeatureGroup
 version = MyFeatureGroup.version()
-# e.g., "0.2.6|my_package.features|a1b2c3d4..."
+# e.g., "0.2.6-my_package.features-a1b2c3d4..."
 ```
 
 ## Custom Versioning
 
-Override by subclassing `BaseFeatureGroupVersion`:
+`FeatureGroup.version()` calls `BaseFeatureGroupVersion.version(cls)` directly, so subclassing `BaseFeatureGroupVersion` alone changes nothing. Override `version()` on your FeatureGroup instead:
 
 ```python
-from mloda.provider import BaseFeatureGroupVersion
-
-class MyVersioning(BaseFeatureGroupVersion):
+class MyFeatureGroup(FeatureGroup):
     @classmethod
-    def version(cls, feature_group_class) -> str:
+    def version(cls) -> str:
         return "1.0.0"  # Custom version logic
 ```
 

--- a/docs/guides/feature-group-patterns/26-input-feature-forwarding.md
+++ b/docs/guides/feature-group-patterns/26-input-feature-forwarding.md
@@ -104,9 +104,9 @@ The engine forwards by default, so a child left at `forward_group=None` already 
 
 If a forwarded group key already exists on the child with a **different** value, forwarding raises `ValueError` (naming the key, both values, and the opt-out remedies). If the child already holds the **same** value, forwarding is a silent no-op. So a child may safely pre-set a key to the value the consumer would forward; it may not silently override it.
 
-## Caveat: Bare-String Children Share the Consumer's Options
+## Caveat: Bare-String Children Cannot Carry Directives
 
-The directives above only take effect on children returned as explicit `Feature(...)` objects. A child returned as a **bare string** from `input_features()` (e.g. `return {"knowledge_graph"}`) is constructed with the consumer's own `Options` instance, so it already carries the consumer's **entire** group and context, and the forwarding directives (`forward_group`, `forward_group_exclude`, `inherit_context_keys`) are no-ops on it (mloda logs a warning if you pass them). Because everything is already shared, there is no way to carve a consumer-local key off a bare-string child. To control what the upstream sees, whether that means excluding a key, isolating the child, or selecting which context reaches it, return an explicit `Feature("knowledge_graph", forward_group_exclude={...})`, not the string.
+The directives above only take effect on children returned as explicit `Feature(...)` objects. A child returned as a **bare string** from `input_features()` (e.g. `return {"knowledge_graph"}`) is constructed with a fresh, empty `Options` and then goes through the same forward-by-default merge as any explicit `Feature(name)` child, so it inherits the consumer's entire group and context. The difference is that a string has nowhere to hang a directive: there is no way to carve a consumer-local key off a bare-string child. To control what the upstream sees, whether that means excluding a key, isolating the child, or selecting which context reaches it, return an explicit `Feature("knowledge_graph", forward_group_exclude={...})`, not the string.
 
 ## Test
 


### PR DESCRIPTION
## Summary

Fact-checked every claim in `docs/guides/` (70 files) against the mloda 0.10.0 source and fixed the ones that were wrong. Each finding was verified against `mloda-ai/mloda@origin/main` (0.10.0) and the registry plugin source before being applied.

Findings were produced by a fan-out of per-file agents, then each alleged error was adversarially re-checked, and every surviving finding was confirmed by hand against source. 3 findings were discarded as false positives.

## Broken examples (raise if run)

| Guide | Problem |
|---|---|
| `04-multi-input`, `05-multi-output`, `06-artifact`, `07-index` | `FeatureName` is a `str` subclass with no `.name`, so `features.name_of_one_feature.name` raises `AttributeError` |
| `07-filter-engine` | `FilterParameter` is a `typing.Protocol` (not instantiable) and `SingleFilter` requires a plain `dict` |
| `05-multi-output` | `apply_naming_convention` checks `hasattr(result, "shape")`; the documented list-of-lists silently returns `{}` |
| `09-testing-guide` | `DataConverter` takes no ctor args and exposes `to_framework()`, not `convert()`; `SCENARIOS` is a `dict[str, MergeScenario]` TypedDict, not a list of objects with `.left_data` / `.expected_count` |
| `09-testing-guide` | Two helper imports pointed at `base_implementations/` instead of `test_tooling/` |

## Wrong statements

- `run_all` has no `data_connections` parameter. Connections go through `data_access_collection=DataAccessCollection(connections={conn})`.
- Zero-dependency frameworks are columnar `dict[str, list[Any]]`, not row-based `List[Dict]`. The guide contradicted the `PythonDictFramework` it links as its own reference implementation.
- Polars lazy overrides `_extract_column_names`, not `set_column_names`.
- `compute_framework_rule()` defaults to `None`, not `True`.
- Version strings are dash-separated, not pipe-separated. Subclassing `BaseFeatureGroupVersion` has no effect, since `FeatureGroup.version()` calls the base class directly.
- Bare-string children get a fresh empty `Options`, not the consumer's instance.
- Percentile has no PyArrow backend (Pandas, DuckDB, Polars only).
- Scalar arithmetic `PREFIX_PATTERN` does not enumerate the ops; the op token is validated via `match_guard` + `allowed_values`.
- SQLite time bucketization returns a plain `SqliteRelation` with a `pa.string()` column. The `_TimeBucketizationSqliteResult` wrapper the guide described was refactored away (see `test_sqlite_result_type.py`).
- Strict type enforcement rejects declared `INT32` vs actual `DOUBLE` because `INT32` has no widening rule, not because "DOUBLE is a narrowing of INT32".
- Fixed the `pandas_pyarrow_transformer.py` link (404) and the `MultiIndexMergeEngineTestBase` test count (6, not 5).

## Test plan

- `scripts/lint_docs.py` passes.
- Docs-only change, no source touched.