### PR TITLE
docs(guides): document the PythonDict columnar contract and warn on GlobalFilter over a group's own output

### DIFF
--- a/docs/guides/feature-group-patterns/01-root-features.md
+++ b/docs/guides/feature-group-patterns/01-root-features.md
@@ -40,6 +40,8 @@ class MyRootFeature(FeatureGroup):
         return {"my_column": [1, 2, 3]}
 ```
 
+The return shape is a contract, not a style choice. On `PythonDictFramework` it is columnar `dict[str, list]`, and a root feature group must return its columns even when it has no rows: `{"my_column": []}`, never `[]` or `{}`. An empty source directory or a query with no hits is a zero-row result, and a result with zero columns raises `EmptyResultError`. See [calculate_feature](12-calculate-feature.md#return-contract).
+
 ## Test
 
 ```python

--- a/docs/guides/feature-group-patterns/09-framework-specific.md
+++ b/docs/guides/feature-group-patterns/09-framework-specific.md
@@ -59,6 +59,7 @@ def test_pandas_group_mean():
 
 | Framework | Import Path |
 |-----------|-------------|
+| PythonDict | `mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework.PythonDictFramework` |
 | Pandas | `mloda_plugins.compute_framework.base_implementations.pandas.dataframe.PandasDataFrame` |
 | Polars | `mloda_plugins.compute_framework.base_implementations.polars.dataframe.PolarsDataFrame` |
 | Polars Lazy | `mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe.PolarsLazyDataFrame` |

--- a/docs/guides/feature-group-patterns/10-testing-guide.md
+++ b/docs/guides/feature-group-patterns/10-testing-guide.md
@@ -56,18 +56,22 @@ from mloda.user import mloda, Feature
 
 def test_full_pipeline():
     result = mloda.run_all([Feature.not_typed("my_feature")])
-    assert "my_feature" in result.columns
+    assert "my_feature" in result[0]
 ```
+
+`run_all()` returns a list of result frames, one per compute framework and feature set, so index into it before asserting on columns.
 
 ### Level 3 Only: The Empty-Result Contract
 
-The rule that a FeatureGroup must return columns even at zero rows (see [calculate_feature](12-calculate-feature.md#empty-results)) is enforced during the run, not inside `calculate_feature()`. A Level 2 test that calls `calculate_feature()` directly passes on a group that returns `[]` or `{}` for "nothing found"; the same group raises `EmptyResultError` the first time that path is hit through `mloda.run_all()`. Cover every reachable empty path (no source files, a query with no hits, a filter that removes every row) at Level 3:
+The rule that a FeatureGroup must return columns even at zero rows (see [calculate_feature](12-calculate-feature.md#empty-results)) is enforced during the run, not inside `calculate_feature()`. A Level 2 test that calls `calculate_feature()` directly passes on a group that returns `[]` or `{}` for "nothing found"; the same group raises `EmptyResultError` the first time that path is hit through a run. Cover every reachable empty path (no source files, a query with no hits, a filter that removes every row) at Level 3:
 
 ```python
 def test_empty_source_keeps_schema():
-    result = mloda.run_all([Feature.not_typed("my_feature")], ...)  # no matching data
-    assert len(result) == 0
-    assert "my_feature" in result.columns
+    result = mloda.run_all(  # no matching data
+        [Feature.not_typed("my_feature")],
+        compute_frameworks={PythonDictFramework},
+    )
+    assert result[0] == {"my_feature": []}  # zero rows, schema intact
 ```
 
 **Tip**: Use `column_ordering="request_order"` for predictable test assertions:
@@ -79,7 +83,7 @@ def test_multiple_features():
         column_ordering="request_order"
     )
     # Columns guaranteed to be in request order
-    assert list(result.columns) == ["feature_a", "feature_b"]
+    assert list(result[0]) == ["feature_a", "feature_b"]
 ```
 
 Without `column_ordering`, column order is non-deterministic and tests comparing column lists may be flaky.

--- a/docs/guides/feature-group-patterns/10-testing-guide.md
+++ b/docs/guides/feature-group-patterns/10-testing-guide.md
@@ -59,6 +59,17 @@ def test_full_pipeline():
     assert "my_feature" in result.columns
 ```
 
+### Level 3 Only: The Empty-Result Contract
+
+The rule that a FeatureGroup must return columns even at zero rows (see [calculate_feature](12-calculate-feature.md#empty-results)) is enforced during the run, not inside `calculate_feature()`. A Level 2 test that calls `calculate_feature()` directly passes on a group that returns `[]` or `{}` for "nothing found"; the same group raises `EmptyResultError` the first time that path is hit through `mloda.run_all()`. Cover every reachable empty path (no source files, a query with no hits, a filter that removes every row) at Level 3:
+
+```python
+def test_empty_source_keeps_schema():
+    result = mloda.run_all([Feature.not_typed("my_feature")], ...)  # no matching data
+    assert len(result) == 0
+    assert "my_feature" in result.columns
+```
+
 **Tip**: Use `column_ordering="request_order"` for predictable test assertions:
 
 ```python

--- a/docs/guides/feature-group-patterns/12-calculate-feature.md
+++ b/docs/guides/feature-group-patterns/12-calculate-feature.md
@@ -43,6 +43,64 @@ def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
     return data
 ```
 
+## Return Contract
+
+Return the native data structure of the compute framework you run on:
+
+| Framework | Return |
+|-----------|--------|
+| `PythonDictFramework` | **Columnar** `dict[str, list[Any]]`: one key per column, all value-lists the same length |
+| `PandasDataFrame` | `pd.DataFrame` |
+| `PolarsDataFrame` / `PolarsLazyDataFrame` | `pl.DataFrame` / `pl.LazyFrame` |
+| `PyArrowTable` | `pa.Table` |
+| `DuckDBFramework` / `SqliteFramework` | Relation |
+| `SparkFramework` | Spark `DataFrame` |
+
+`PythonDictFramework` is columnar since mloda 0.9.0:
+
+```python
+@classmethod
+def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+    return {"doc_id": [1, 2], "score": [0.9, 0.4]}  # native
+```
+
+A row-oriented `list[dict]` is still accepted, but it is not the native shape: `transform()` pivots it with `rows_to_columnar()` on every calculation, and that pivot requires **homogeneous keys** across rows. A row missing a key raises `ValueError: Inconsistent row keys at index i`. Build the columnar dict directly, or run rows through `homogenize_rows()` first.
+
+## Empty Results
+
+Zero rows is a valid result. Zero columns is not: a FeatureGroup must always return its schema, so a result with no columns raises after calculation.
+
+```
+EmptyResultError: Result carries no schema (no columns): <FG>. A feature must
+return a schema; zero rows is a valid result, zero columns is not.
+```
+
+For `PythonDictFramework` this means returning `[]` or `{}` to mean "nothing found" is a bug, because both normalize to the schema-less `{}`. Name the columns instead:
+
+```python
+if not hits:
+    return {"doc_id": [], "score": []}  # zero rows, schema intact
+```
+
+A row-oriented `list[dict]` return cannot express "zero rows with schema" at all, since an empty list carries no keys. Any FeatureGroup with a reachable empty path (empty source directory, query with no hits, a [filter](15-filter-concepts.md) that empties the result) must therefore be columnar.
+
+The contract is only enforced through `mloda.run_all()`, so a unit test calling `calculate_feature()` directly will not catch a violation. See [Testing Guide](10-testing-guide.md).
+
+## Columnar Helpers
+
+`mloda.user` exports helpers for the `PythonDictFramework` shape. Use them instead of hand-rolling conversions:
+
+| Helper | Purpose |
+|--------|---------|
+| `rows_to_columnar(rows)` | Pivot `list[dict]` to columnar; requires homogeneous keys |
+| `columnar_to_rows(data)` | Pivot columnar to `list[dict]`, e.g. to feed a row-wise library |
+| `is_columnar(data)` | True iff `data` is a dict of equal-length lists |
+| `homogenize_rows(rows)` | Fill missing keys with `None` so rows pivot cleanly |
+
+```python
+from mloda.user import columnar_to_rows, homogenize_rows, is_columnar, rows_to_columnar
+```
+
 ## Extracting the Operation Type
 
 Chained feature groups (using `FeatureChainParserMixin`) often need to extract an operation type inside `calculate_feature`. The operation can come from the feature name string or from a config key in options. Use `_resolve_operation()` to handle both paths in one call:

--- a/docs/guides/feature-group-patterns/12-calculate-feature.md
+++ b/docs/guides/feature-group-patterns/12-calculate-feature.md
@@ -98,7 +98,7 @@ Zero rows is a valid result. Zero columns is not: a FeatureGroup must always ret
 from mloda.provider import EmptyResultError
 ```
 
-```
+```text
 EmptyResultError: Result carries no schema (no columns): <FG>. A feature must
 return a schema; zero rows is a valid result, zero columns is not.
 ```

--- a/docs/guides/feature-group-patterns/12-calculate-feature.md
+++ b/docs/guides/feature-group-patterns/12-calculate-feature.md
@@ -45,23 +45,47 @@ def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
 
 ## Return Contract
 
-Return the native data structure of the compute framework you run on:
+The framework's `transform()` accepts two shapes, and which one you return decides whether you **replace** the frame or **append** a column:
 
-| Framework | Return |
-|-----------|--------|
-| `PythonDictFramework` | **Columnar** `dict[str, list[Any]]`: one key per column, all value-lists the same length |
-| `PandasDataFrame` | `pd.DataFrame` |
-| `PolarsDataFrame` / `PolarsLazyDataFrame` | `pl.DataFrame` / `pl.LazyFrame` |
-| `PyArrowTable` | `pa.Table` |
-| `DuckDBFramework` / `SqliteFramework` | Relation |
-| `SparkFramework` | Spark `DataFrame` |
+| Return | Meaning |
+|--------|---------|
+| A whole frame | Initial data. Becomes the frame. This is what root features return. |
+| A single column | Added data. Appended to the existing frame under the requested name. Only valid when the FeatureSet holds exactly one feature. |
 
-`PythonDictFramework` is columnar since mloda 0.9.0:
+| Framework | Whole frame | Single column |
+|-----------|-------------|---------------|
+| `PythonDictFramework` | Columnar `dict[str, list[Any]]` | None: see below |
+| `PandasDataFrame` | `pd.DataFrame` | `pd.Series` |
+| `PolarsDataFrame` / `PolarsLazyDataFrame` | `pl.DataFrame` / `pl.LazyFrame` | `pl.Series` |
+| `PyArrowTable` | `pa.Table` | `pa.Array` / `pa.ChunkedArray` |
+| `DuckDBFramework` | `duckdb.DuckDBPyRelation` | Any iterable of values |
+| `SqliteFramework` | `SqliteRelation` | Any iterable of values |
+| `SparkFramework` | Spark `DataFrame` | Any iterable of values |
+
+Every framework above also accepts a columnar `dict[str, list]` as the whole-frame form, not just `PythonDictFramework`.
+
+### PythonDictFramework Is Columnar
+
+Since mloda 0.9.0 the native structure is columnar `dict[str, list[Any]]`: one key per column, all value-lists the same length.
 
 ```python
 @classmethod
 def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-    return {"doc_id": [1, 2], "score": [0.9, 0.4]}  # native
+    return {"doc_id": [1, 2], "score": [0.9, 0.4]}  # root: this becomes the frame
+```
+
+It has **no single-column form**. A bare `list` is read as a list of row dicts, not as one column's values. Because the returned dict is already the native type, `transform()` is skipped and the dict *becomes* the frame, so a derived feature that returns only its own column silently drops every input column:
+
+```python
+@classmethod
+def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+    # WRONG: replaces the frame. A downstream group needing "src"
+    # then fails with ValueError: Feature '...' failed with a KeyError: 'src'
+    return {"doubled": [v * 2 for v in data["src"]]}
+
+    # RIGHT: add the column, return the whole dict (the analogue of pandas data[name] = ...)
+    data["doubled"] = [v * 2 for v in data["src"]]
+    return data
 ```
 
 A row-oriented `list[dict]` is still accepted, but it is not the native shape: `transform()` pivots it with `rows_to_columnar()` on every calculation, and that pivot requires **homogeneous keys** across rows. A row missing a key raises `ValueError: Inconsistent row keys at index i`. Build the columnar dict directly, or run rows through `homogenize_rows()` first.
@@ -69,6 +93,10 @@ A row-oriented `list[dict]` is still accepted, but it is not the native shape: `
 ## Empty Results
 
 Zero rows is a valid result. Zero columns is not: a FeatureGroup must always return its schema, so a result with no columns raises after calculation.
+
+```python
+from mloda.provider import EmptyResultError
+```
 
 ```
 EmptyResultError: Result carries no schema (no columns): <FG>. A feature must
@@ -84,7 +112,9 @@ if not hits:
 
 A row-oriented `list[dict]` return cannot express "zero rows with schema" at all, since an empty list carries no keys. Any FeatureGroup with a reachable empty path (empty source directory, query with no hits, a [filter](15-filter-concepts.md) that empties the result) must therefore be columnar.
 
-The contract is only enforced through `mloda.run_all()`, so a unit test calling `calculate_feature()` directly will not catch a violation. See [Testing Guide](10-testing-guide.md).
+`EmptyResultError` is raised when the schema-less group's feature was requested from the API. An intermediate group that returns no schema fails later instead, as a missing-column error in whichever group consumed it. Return your columns either way.
+
+The check runs during execution, not inside `calculate_feature()`, so a unit test calling `calculate_feature()` directly will not catch a violation. See [Testing Guide](10-testing-guide.md).
 
 ## Columnar Helpers
 

--- a/docs/guides/feature-group-patterns/15-filter-concepts.md
+++ b/docs/guides/feature-group-patterns/15-filter-concepts.md
@@ -50,27 +50,22 @@ global_filter.add_filter("status", FilterType.EQUAL, {"value": "active"})
 
 ---
 
-## Known Limitation: Filtering a Root FeatureGroup's Own Output Column
+## Known Limitation: Filtering a Column the FeatureGroup Itself Outputs
 
-> **Warning (mloda 0.10.0):** Do not attach a `GlobalFilter` to a column that a **root** FeatureGroup itself produces. The engine schedules the filter feature as a separately calculable node, which fails in one of two ways:
+> **Warning (mloda 0.10.0):** Do not attach a `GlobalFilter` to a column that the producing FeatureGroup itself outputs. `GlobalFilter.unify_options()` copies every option of the requested feature, **context keys included**, into the filter feature's `group`. Since `Options` compares on `group` only, the filter feature no longer matches the requested one: the engine gives it a fresh UUID and schedules it as a separate calculable node. That fails in one of two ways:
 >
-> - The filter feature's options are all moved into `group`, so a FeatureGroup that reads runtime parameters from `options.context` lands in its own batch with an empty context and raises.
-> - If the options are passed so the batches merge, the filter twin displaces the requested feature and the filtered column is silently missing from the result.
+> - The filter node runs with everything in `options.group` and an empty `options.context`, so a FeatureGroup that reads its runtime parameters from `options.context` raises (typically a `ValueError` for the missing key).
+> - If the options are passed so the two batches merge, the filter twin displaces the requested feature and the filtered column is silently missing from the result.
 >
-> Tracked in [mloda#712](https://github.com/mloda-ai/mloda/issues/712).
+> Reproduced on a root FeatureGroup, but nothing in the engine limits it to root groups. Tracked in [mloda#712](https://github.com/mloda-ai/mloda/issues/712).
 
 Until that is fixed, pass the threshold as a plain option and filter inline:
 
 ```python
 class RetrievalFeature(FeatureGroup):
     @classmethod
-    def final_filters(cls) -> bool | None:
-        return False
-
-    @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        options = next(iter(features.features)).options
-        max_distance = options.get("max_distance")
+        max_distance = features.get_options_key("max_distance")
 
         hits = [h for h in search(...) if h.distance <= max_distance]
         # Columnar, so an empty hit list still carries the schema.
@@ -82,7 +77,7 @@ class RetrievalFeature(FeatureGroup):
 
 Filtering is the most likely way to produce a legitimately empty result, so a FeatureGroup that filters inline must be able to express "zero rows with schema". See [Empty Results](12-calculate-feature.md#empty-results).
 
-This limitation does not apply to filtering a **derived** feature group's input columns, which is the normal case shown above.
+Filtering a FeatureGroup's **input** columns, the normal case shown above, is unaffected.
 
 ---
 

--- a/docs/guides/feature-group-patterns/15-filter-concepts.md
+++ b/docs/guides/feature-group-patterns/15-filter-concepts.md
@@ -50,6 +50,42 @@ global_filter.add_filter("status", FilterType.EQUAL, {"value": "active"})
 
 ---
 
+## Known Limitation: Filtering a Root FeatureGroup's Own Output Column
+
+> **Warning (mloda 0.10.0):** Do not attach a `GlobalFilter` to a column that a **root** FeatureGroup itself produces. The engine schedules the filter feature as a separately calculable node, which fails in one of two ways:
+>
+> - The filter feature's options are all moved into `group`, so a FeatureGroup that reads runtime parameters from `options.context` lands in its own batch with an empty context and raises.
+> - If the options are passed so the batches merge, the filter twin displaces the requested feature and the filtered column is silently missing from the result.
+>
+> Tracked in [mloda#712](https://github.com/mloda-ai/mloda/issues/712).
+
+Until that is fixed, pass the threshold as a plain option and filter inline:
+
+```python
+class RetrievalFeature(FeatureGroup):
+    @classmethod
+    def final_filters(cls) -> bool | None:
+        return False
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        options = next(iter(features.features)).options
+        max_distance = options.get("max_distance")
+
+        hits = [h for h in search(...) if h.distance <= max_distance]
+        # Columnar, so an empty hit list still carries the schema.
+        return {
+            "retrieval__doc_id": [h.doc_id for h in hits],
+            "retrieval__distance": [h.distance for h in hits],
+        }
+```
+
+Filtering is the most likely way to produce a legitimately empty result, so a FeatureGroup that filters inline must be able to express "zero rows with schema". See [Empty Results](12-calculate-feature.md#empty-results).
+
+This limitation does not apply to filtering a **derived** feature group's input columns, which is the normal case shown above.
+
+---
+
 ## Time Filters
 
 ```python
@@ -188,5 +224,5 @@ All features from the same FeatureGroup must have the same filters. Split into s
 ## Related
 
 - [Filter Engine](../compute-framework-patterns/07-filter-engine.md) - Implementing filter operations in a compute framework
-- [calculate_feature](12-calculate-feature.md) - Accessing `features.filters` inside the calculation method
+- [calculate_feature](12-calculate-feature.md) - Accessing `features.filters` inside the calculation method, and the [empty-result contract](12-calculate-feature.md#empty-results) a filter can trigger
 - [Masking](25-masking.md) - Conditional aggregation that nulls out values instead of removing rows


### PR DESCRIPTION
Closes #314. Closes #315.

Both issues report the same root cause from two angles: the feature-group pattern guides never state what `calculate_feature()` must return, so following them literally on `PythonDictFramework` produces code that is slower than it needs to be and broken on the empty path.

## Changes

- **`12-calculate-feature.md`**: new **Return Contract** section. States the two accepted shapes (whole frame vs single appended column) per framework, that `PythonDictFramework` is columnar `dict[str, list]` since mloda 0.9.0, and that a row-oriented `list[dict]` is accepted but pivoted via `rows_to_columnar()` with a homogeneous-key requirement. New **Empty Results** section for the `EmptyResultError` contract (zero rows valid, zero columns not) and a **Columnar Helpers** table for the four `mloda.user` helpers (`columnar_to_rows`, `rows_to_columnar`, `is_columnar`, `homogenize_rows`), which no guide referenced.
- **`01-root-features.md`**: a root group must return its columns even at zero rows (`{"col": []}`, never `[]`).
- **`10-testing-guide.md`**: the empty-result contract is enforced during a run, not inside `calculate_feature()`, so a Level 2 test cannot catch a violation. Adds a Level 3 example covering the empty path.
- **`15-filter-concepts.md`**: warning box for `GlobalFilter` on a column the group itself outputs (mloda-ai/mloda#712, still open), with the inline-`Options` workaround, plus a cross-reference to the empty-result contract since filters are the likeliest way to empty a result.
- **`09-framework-specific.md`**: adds the missing `PythonDictFramework` row to the frameworks table.

## Verification

Every claim was checked against mloda core, and the load-bearing ones were probed against the installed 0.10.0:

- `{"my_feature": []}` runs clean and returns `[{'my_feature': []}]`; returning `[]` raises `EmptyResultError` with the documented message.
- A `PythonDictFramework` derived group returning only its own column drops the input columns (`transform()` is skipped for the already-native dict, so the dict *becomes* the frame). A downstream group then fails with `ValueError: Feature 'Downstream' failed with a KeyError: 'src'`. The guide now shows the mutate-and-return form, matching mloda's own PythonDict plugins.

## Incidental fix

The existing Level 3 examples in `10-testing-guide.md` asserted `result.columns`. `run_all()` returns a `RunResult` list of frames, which has no `.columns`, so those examples could not pass as written. Corrected to index into the result.

`tox` green: 4309 passed, ruff/mypy/bandit clean.