### PR TITLE
chore(deps): cap mloda core dependency to 0.10.x patch releases

### DIFF
--- a/config/shared.toml
+++ b/config/shared.toml
@@ -16,5 +16,5 @@ build-backend = "setuptools.build_meta"
 
 [defaults]
 license = "Apache-2.0"
-core_dependency = "mloda>=0.10.0"
+core_dependency = "mloda>=0.10.0,<0.11.0"
 optional_dependencies = { dev = ["mloda-testing", "pytest>=9.0.3"] }

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "Example community ComputeFramework plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "Example community Extender plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "Shared base classes for data operation feature groups"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "Example community FeatureGroup plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "All community plugins for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.urls]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "Example enterprise ComputeFramework plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "Example enterprise Extender plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "Example enterprise FeatureGroup plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.urls]

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "Plugin discovery and search for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.10.0,<0.11.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/testing/pyproject.toml
+++ b/mloda/testing/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.3"
 description = "Test utilities for mloda plugin development"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0", "pytest>=9.0.3"]
+dependencies = ["mloda>=0.10.0,<0.11.0", "pytest>=9.0.3"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Development workspace for mloda registry packages"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10,<3.15"
 dependencies = [
-    "mloda>=0.10.0",
+    "mloda>=0.10.0,<0.11.0",
 ]
 authors = [
     { name = "Tom Kaltofen", email = "info@mloda.ai" }

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.10.0" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.10.0,<0.11.0" }]
 
 [[package]]
 name = "mloda-community-aggregation"
@@ -458,7 +458,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -499,7 +499,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "mloda-community-aggregation", marker = "extra == 'all'" },
     { name = "mloda-community-binning", marker = "extra == 'all'" },
     { name = "mloda-community-datetime", marker = "extra == 'all'" },
@@ -614,7 +614,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "mloda-community-example-a", marker = "extra == 'all'" },
     { name = "mloda-community-example-b", marker = "extra == 'all'" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
@@ -682,7 +682,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1295,7 +1295,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.10.0" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.10.0,<0.11.0" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
@@ -1313,7 +1313,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1335,7 +1335,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1357,7 +1357,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1379,7 +1379,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "mloda-testing", marker = "extra == 'dev'", editable = "mloda/testing" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1416,7 +1416,7 @@ dev = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
     { name = "duckdb", marker = "extra == 'dev'" },
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'dev'" },
     { name = "polars", marker = "extra == 'dev'" },
@@ -1448,7 +1448,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]


### PR DESCRIPTION
## Summary
- mloda is expected to keep shipping breaking changes across minor versions for the foreseeable future, so cap the core dependency to patch releases only within 0.10.x instead of an open `>=0.10.0` floor.
- Change is single-sourced in `config/shared.toml` `core_dependency`, regenerated via `scripts/generate_pyproject.py` (updates all 30 per-package pyproject.toml files plus root pyproject.toml), and `uv.lock` was relocked to match.
- Resolved mloda version is unaffected (still 0.10.0); only the dependency specifier metadata changed.

## Test plan
- [x] `python scripts/generate_pyproject.py --check` passes (all pyproject.toml files up-to-date, workspace members up-to-date, root mloda-core dependency up-to-date)
- [x] `uv lock --check` passes after relocking