### PR TITLE
docs: fix PandasDataFrame casing in guide snippets

### DIFF
--- a/docs/guides/02-discover-plugins.md
+++ b/docs/guides/02-discover-plugins.md
@@ -55,7 +55,7 @@ docs = get_feature_group_docs(name="Customer")
 docs = get_feature_group_docs(search="aggregation")
 
 # Filter by compute framework
-docs = get_feature_group_docs(compute_framework="PandasDataframe")
+docs = get_feature_group_docs(compute_framework="PandasDataFrame")
 
 # Filter by version
 docs = get_feature_group_docs(version_contains="1.0")

--- a/docs/guides/feature-group-patterns/10-testing-guide.md
+++ b/docs/guides/feature-group-patterns/10-testing-guide.md
@@ -29,7 +29,7 @@ def test_matching():
     assert not ScaledFeature.match_feature_group_criteria("price", None)
 
     # Framework restriction
-    assert PandasDataframe in PandasOnlyFeature.compute_framework_rule()
+    assert PandasDataFrame in PandasOnlyFeature.compute_framework_rule()
 ```
 
 ## Level 2: Framework Test Example


### PR DESCRIPTION
## Summary

Fix the two guide snippets that use `PandasDataframe` so they reference the canonical `PandasDataFrame` class name.

## Related issue

Closes #320

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature / new plugin (`feat:`)
- [x] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [x] Linux `tox run -e python311,lint-docs` passes: 4309 tests passed, 149 skipped; `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, and the docs lint all passed.
- [ ] Tests added or updated for the change — not applicable to this static documentation-only casing correction.
- [x] Documentation updated where relevant
- [x] `pyproject.toml` not edited by hand
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## AI assistance disclosure

OpenAI Codex was used to prepare and validate this two-line documentation correction. The issue scope, exact spelling occurrences, diff, and Linux test results were independently rechecked before opening this draft pull request.
