### PR TITLE
fix(data_operations): align PROPERTY_MAPPING declarations with runtime dispatch

### DIFF
--- a/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
+++ b/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
@@ -94,6 +94,12 @@ All offset types require `order_by`; partition ordering is what "previous row" m
 
 ---
 
+## Both creation paths accept the same operations
+
+Every rank and offset type above is accepted identically whether it arrives in the feature name (`value__lag_1_offset`) or in Options (`{"offset_type": "lag_1", ...}`). The parametric families are part of that: `ntile_N`, `top_N`, `bottom_N`, `lag_N`, `lead_N`, `diff_N` and `pct_change_N` are validated by the same predicate on both paths, declared as an `element_validator` on the `rank_type` / `offset_type` PROPERTY_MAPPING entry.
+
+Unsupported values are rejected at match time, not at compute: `offset_type="banana"`, a zero or negative suffix (`lag_0`), and a malformed token (`ntile_abc`) are all non-matches on both paths.
+
 ## Shared semantics
 
 - **NULL in offsets**: Offsets reference *other* rows, so the current row being NULL does not force a NULL result. `lag_N` on a NULL row returns whatever sits N rows earlier (possibly non-NULL). `first_value` and `last_value` skip NULL source values and return the first or last non-NULL in the partition; the result is NULL only when every value in the partition is NULL. A NULL result from `lag_N`/`lead_N` happens when the referenced position falls outside the partition (first or last N rows).

--- a/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
+++ b/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
@@ -144,6 +144,10 @@ All frame-aggregate variants accept:
 | `order_by` | `str` | Required for rolling, time-window, cumulative, and expanding |
 | `mask` | tuple or list of tuples | Conditional aggregation; see [Masking](../feature-group-patterns/25-masking.md) |
 
+### Config-based frame features
+
+A frame feature built from Options instead of a name declares its window explicitly, and PROPERTY_MAPPING is what enforces it: `aggregation_type`, `frame_type` and `in_features` are always required, `frame_size` (a positive integer) is required for `rolling` and `time`, and `frame_unit` is required for `time` and must be one of the units above. Name-based features carry all of that in the name, so they need only `partition_by` and `order_by`.
+
 ---
 
 ## Scalar vs scalar arithmetic vs point arithmetic vs frame vs window vs aggregation

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from enum import Enum
 
 
@@ -113,6 +114,37 @@ def is_op_token(value: object) -> bool:
     return isinstance(value, str) and bool(value)
 
 
+def op_token_value(value: object) -> str:
+    """The single token of a value is_op_token accepts, unwrapped from its container."""
+    if isinstance(value, (list, tuple, set, frozenset)) and len(value) == 1:
+        (value,) = value
+    return str(value)
+
+
+def _is_feature_ref(value: object) -> bool:
+    """One source-feature reference: a non-empty string, or a Feature (duck-typed as core's converter does)."""
+    if isinstance(value, str):
+        return bool(value)
+    return hasattr(value, "options")
+
+
+def is_in_features_value(value: object) -> bool:
+    """True for source-feature references core can resolve: non-empty str or Feature, or a container of those."""
+    if isinstance(value, (list, tuple, set, frozenset)):
+        # An empty container passes: core's in-feature count check owns it as a plain non-match.
+        return all(_is_feature_ref(item) for item in value)
+    return _is_feature_ref(value)
+
+
 def is_positive_int(value: object) -> bool:
     """True only for a positive int (rejects bool, non-int, and n < 1)."""
     return isinstance(value, int) and not isinstance(value, bool) and value >= 1
+
+
+#: ASCII decimal >= 1. str.isdigit also accepts superscripts (int() raises) and non-ASCII digits.
+_PARAMETRIC_SUFFIX_PATTERN = re.compile(r"[1-9][0-9]*")
+
+
+def is_parametric_suffix(suffix: str) -> bool:
+    """True for the ASCII positive-integer suffix of a parametric operation token (e.g. the 4 in ntile_4)."""
+    return _PARAMETRIC_SUFFIX_PATTERN.fullmatch(suffix) is not None

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -111,3 +111,8 @@ def is_op_token(value: object) -> bool:
             return False
         (value,) = value
     return isinstance(value, str) and bool(value)
+
+
+def is_positive_int(value: object) -> bool:
+    """True only for a positive int (rejects bool, non-int, and n < 1)."""
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 1

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -12,17 +12,12 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import is_op_token, is_positive_int
 
 BINNING_OPS = {
     "bin": "Equal-width binning (value range divided into n equal intervals)",
     "qbin": "Quantile-based binning (rows divided into n roughly equal groups by rank)",
 }
-
-
-def _is_positive_int(value: object) -> bool:
-    """True only for a positive int (rejects bool, non-int, and n < 1)."""
-    return isinstance(value, int) and not isinstance(value, bool) and value >= 1
 
 
 class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -46,7 +41,7 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Number of bins (positive integer)",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: _is_positive_int,
+            DefaultOptionKeys.match_guard: is_positive_int,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source numeric column",

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -14,7 +14,15 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import FRAME_TYPE, is_op_token, is_positive_int
+from mloda.community.feature_groups.data_operations.base import (
+    FRAME_SIZE as _FRAME_SIZE_KEY,
+    FRAME_TYPE as _FRAME_TYPE_KEY,
+    FRAME_UNIT as _FRAME_UNIT_KEY,
+    is_in_features_value,
+    is_op_token,
+    is_positive_int,
+    op_token_value,
+)
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
@@ -25,8 +33,10 @@ from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, 
 #   {col}__avg_5_day_window      -> time-interval window
 #   {col}__cumsum                -> cumulative sum
 #   {col}__expanding_avg         -> expanding window
-_ROLLING_PATTERN = re.compile(r"^.+__(\w+)_rolling_(\d+)$")
-_TIME_WINDOW_PATTERN = re.compile(r"^.+__(\w+)_(\d+)_(\w+)_window$")
+# The size group is [1-9]\d*, not \d+: a zero-sized or zero-padded frame is not a window, and the
+# string path must reject it in the pattern itself, exactly as the config path rejects frame_size=0.
+_ROLLING_PATTERN = re.compile(r"^.+__(\w+)_rolling_([1-9]\d*)$")
+_TIME_WINDOW_PATTERN = re.compile(r"^.+__(\w+)_([1-9]\d*)_(\w+)_window$")
 _CUMULATIVE_PATTERN = re.compile(r"^.+__cum(\w+)$")
 _EXPANDING_PATTERN = re.compile(r"^.+__expanding_(\w+)$")
 
@@ -41,12 +51,12 @@ _TIME_UNITS = {"second", "minute", "hour", "day", "week", "month", "year"}
 
 def _needs_frame_size(options: Options) -> bool:
     """Rolling and time frames are sized; cumulative and expanding are not."""
-    return options.get(FRAME_TYPE) in ("rolling", "time")
+    return options.get(_FRAME_TYPE_KEY) in ("rolling", "time")
 
 
 def _needs_frame_unit(options: Options) -> bool:
     """Only a time-interval frame carries a unit."""
-    return bool(options.get(FRAME_TYPE) == "time")
+    return bool(options.get(_FRAME_TYPE_KEY) == "time")
 
 
 @functools.lru_cache(maxsize=1024)
@@ -185,9 +195,10 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
     _CAPABILITY_HAS_AXIS: bool = True
 
     AGGREGATION_TYPE = "aggregation_type"
-    FRAME_TYPE = "frame_type"
-    FRAME_SIZE = "frame_size"
-    FRAME_UNIT = "frame_unit"
+    # Aliases of the shared keys, so the literals stay defined once in data_operations/base.py.
+    FRAME_TYPE = _FRAME_TYPE_KEY
+    FRAME_SIZE = _FRAME_SIZE_KEY
+    FRAME_UNIT = _FRAME_UNIT_KEY
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
 
@@ -229,6 +240,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
             "explanation": "Source feature for frame aggregation",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_in_features_value,
         },
         PARTITION_BY: {
             "explanation": "List of columns to partition by",
@@ -293,12 +305,24 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
             return False
         if parsed["frame_type"] not in cls.SUPPORTED_FRAME_TYPES:
             return False
-        if parsed["frame_type"] == "time":
-            if parsed["frame_unit"] not in _TIME_UNITS:
-                return False
-            if parsed["frame_unit"] not in cls.SUPPORTED_TIME_UNITS:
-                return False
+        # SUPPORTED_TIME_UNITS defaults to _TIME_UNITS and subclasses only narrow it, so it subsumes it.
+        if parsed["frame_type"] == "time" and parsed["frame_unit"] not in cls.SUPPORTED_TIME_UNITS:
+            return False
         return True
+
+    @classmethod
+    def _validate_required_when(
+        cls,
+        result: bool,
+        feature_name: str | FeatureName,
+        prefix_patterns: list[str],
+        property_mapping: dict[str, Any] | None,
+        options: Options,
+    ) -> bool:
+        # A frame name carries its own size and unit, so the conditional requirements are config-path only.
+        if cls._parse_frame_feature(str(feature_name)) is not None:
+            return True
+        return super()._validate_required_when(result, feature_name, prefix_patterns, property_mapping, options)
 
     @classmethod
     def match_feature_group_criteria(
@@ -318,10 +342,10 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
 
         # Config path only: SUPPORTED_* narrows per subclass, so it cannot be declared once on the base.
         if cls._parse_frame_feature(str(feature_name)) is None:
-            frame_type = str(options.get(cls.FRAME_TYPE))
+            frame_type = op_token_value(options.get(cls.FRAME_TYPE))
             if frame_type not in cls.SUPPORTED_FRAME_TYPES:
                 return False
-            if frame_type == "time" and str(options.get(cls.FRAME_UNIT)) not in cls.SUPPORTED_TIME_UNITS:
+            if frame_type == "time" and op_token_value(options.get(cls.FRAME_UNIT)) not in cls.SUPPORTED_TIME_UNITS:
                 return False
 
         partition_by = options.get(cls.PARTITION_BY)
@@ -342,7 +366,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
         if parsed is not None:
             return str(parsed["agg_type"])
         agg_type = options.get(cls.AGGREGATION_TYPE)
-        return None if agg_type is None else str(agg_type)
+        return None if agg_type is None else op_token_value(agg_type)
 
     @classmethod
     def _capability_secondary(cls, feature_name: str, options: Options) -> str | None:
@@ -350,7 +374,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
         if parsed is not None:
             return str(parsed["frame_type"])
         frame_type = options.get(cls.FRAME_TYPE)
-        return None if frame_type is None else str(frame_type)
+        return None if frame_type is None else op_token_value(frame_type)
 
     @classmethod
     def _capability_guard(cls, feature_name: str, options: Options) -> bool:
@@ -363,7 +387,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
         if frame_type == "time":
             parsed = cls._parse_frame_feature(feature_name)
             frame_unit = parsed["frame_unit"] if parsed is not None else options.get(cls.FRAME_UNIT)
-            if frame_unit is not None and str(frame_unit) not in cls.SUPPORTED_TIME_UNITS:
+            if frame_unit is not None and op_token_value(frame_unit) not in cls.SUPPORTED_TIME_UNITS:
                 return False
         return True
 
@@ -385,12 +409,13 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
             }
 
         source_features = cls._extract_source_features(feature)
+        frame_unit = feature.options.get(cls.FRAME_UNIT)
         return {
             "source_col": source_features[0],
-            "agg_type": str(feature.options.get(cls.AGGREGATION_TYPE)),
-            "frame_type": str(feature.options.get(cls.FRAME_TYPE)),
+            "agg_type": op_token_value(feature.options.get(cls.AGGREGATION_TYPE)),
+            "frame_type": op_token_value(feature.options.get(cls.FRAME_TYPE)),
             "frame_size": feature.options.get(cls.FRAME_SIZE),
-            "frame_unit": feature.options.get(cls.FRAME_UNIT),
+            "frame_unit": None if frame_unit is None else op_token_value(frame_unit),
             "partition_by": feature.options.get(cls.PARTITION_BY),
             "order_by": feature.options.get(cls.ORDER_BY),
         }

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -14,58 +14,74 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import FRAME_TYPE, is_op_token, is_positive_int
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
 
-# Patterns for string-based feature names:
+# Patterns for string-based feature names; group 1 is the aggregation token, matching what
+# core's FeatureChainParser.parse_feature_name returns as the operation:
 #   {col}__sum_rolling_3         -> rolling N rows
 #   {col}__avg_5_day_window      -> time-interval window
 #   {col}__cumsum                -> cumulative sum
 #   {col}__expanding_avg         -> expanding window
-_ROLLING_PATTERN = re.compile(r"^(.+)__(\w+)_rolling_(\d+)$")
-_TIME_WINDOW_PATTERN = re.compile(r"^(.+)__(\w+)_(\d+)_(\w+)_window$")
-_CUMULATIVE_PATTERN = re.compile(r"^(.+)__cum(\w+)$")
-_EXPANDING_PATTERN = re.compile(r"^(.+)__expanding_(\w+)$")
+_ROLLING_PATTERN = re.compile(r"^.+__(\w+)_rolling_(\d+)$")
+_TIME_WINDOW_PATTERN = re.compile(r"^.+__(\w+)_(\d+)_(\w+)_window$")
+_CUMULATIVE_PATTERN = re.compile(r"^.+__cum(\w+)$")
+_EXPANDING_PATTERN = re.compile(r"^.+__expanding_(\w+)$")
 
 # Frame aggregation supports the order-independent subset of the canonical
 # aggregation-type table (no mode/nunique/first/last, no ddof-variant spellings).
 # Frame never uses the canonical descriptions, so this is an explicit set rather
-# than a derivation from the shared table.
+# than a derivation from the shared table. Cumulative and expanding accept this
+# full set, so they need no narrower table of their own.
 _AGGREGATION_TYPES = frozenset({"sum", "avg", "count", "min", "max", "std", "var", "median"})
-_CUMULATIVE_OPS = _AGGREGATION_TYPES
 _TIME_UNITS = {"second", "minute", "hour", "day", "week", "month", "year"}
+
+
+def _needs_frame_size(options: Options) -> bool:
+    """Rolling and time frames are sized; cumulative and expanding are not."""
+    return options.get(FRAME_TYPE) in ("rolling", "time")
+
+
+def _needs_frame_unit(options: Options) -> bool:
+    """Only a time-interval frame carries a unit."""
+    return bool(options.get(FRAME_TYPE) == "time")
 
 
 @functools.lru_cache(maxsize=1024)
 def _parse_frame_feature_cached(feature_name: str) -> dict[str, Any] | None:
     """Regex-parse a frame feature name; cached on the name since the regexes are module constants."""
+    # Same split core uses, so the parsed source column cannot drift from the routed one.
+    source_col = feature_name.rsplit("__", 1)[0]
+    if not source_col:
+        return None
+
     m = _ROLLING_PATTERN.match(feature_name)
     if m:
         return {
-            "source_col": m.group(1),
-            "agg_type": m.group(2),
+            "source_col": source_col,
+            "agg_type": m.group(1),
             "frame_type": "rolling",
-            "frame_size": int(m.group(3)),
+            "frame_size": int(m.group(2)),
             "frame_unit": None,
         }
 
     m = _TIME_WINDOW_PATTERN.match(feature_name)
     if m:
         return {
-            "source_col": m.group(1),
-            "agg_type": m.group(2),
+            "source_col": source_col,
+            "agg_type": m.group(1),
             "frame_type": "time",
-            "frame_size": int(m.group(3)),
-            "frame_unit": m.group(4),
+            "frame_size": int(m.group(2)),
+            "frame_unit": m.group(3),
         }
 
     m = _CUMULATIVE_PATTERN.match(feature_name)
     if m:
         return {
-            "source_col": m.group(1),
-            "agg_type": m.group(2),
+            "source_col": source_col,
+            "agg_type": m.group(1),
             "frame_type": "cumulative",
             "frame_size": None,
             "frame_unit": None,
@@ -74,8 +90,8 @@ def _parse_frame_feature_cached(feature_name: str) -> dict[str, Any] | None:
     m = _EXPANDING_PATTERN.match(feature_name)
     if m:
         return {
-            "source_col": m.group(1),
-            "agg_type": m.group(2),
+            "source_col": source_col,
+            "agg_type": m.group(1),
             "frame_type": "expanding",
             "frame_size": None,
             "frame_unit": None,
@@ -150,10 +166,14 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
     - ``order_by``: Column to order by (required for all frame types)
     """
 
-    # Required by FeatureChainParserMixin but unused: match_feature_group_criteria
-    # is fully overridden to handle four distinct patterns (rolling, time, cumulative,
-    # expanding). This value is a placeholder to satisfy the mixin contract.
-    PREFIX_PATTERN = r".*__([\w]+)_rolling_\d+$"
+    # PREFIX_PATTERN is the rolling member; FRAME_PATTERNS is the full matching set the mixin uses.
+    FRAME_PATTERNS: tuple[str, ...] = (
+        _ROLLING_PATTERN.pattern,
+        _TIME_WINDOW_PATTERN.pattern,
+        _CUMULATIVE_PATTERN.pattern,
+        _EXPANDING_PATTERN.pattern,
+    )
+    PREFIX_PATTERN = _ROLLING_PATTERN.pattern
 
     SUPPORTED_FRAME_TYPES: set[str] = {"rolling", "time", "cumulative", "expanding"}
     SUPPORTED_TIME_UNITS: set[str] = _TIME_UNITS
@@ -178,7 +198,6 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.match_guard: is_op_token,
-            DefaultOptionKeys.default: None,
         },
         FRAME_TYPE: {
             "explanation": "Frame semantics of the window",
@@ -191,19 +210,20 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.match_guard: is_op_token,
-            DefaultOptionKeys.default: None,
         },
         FRAME_SIZE: {
             "explanation": "Window size (rows for rolling, integer for time)",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
+            DefaultOptionKeys.match_guard: is_positive_int,
+            DefaultOptionKeys.required_when: _needs_frame_size,
         },
         FRAME_UNIT: {
             "explanation": "Time unit for time windows",
+            DefaultOptionKeys.allowed_values: {unit: f"{unit} interval" for unit in sorted(_TIME_UNITS)},
             DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.required_when: _needs_frame_unit,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature for frame aggregation",
@@ -259,57 +279,49 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
         return None if cached is None else dict(cached)
 
     @classmethod
+    def _get_prefix_patterns(cls) -> list[str]:
+        """All four name shapes, so the mixin routes every frame pattern, not only rolling."""
+        return list(cls.FRAME_PATTERNS)
+
+    @classmethod
+    def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
+        """Name path: the parsed agg type, frame type and time unit must all be supported here."""
+        parsed = cls._parse_frame_feature(str(feature_name))
+        if parsed is None:
+            return False
+        if parsed["agg_type"] not in _AGGREGATION_TYPES:
+            return False
+        if parsed["frame_type"] not in cls.SUPPORTED_FRAME_TYPES:
+            return False
+        if parsed["frame_type"] == "time":
+            if parsed["frame_unit"] not in _TIME_UNITS:
+                return False
+            if parsed["frame_unit"] not in cls.SUPPORTED_TIME_UNITS:
+                return False
+        return True
+
+    @classmethod
     def match_feature_group_criteria(
         cls,
         feature_name: Any,
         options: Any,
         _data_access_collection: Any = None,
     ) -> bool:
-        """Match using four string patterns or config-based matching.
+        """Extend the declaration-driven mixin match with per-subclass capability and shape checks.
 
-        Validates:
-        - Feature name matches one of the four patterns, OR config has required keys
-        - partition_by is a list of strings
-        - order_by is a string
-        - aggregation_type is supported
-        - For cumulative/expanding: agg in _CUMULATIVE_OPS (same as _AGGREGATION_TYPES)
-        - For time: frame_unit in _TIME_UNITS
+        PROPERTY_MAPPING owns the value spaces (agg type, frame type, frame unit, frame size)
+        and the config-path presence rules; only what a shared class-level declaration cannot
+        express lives here.
         """
-        name = str(feature_name)
+        if not super().match_feature_group_criteria(feature_name, options, _data_access_collection):
+            return False
 
-        parsed = cls._parse_frame_feature(name)
-
-        if parsed is not None:
-            if parsed["agg_type"] not in _AGGREGATION_TYPES:
+        # Config path only: SUPPORTED_* narrows per subclass, so it cannot be declared once on the base.
+        if cls._parse_frame_feature(str(feature_name)) is None:
+            frame_type = str(options.get(cls.FRAME_TYPE))
+            if frame_type not in cls.SUPPORTED_FRAME_TYPES:
                 return False
-            if parsed["frame_type"] in ("cumulative", "expanding") and parsed["agg_type"] not in _CUMULATIVE_OPS:
-                return False
-            if parsed["frame_type"] == "time" and parsed["frame_unit"] not in _TIME_UNITS:
-                return False
-            if parsed["frame_type"] not in cls.SUPPORTED_FRAME_TYPES:
-                return False
-            if parsed["frame_type"] == "time" and parsed["frame_unit"] not in cls.SUPPORTED_TIME_UNITS:
-                return False
-        else:
-            agg_type = options.get(cls.AGGREGATION_TYPE)
-            frame_type = options.get(cls.FRAME_TYPE)
-            if agg_type is None or frame_type is None:
-                return False
-            if str(agg_type) not in _AGGREGATION_TYPES:
-                return False
-            frame_type_str = str(frame_type)
-            if frame_type_str not in cls.SUPPORTED_FRAME_TYPES:
-                return False
-            if frame_type_str in ("cumulative", "expanding") and str(agg_type) not in _CUMULATIVE_OPS:
-                return False
-            if frame_type_str == "time":
-                frame_unit = options.get(cls.FRAME_UNIT)
-                if frame_unit is None or str(frame_unit) not in _TIME_UNITS:
-                    return False
-                if str(frame_unit) not in cls.SUPPORTED_TIME_UNITS:
-                    return False
-            # Config features must carry a source column; name-based features encode it in the name.
-            if not options.get(DefaultOptionKeys.in_features):
+            if frame_type == "time" and str(options.get(cls.FRAME_UNIT)) not in cls.SUPPORTED_TIME_UNITS:
                 return False
 
         partition_by = options.get(cls.PARTITION_BY)

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -348,6 +348,45 @@ class TestConfigBasedFrameSizeValidation:
         assert result is True, f"Config path should accept {frame_type} without frame_size"
 
 
+class TestNameBasedZeroFrameSizeRejected:
+    """A zero-sized frame is not a window, so the name path must reject it exactly as the config path does."""
+
+    def _options(self) -> Options:
+        return Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            "sales__sum_rolling_0",
+            "sales__avg_0_day_window",
+            "sales__sum_rolling_00",
+            "sales__avg_0_hour_window",
+        ],
+    )
+    def test_rejects_zero_frame_size(self, feature_name: str) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(feature_name, self._options(), None)
+        assert result is False, f"Name path should reject zero-sized frame: {feature_name}"
+
+    @pytest.mark.parametrize("feature_name", ["sales__sum_rolling_0", "sales__avg_0_day_window"])
+    def test_parse_returns_none_for_zero_frame_size(self, feature_name: str) -> None:
+        assert FrameAggregateFeatureGroup._parse_frame_feature(feature_name) is None
+
+    @pytest.mark.parametrize(
+        "feature_name",
+        ["sales__sum_rolling_3", "sales__avg_7_day_window", "sales__sum_rolling_10"],
+    )
+    def test_positive_frame_size_still_matches(self, feature_name: str) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(feature_name, self._options(), None)
+        assert result is True, f"Name path should accept: {feature_name}"
+
+    @pytest.mark.parametrize(
+        "feature_name",
+        ["sales__sum_rolling_3", "sales__avg_7_day_window", "sales__sum_rolling_10"],
+    )
+    def test_positive_frame_size_still_parses(self, feature_name: str) -> None:
+        assert FrameAggregateFeatureGroup._parse_frame_feature(feature_name) is not None
+
+
 class TestNameBasedUnaffectedByConfigValidation:
     """Name-based features carry their frame parameters in the name.
 
@@ -368,6 +407,167 @@ class TestNameBasedUnaffectedByConfigValidation:
         options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
         result = FrameAggregateFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Name path should accept: {feature_name}"
+
+
+class TestNameBasedFrameTypeInOptions:
+    """A frame name already encodes its size, so a frame_type carried in Options must not demand frame_size."""
+
+    def test_rolling_name_with_frame_type_option(self) -> None:
+        options = Options(context={"frame_type": "rolling", "partition_by": ["region"], "order_by": "timestamp"})
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
+        assert result is True
+
+    def test_time_window_name_with_frame_type_option(self) -> None:
+        options = Options(context={"frame_type": "time", "partition_by": ["region"], "order_by": "timestamp"})
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__avg_7_day_window", options, None)
+        assert result is True
+
+    def test_rolling_name_with_propagated_frame_type(self) -> None:
+        """A propagated frame_type must behave like a directly set one."""
+        consumer = Options(context={"frame_type": "rolling"}, propagate_context_keys=frozenset({"frame_type"}))
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        options.inherit_from(consumer)
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
+        assert result is True
+
+
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one token, so it must reach dispatch unwrapped."""
+
+    def _options(self, **overrides: Any) -> Options:
+        context: dict[str, Any] = {
+            "aggregation_type": "sum",
+            "frame_type": "rolling",
+            "frame_size": 3,
+            "in_features": "sales",
+            "partition_by": ["region"],
+            "order_by": "timestamp",
+        }
+        context.update(overrides)
+        return Options(context=context)
+
+    @pytest.mark.parametrize("aggregation_type", [("sum",), ["sum"]])
+    def test_single_element_aggregation_type(self, aggregation_type: Any) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(aggregation_type=aggregation_type), None
+        )
+        assert result is True, f"Config path should accept: {aggregation_type!r}"
+        feature = Feature("my_result", options=self._options(aggregation_type=aggregation_type))
+        assert FrameAggregateFeatureGroup._extract_params(feature)["agg_type"] == "sum"
+
+    @pytest.mark.parametrize("frame_type", [("rolling",), ["rolling"]])
+    def test_single_element_frame_type(self, frame_type: Any) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(frame_type=frame_type), None
+        )
+        assert result is True, f"Config path should accept: {frame_type!r}"
+        feature = Feature("my_result", options=self._options(frame_type=frame_type))
+        assert FrameAggregateFeatureGroup._extract_params(feature)["frame_type"] == "rolling"
+
+    @pytest.mark.parametrize("frame_unit", [("day",), ["day"]])
+    def test_single_element_frame_unit(self, frame_unit: Any) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(frame_type="time", frame_size=7, frame_unit=frame_unit), None
+        )
+        assert result is True, f"Config path should accept: {frame_unit!r}"
+        feature = Feature("my_result", options=self._options(frame_type="time", frame_size=7, frame_unit=frame_unit))
+        assert FrameAggregateFeatureGroup._extract_params(feature)["frame_unit"] == "day"
+
+    @pytest.mark.parametrize("aggregation_type", [["sum", "max"], ("sum", "max")])
+    def test_multi_element_aggregation_type_rejected(self, aggregation_type: Any) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(aggregation_type=aggregation_type), None
+        )
+        assert result is False, f"Config path should reject: {aggregation_type!r}"
+
+
+class TestHostileInFeatures:
+    """A hostile in_features value is a plain non-match; no exception may escape the matcher."""
+
+    @pytest.mark.parametrize("in_features", ["", 0, 3.5, True, {"a": 1}, []])
+    def test_rejects_hostile_in_features(self, in_features: Any) -> None:
+        options = Options(
+            context={
+                "aggregation_type": "sum",
+                "frame_type": "rolling",
+                "frame_size": 3,
+                "in_features": in_features,
+                "partition_by": ["region"],
+                "order_by": "timestamp",
+            }
+        )
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False, f"Config path should reject in_features: {in_features!r}"
+
+
+class TestForwardedNameMismatch:
+    """A forwarded aggregation_type that contradicts the name must raise, never be silently overridden."""
+
+    def test_forwarded_aggregation_type_mismatch_raises(self) -> None:
+        consumer = Options(group={"aggregation_type": "max"})
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        options.inherit_from(consumer)
+        with pytest.raises(ValueError):
+            FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
+
+
+#: Each frame name shape, its configuration equivalent, and the same shape with a malformed agg token.
+_FRAME_SHAPE_PAIRS: list[tuple[str, dict[str, Any], str]] = [
+    (
+        "sales__sum_rolling_3",
+        {"aggregation_type": "sum", "frame_type": "rolling", "frame_size": 3},
+        "sales__banana_rolling_3",
+    ),
+    (
+        "sales__avg_7_day_window",
+        {"aggregation_type": "avg", "frame_type": "time", "frame_size": 7, "frame_unit": "day"},
+        "sales__banana_7_day_window",
+    ),
+    (
+        "sales__cumsum",
+        {"aggregation_type": "sum", "frame_type": "cumulative"},
+        "sales__cumbanana",
+    ),
+    (
+        "sales__expanding_avg",
+        {"aggregation_type": "avg", "frame_type": "expanding"},
+        "sales__expanding_banana",
+    ),
+]
+
+
+class TestFrameShapeParity:
+    """All four name shapes, not only rolling, must agree with their config equivalent on both verdicts."""
+
+    def _pattern_options(self) -> Options:
+        return Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+
+    def _config_options(self, config: dict[str, Any]) -> Options:
+        context: dict[str, Any] = {"in_features": "sales", "partition_by": ["region"], "order_by": "timestamp"}
+        context.update(config)
+        return Options(context=context)
+
+    @pytest.mark.parametrize(("feature_name", "config", "malformed_name"), _FRAME_SHAPE_PAIRS)
+    def test_shape_matches_on_both_paths(self, feature_name: str, config: dict[str, Any], malformed_name: str) -> None:
+        by_name = FrameAggregateFeatureGroup.match_feature_group_criteria(feature_name, self._pattern_options(), None)
+        assert by_name is True, f"Name path should accept: {feature_name}"
+        by_config = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._config_options(config), None
+        )
+        assert by_config is True, f"Config path should accept: {config}"
+
+    @pytest.mark.parametrize(("feature_name", "config", "malformed_name"), _FRAME_SHAPE_PAIRS)
+    def test_malformed_shape_rejected_on_both_paths(
+        self, feature_name: str, config: dict[str, Any], malformed_name: str
+    ) -> None:
+        by_name = FrameAggregateFeatureGroup.match_feature_group_criteria(malformed_name, self._pattern_options(), None)
+        assert by_name is False, f"Name path should reject: {malformed_name}"
+        malformed_config = dict(config)
+        malformed_config["aggregation_type"] = "banana"
+        by_config = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._config_options(malformed_config), None
+        )
+        assert by_config is False, f"Config path should reject: {malformed_config}"
 
 
 class TestExtractParams:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
@@ -273,6 +274,102 @@ class TestConfigBasedMatching:
         assert result is True
 
 
+class TestConfigBasedFrameUnitValidation:
+    """The config path must honour the declared frame_unit value space."""
+
+    def _options(self, **overrides: Any) -> Options:
+        context: dict[str, Any] = {
+            "aggregation_type": "sum",
+            "in_features": "sales",
+            "partition_by": ["region"],
+            "order_by": "timestamp",
+        }
+        context.update(overrides)
+        return Options(context=context)
+
+    def test_rejects_invalid_frame_unit(self) -> None:
+        options = self._options(frame_type="time", frame_size=7, frame_unit="banana")
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False
+
+    def test_rejects_missing_frame_unit(self) -> None:
+        options = self._options(frame_type="time", frame_size=7)
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False
+
+    def test_accepts_declared_frame_unit(self) -> None:
+        options = self._options(frame_type="time", frame_size=7, frame_unit="day")
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is True
+
+
+class TestConfigBasedFrameSizeValidation:
+    """The config path must honour the declared frame_size value space.
+
+    frame_size is a positive integer count; bools and numeric strings are not
+    integers for this purpose and must be non-matches at discovery.
+    """
+
+    def _options(self, **overrides: Any) -> Options:
+        context: dict[str, Any] = {
+            "aggregation_type": "sum",
+            "in_features": "sales",
+            "partition_by": ["region"],
+            "order_by": "timestamp",
+        }
+        context.update(overrides)
+        return Options(context=context)
+
+    @pytest.mark.parametrize("frame_size", [0, -1, True, "3"])
+    def test_rejects_invalid_frame_size(self, frame_size: Any) -> None:
+        options = self._options(frame_type="rolling", frame_size=frame_size)
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False, f"Config path should reject frame_size: {frame_size!r}"
+
+    def test_accepts_positive_frame_size(self) -> None:
+        options = self._options(frame_type="rolling", frame_size=3)
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is True
+
+    def test_rejects_missing_frame_size_for_rolling(self) -> None:
+        options = self._options(frame_type="rolling")
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False
+
+    def test_rejects_missing_frame_size_for_time(self) -> None:
+        options = self._options(frame_type="time", frame_unit="day")
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False
+
+    @pytest.mark.parametrize("frame_type", ["cumulative", "expanding"])
+    def test_accepts_missing_frame_size_for_unsized_frames(self, frame_type: str) -> None:
+        options = self._options(frame_type=frame_type)
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is True, f"Config path should accept {frame_type} without frame_size"
+
+
+class TestNameBasedUnaffectedByConfigValidation:
+    """Name-based features carry their frame parameters in the name.
+
+    Tightening the config path must not start demanding in_features or frame_size
+    from a feature that encodes them in its name.
+    """
+
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            "sales__sum_rolling_3",
+            "sales__avg_7_day_window",
+            "sales__cumsum",
+            "sales__expanding_avg",
+        ],
+    )
+    def test_name_based_matches_with_partition_and_order_only(self, feature_name: str) -> None:
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(feature_name, options, None)
+        assert result is True, f"Name path should accept: {feature_name}"
+
+
 class TestExtractParams:
     """Tests for _extract_params."""
 
@@ -369,3 +466,12 @@ class TestFrameAggregateMatchValidation(MatchValidationTestBase):
     @classmethod
     def pattern_match_options(cls) -> Options:
         return Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+
+    @classmethod
+    def parity_operations(cls) -> set[str]:
+        # No parametric family here: the fixed aggregation types are the whole value space.
+        return set(_AGGREGATION_TYPES)
+
+    @classmethod
+    def malformed_operations(cls) -> set[str]:
+        return {"banana", "mode", "nunique", "first"}

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -14,6 +14,30 @@ from mloda.provider import DefaultOptionKeys, FeatureGroup
 from mloda.community.feature_groups.data_operations.base import is_op_token
 
 
+_OFFSET_TYPES = {
+    "first_value": "First value in partition",
+    "last_value": "Last value in partition",
+}
+
+#: Parametric offset families; each accepts a positive integer suffix (e.g. ``lag_3``).
+_PARAMETRIC_OFFSET_FAMILIES: tuple[str, ...] = ("lag", "lead", "diff", "pct_change")
+
+
+def _is_supported_offset_type(value: object) -> bool:
+    """Fixed offset types plus parametric lag_N / lead_N / diff_N / pct_change_N with N >= 1."""
+    if not isinstance(value, str):
+        return False
+    if value in _OFFSET_TYPES:
+        return True
+    for family in _PARAMETRIC_OFFSET_FAMILIES:
+        prefix = f"{family}_"
+        if value.startswith(prefix):
+            suffix = value[len(prefix) :]
+            if suffix.isdigit() and int(suffix) >= 1:
+                return True
+    return False
+
+
 class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """Base class for offset operations that preserve row count.
 
@@ -88,20 +112,17 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
 
-    OFFSET_TYPES = {
-        "first_value": "First value in partition",
-        "last_value": "Last value in partition",
-    }
+    OFFSET_TYPES = _OFFSET_TYPES
 
-    #: Parametric offset families; each accepts a positive integer suffix (e.g. ``lag_3``).
-    PARAMETRIC_OFFSET_FAMILIES: tuple[str, ...] = ("lag", "lead", "diff", "pct_change")
+    PARAMETRIC_OFFSET_FAMILIES: tuple[str, ...] = _PARAMETRIC_OFFSET_FAMILIES
 
     PROPERTY_MAPPING = {
         OFFSET_TYPE: {
             "explanation": "Offset type applied within each partition",
             DefaultOptionKeys.allowed_values: OFFSET_TYPES,
             DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.element_validator: _is_supported_offset_type,
             DefaultOptionKeys.match_guard: is_op_token,
         },
         DefaultOptionKeys.in_features: {
@@ -124,15 +145,8 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def _supports_offset_type(cls, offset_type: str) -> bool:
         """Check if the given offset type is supported."""
-        if offset_type in cls.OFFSET_TYPES:
-            return True
-        for family in cls.PARAMETRIC_OFFSET_FAMILIES:
-            prefix = f"{family}_"
-            if offset_type.startswith(prefix):
-                suffix = offset_type[len(prefix) :]
-                if suffix.isdigit() and int(suffix) >= 1:
-                    return True
-        return False
+        # Per-backend narrowing lives in SubtypeCapabilityHook, not here.
+        return _is_supported_offset_type(offset_type)
 
     @classmethod
     def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -11,7 +11,12 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import (
+    is_in_features_value,
+    is_op_token,
+    is_parametric_suffix,
+    op_token_value,
+)
 
 
 _OFFSET_TYPES = {
@@ -32,8 +37,7 @@ def _is_supported_offset_type(value: object) -> bool:
     for family in _PARAMETRIC_OFFSET_FAMILIES:
         prefix = f"{family}_"
         if value.startswith(prefix):
-            suffix = value[len(prefix) :]
-            if suffix.isdigit() and int(suffix) >= 1:
+            if is_parametric_suffix(value[len(prefix) :]):
                 return True
     return False
 
@@ -112,6 +116,8 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
 
+    # Aliases of the module tables the validator reads: overriding them in a subclass has no
+    # effect, per-backend narrowing belongs in SubtypeCapabilityHook.
     OFFSET_TYPES = _OFFSET_TYPES
 
     PARAMETRIC_OFFSET_FAMILIES: tuple[str, ...] = _PARAMETRIC_OFFSET_FAMILIES
@@ -129,6 +135,7 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Source feature for offset operation",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_in_features_value,
         },
         PARTITION_BY: {
             "explanation": "List of columns to partition by",
@@ -204,16 +211,14 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         offset_type = feature.options.get(cls.OFFSET_TYPE)
         if offset_type is None:
             raise ValueError(f"Could not extract offset type for {feature_name}")
-        return str(offset_type)
+        return op_token_value(offset_type)
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:
         """Declare DOUBLE for pct_change_N (a ratio); other offsets stay open."""
         offset_type = cls._extract_offset_type(feature)
-        if offset_type.startswith("pct_change_"):
-            suffix = offset_type[len("pct_change_") :]
-            if suffix.isdigit() and int(suffix) >= 1:
-                return DataType.DOUBLE
+        if offset_type.startswith("pct_change_") and is_parametric_suffix(offset_type[len("pct_change_") :]):
+            return DataType.DOUBLE
         return None
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -175,6 +175,37 @@ class TestConfigBasedFeatures:
         assert result.num_rows == 12
 
 
+class TestConfigBasedOffsetTypeValidation:
+    """The config path must reject exactly the offset types the feature-name path rejects.
+
+    Matching may not defer offset-type validation to compute time: an unsupported
+    offset_type has to be a non-match at discovery.
+    """
+
+    def _options(self, offset_type: Any) -> Options:
+        return Options(
+            context={
+                "offset_type": offset_type,
+                "in_features": "value_int",
+                "partition_by": ["region"],
+                "order_by": "value_int",
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "offset_type",
+        ["lag_1", "lead_2", "diff_1", "pct_change_3", "first_value", "last_value"],
+    )
+    def test_config_based_match_accepts_supported_offset_types(self, offset_type: str) -> None:
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(offset_type), None)
+        assert result is True, f"Config path should accept: {offset_type}"
+
+    @pytest.mark.parametrize("offset_type", ["banana", "lag_0", "lag_-1", "lag_abc", "lead_", ""])
+    def test_config_based_match_rejects_unsupported_offset_types(self, offset_type: str) -> None:
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(offset_type), None)
+        assert result is False, f"Config path should reject: {offset_type!r}"
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.
 
@@ -228,5 +259,17 @@ class TestOffsetMatchValidation(MatchValidationTestBase):
         return {"in_features": "value_int", "partition_by": ["region"], "order_by": "timestamp"}
 
     @classmethod
+    def pattern_match_options(cls) -> Options:
+        return Options(context={"partition_by": ["region"], "order_by": "value_int"})
+
+    @classmethod
     def options_reject_invalid_types(cls) -> bool:
-        return False
+        return True
+
+    @classmethod
+    def parity_operations(cls) -> set[str]:
+        return {"first_value", "last_value", "lag_1", "lead_2", "diff_1", "pct_change_3"}
+
+    @classmethod
+    def malformed_operations(cls) -> set[str]:
+        return {"banana", "lag_0", "lag_abc", "lead_"}

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -206,6 +206,91 @@ class TestConfigBasedOffsetTypeValidation:
         assert result is False, f"Config path should reject: {offset_type!r}"
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one offset token, so it must reach dispatch unwrapped."""
+
+    def _options(self, offset_type: Any) -> Options:
+        return Options(
+            context={
+                "offset_type": offset_type,
+                "in_features": "value_int",
+                "partition_by": ["region"],
+                "order_by": "value_int",
+            }
+        )
+
+    @pytest.mark.parametrize("offset_type", [("lag_1",), ["lag_1"]])
+    def test_single_element_offset_type(self, offset_type: Any) -> None:
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(offset_type), None)
+        assert result is True, f"Config path should accept: {offset_type!r}"
+        feature = Feature("my_result", options=self._options(offset_type))
+        assert OffsetFeatureGroup._extract_offset_type(feature) == "lag_1"
+
+    @pytest.mark.parametrize("offset_type", [["lag_1", "lead_2"], ("lag_1", "lead_2")])
+    def test_multi_element_offset_type_rejected(self, offset_type: Any) -> None:
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(offset_type), None)
+        assert result is False, f"Config path should reject: {offset_type!r}"
+
+
+class TestDigitLikeOffsetSuffixes:
+    """A suffix that str.isdigit accepts is not automatically an int; both paths must reject it without raising."""
+
+    def _pattern_options(self) -> Options:
+        return Options(context={"partition_by": ["region"], "order_by": "value_int"})
+
+    def _config_options(self, offset_type: str) -> Options:
+        return Options(
+            context={
+                "offset_type": offset_type,
+                "in_features": "value_int",
+                "partition_by": ["region"],
+                "order_by": "value_int",
+            }
+        )
+
+    @pytest.mark.parametrize("feature_name", ["value_int__lag_²_offset", "value_int__pct_change_²_offset"])
+    def test_name_path_rejects_superscript_digit(self, feature_name: str) -> None:
+        """Superscript two is isdigit-true but int()-invalid."""
+        result = OffsetFeatureGroup.match_feature_group_criteria(feature_name, self._pattern_options(), None)
+        assert result is False, f"Name path should reject: {feature_name}"
+
+    @pytest.mark.parametrize("offset_type", ["lag_²", "pct_change_²"])
+    def test_config_path_rejects_superscript_digit(self, offset_type: str) -> None:
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._config_options(offset_type), None)
+        assert result is False, f"Config path should reject: {offset_type}"
+
+    def test_name_path_rejects_non_ascii_digit(self) -> None:
+        """Arabic-Indic three is isdigit-true and int()-valid, but still not an ASCII offset suffix."""
+        options = self._pattern_options()
+        result = OffsetFeatureGroup.match_feature_group_criteria("value_int__lag_٣_offset", options, None)
+        assert result is False
+
+    def test_config_path_rejects_non_ascii_digit(self) -> None:
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._config_options("lag_٣"), None)
+        assert result is False
+
+    @pytest.mark.parametrize("offset_type", ["lag_²", "pct_change_²", "lag_٣"])
+    def test_supports_offset_type_rejects_digit_like_suffixes(self, offset_type: str) -> None:
+        assert not OffsetFeatureGroup._supports_offset_type(offset_type)
+
+
+class TestHostileInFeatures:
+    """A hostile in_features value is a plain non-match; no exception may escape the matcher."""
+
+    @pytest.mark.parametrize("in_features", ["", 0, 3.5, True, {"a": 1}, []])
+    def test_rejects_hostile_in_features(self, in_features: Any) -> None:
+        options = Options(
+            context={
+                "offset_type": "lag_1",
+                "in_features": in_features,
+                "partition_by": ["region"],
+                "order_by": "value_int",
+            }
+        )
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False, f"Config path should reject in_features: {in_features!r}"
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -16,6 +16,32 @@ from mloda.community.feature_groups.data_operations.capability_hook import Subty
 from mloda.community.feature_groups.data_operations.base import is_op_token
 
 
+_RANK_TYPES = {
+    "row_number": "Sequential position, no ties",
+    "rank": "Standard rank with gaps for ties",
+    "dense_rank": "Rank without gaps for ties",
+    "percent_rank": "Relative rank as fraction (0.0 to 1.0)",
+}
+
+#: Parametric rank families; each accepts a positive integer suffix (e.g. ``ntile_4``).
+_PARAMETRIC_RANK_FAMILIES: tuple[str, ...] = ("ntile", "top", "bottom")
+
+
+def _is_supported_rank_type(value: object) -> bool:
+    """Fixed rank types plus parametric ntile_N / top_N / bottom_N with N >= 1."""
+    if not isinstance(value, str):
+        return False
+    if value in _RANK_TYPES:
+        return True
+    for family in _PARAMETRIC_RANK_FAMILIES:
+        prefix = f"{family}_"
+        if value.startswith(prefix):
+            suffix = value[len(prefix) :]
+            if suffix.isdigit() and int(suffix) >= 1:
+                return True
+    return False
+
+
 class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGroup):
     """Base class for rank operations that preserve row count.
 
@@ -102,15 +128,9 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
 
-    RANK_TYPES = {
-        "row_number": "Sequential position, no ties",
-        "rank": "Standard rank with gaps for ties",
-        "dense_rank": "Rank without gaps for ties",
-        "percent_rank": "Relative rank as fraction (0.0 to 1.0)",
-    }
+    RANK_TYPES = _RANK_TYPES
 
-    #: Parametric rank families; each accepts a positive integer suffix (e.g. ``ntile_4``).
-    PARAMETRIC_RANK_FAMILIES: tuple[str, ...] = ("ntile", "top", "bottom")
+    PARAMETRIC_RANK_FAMILIES: tuple[str, ...] = _PARAMETRIC_RANK_FAMILIES
 
     PROPERTY_MAPPING = {
         RANK_TYPE: {
@@ -118,6 +138,7 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
             DefaultOptionKeys.allowed_values: RANK_TYPES,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.element_validator: _is_supported_rank_type,
             DefaultOptionKeys.match_guard: is_op_token,
         },
         DefaultOptionKeys.in_features: {
@@ -140,15 +161,8 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
     @classmethod
     def _supports_rank_type(cls, rank_type: str) -> bool:
         """Check if the given rank type is supported, including ntile_N, top_N, and bottom_N."""
-        if rank_type in cls.RANK_TYPES:
-            return True
-        for family in cls.PARAMETRIC_RANK_FAMILIES:
-            prefix = f"{family}_"
-            if rank_type.startswith(prefix):
-                suffix = rank_type[len(prefix) :]
-                if suffix.isdigit() and int(suffix) >= 1:
-                    return True
-        return False
+        # Per-backend narrowing lives in SubtypeCapabilityHook, not here.
+        return _is_supported_rank_type(rank_type)
 
     @classmethod
     def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -13,7 +13,12 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import (
+    is_in_features_value,
+    is_op_token,
+    is_parametric_suffix,
+    op_token_value,
+)
 
 
 _RANK_TYPES = {
@@ -36,8 +41,7 @@ def _is_supported_rank_type(value: object) -> bool:
     for family in _PARAMETRIC_RANK_FAMILIES:
         prefix = f"{family}_"
         if value.startswith(prefix):
-            suffix = value[len(prefix) :]
-            if suffix.isdigit() and int(suffix) >= 1:
+            if is_parametric_suffix(value[len(prefix) :]):
                 return True
     return False
 
@@ -128,6 +132,8 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
 
+    # Aliases of the module tables the validator reads: overriding them in a subclass has no
+    # effect, per-backend narrowing belongs in SubtypeCapabilityHook.
     RANK_TYPES = _RANK_TYPES
 
     PARAMETRIC_RANK_FAMILIES: tuple[str, ...] = _PARAMETRIC_RANK_FAMILIES
@@ -145,6 +151,7 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
             "explanation": "Source feature for rank ordering",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_in_features_value,
         },
         PARTITION_BY: {
             "explanation": "List of columns to partition by",
@@ -224,7 +231,7 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
         rank_type = feature.options.get(cls.RANK_TYPE)
         if rank_type is None:
             raise ValueError(f"Could not extract rank type for {feature_name}")
-        return str(rank_type)
+        return op_token_value(rank_type)
 
     @classmethod
     def _resolve_rank_type(cls, feature_name: str, options: Options) -> str | None:
@@ -236,7 +243,7 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
         if operation_config is not None:
             return operation_config
         rank_type = options.get(cls.RANK_TYPE)
-        return None if rank_type is None else str(rank_type)
+        return None if rank_type is None else op_token_value(rank_type)
 
     @classmethod
     def _capability_subtype(cls, feature_name: str, options: Options) -> str | None:
@@ -260,10 +267,8 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
             return DataType.INT64
         if rank_type == "percent_rank":
             return DataType.DOUBLE
-        if rank_type.startswith("ntile_"):
-            suffix = rank_type[len("ntile_") :]
-            if suffix.isdigit() and int(suffix) >= 1:
-                return DataType.INT64
+        if rank_type.startswith("ntile_") and is_parametric_suffix(rank_type[len("ntile_") :]):
+            return DataType.INT64
         return None
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -316,6 +316,91 @@ class TestConfigBasedParametricRankTypes:
         assert result is False, f"Config path should reject: {rank_type!r}"
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one rank token, so it must reach dispatch unwrapped."""
+
+    def _options(self, rank_type: Any) -> Options:
+        return Options(
+            context={
+                "rank_type": rank_type,
+                "in_features": "value_int",
+                "partition_by": ["region"],
+                "order_by": "value_int",
+            }
+        )
+
+    @pytest.mark.parametrize("rank_type", [("ntile_4",), ["ntile_4"]])
+    def test_single_element_rank_type(self, rank_type: Any) -> None:
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(rank_type), None)
+        assert result is True, f"Config path should accept: {rank_type!r}"
+        feature = Feature("my_result", options=self._options(rank_type))
+        assert RankFeatureGroup._extract_rank_type(feature) == "ntile_4"
+
+    @pytest.mark.parametrize("rank_type", [["ntile_4", "top_5"], ("ntile_4", "top_5")])
+    def test_multi_element_rank_type_rejected(self, rank_type: Any) -> None:
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(rank_type), None)
+        assert result is False, f"Config path should reject: {rank_type!r}"
+
+
+class TestDigitLikeRankSuffixes:
+    """A suffix that str.isdigit accepts is not automatically an int; both paths must reject it without raising."""
+
+    def _pattern_options(self) -> Options:
+        return Options(context={"partition_by": ["region"], "order_by": "value_int"})
+
+    def _config_options(self, rank_type: str) -> Options:
+        return Options(
+            context={
+                "rank_type": rank_type,
+                "in_features": "value_int",
+                "partition_by": ["region"],
+                "order_by": "value_int",
+            }
+        )
+
+    @pytest.mark.parametrize("feature_name", ["value_int__ntile_²_ranked", "value_int__top_²_ranked"])
+    def test_name_path_rejects_superscript_digit(self, feature_name: str) -> None:
+        """Superscript two is isdigit-true but int()-invalid."""
+        result = RankFeatureGroup.match_feature_group_criteria(feature_name, self._pattern_options(), None)
+        assert result is False, f"Name path should reject: {feature_name}"
+
+    @pytest.mark.parametrize("rank_type", ["ntile_²", "top_²"])
+    def test_config_path_rejects_superscript_digit(self, rank_type: str) -> None:
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._config_options(rank_type), None)
+        assert result is False, f"Config path should reject: {rank_type}"
+
+    def test_name_path_rejects_non_ascii_digit(self) -> None:
+        """Arabic-Indic three is isdigit-true and int()-valid, but still not an ASCII rank suffix."""
+        options = self._pattern_options()
+        result = RankFeatureGroup.match_feature_group_criteria("value_int__ntile_٣_ranked", options, None)
+        assert result is False
+
+    def test_config_path_rejects_non_ascii_digit(self) -> None:
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._config_options("ntile_٣"), None)
+        assert result is False
+
+    @pytest.mark.parametrize("rank_type", ["ntile_²", "top_²", "ntile_٣"])
+    def test_supports_rank_type_rejects_digit_like_suffixes(self, rank_type: str) -> None:
+        assert not RankFeatureGroup._supports_rank_type(rank_type)
+
+
+class TestHostileInFeatures:
+    """A hostile in_features value is a plain non-match; no exception may escape the matcher."""
+
+    @pytest.mark.parametrize("in_features", ["", 0, 3.5, True, {"a": 1}, []])
+    def test_rejects_hostile_in_features(self, in_features: Any) -> None:
+        options = Options(
+            context={
+                "rank_type": "row_number",
+                "in_features": in_features,
+                "partition_by": ["region"],
+                "order_by": "value_int",
+            }
+        )
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False, f"Config path should reject in_features: {in_features!r}"
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type for deterministic rank ops.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -279,6 +279,43 @@ class TestConfigBasedFeatures:
         assert result.num_rows == 12
 
 
+class TestConfigBasedParametricRankTypes:
+    """The config path must accept exactly the rank types the feature-name path accepts.
+
+    ``ntile_N`` / ``top_N`` / ``bottom_N`` are supported through the name path, so the
+    ``rank_type`` declaration must admit them on the config path as well.
+    """
+
+    def _options(self, rank_type: Any) -> Options:
+        return Options(
+            context={
+                "rank_type": rank_type,
+                "in_features": "value_int",
+                "partition_by": ["region"],
+                "order_by": "value_int",
+            }
+        )
+
+    @pytest.mark.parametrize("rank_type", ["ntile_4", "top_5", "bottom_3"])
+    def test_config_based_match_accepts_parametric_rank_types(self, rank_type: str) -> None:
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(rank_type), None)
+        assert result is True, f"Config path should accept: {rank_type}"
+
+    @pytest.mark.parametrize(
+        "rank_type",
+        ["ntile_0", "top_0", "bottom_0", "ntile_-1", "ntile_abc", "lag_1", "banana"],
+    )
+    def test_config_based_match_rejects_invalid_rank_types(self, rank_type: str) -> None:
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(rank_type), None)
+        assert result is False, f"Config path should reject: {rank_type}"
+
+    @pytest.mark.parametrize("rank_type", [42, {"rank_type": "row_number"}])
+    def test_config_based_match_rejects_non_string_rank_type(self, rank_type: Any) -> None:
+        """A non-string rank_type is a plain non-match, never an uncaught exception."""
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(rank_type), None)
+        assert result is False, f"Config path should reject: {rank_type!r}"
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type for deterministic rank ops.
 
@@ -335,3 +372,15 @@ class TestRankMatchValidation(MatchValidationTestBase):
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
         return {"in_features": "value_int", "partition_by": ["region"], "order_by": "value_int"}
+
+    @classmethod
+    def pattern_match_options(cls) -> Options:
+        return Options(context={"partition_by": ["region"], "order_by": "value_int"})
+
+    @classmethod
+    def parity_operations(cls) -> set[str]:
+        return {"row_number", "percent_rank", "ntile_4", "top_5", "bottom_3"}
+
+    @classmethod
+    def malformed_operations(cls) -> set[str]:
+        return {"ntile_0", "ntile_abc", "top_0", "bottom_0", "banana"}

--- a/mloda/community/feature_groups/data_operations/tests/test_prefix_pattern_collisions.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_prefix_pattern_collisions.py
@@ -72,10 +72,10 @@ class FamilySpec:
     module: str
     class_name: str
     representative_names: tuple[str, ...]
-    # ``frame_aggregate``'s PREFIX_PATTERN is a rolling-only placeholder; its real
-    # matching uses four module-level compiled patterns. When ``pattern_module_attrs``
-    # is set these module attributes are collected, and ``ignore_prefix_pattern``
-    # drops the misleading placeholder.
+    # ``frame_aggregate``'s PREFIX_PATTERN is only the rolling member of its four
+    # module-level compiled patterns (the set ``_get_prefix_patterns()`` returns). When
+    # ``pattern_module_attrs`` is set these module attributes are collected, and
+    # ``ignore_prefix_pattern`` drops the duplicated rolling entry.
     pattern_module_attrs: tuple[str, ...] = ()
     ignore_prefix_pattern: bool = False
 

--- a/mloda/testing/feature_groups/data_operations/match_validation.py
+++ b/mloda/testing/feature_groups/data_operations/match_validation.py
@@ -7,6 +7,7 @@ Provides ``MatchValidationTestBase`` with reusable test methods covering:
 - Special characters in the operation portion of feature names
 - Type confusion via Options (None, int, list)
 - Case sensitivity enforcement (lowercase only)
+- Declaration/dispatch drift between the name path and the config path (opt-in)
 
 Concrete test classes implement abstract methods to adapt these tests
 to each specific operation.
@@ -86,6 +87,22 @@ class MatchValidationTestBase:
         False for operations with strict_validation=False on the config key.
         """
         return True
+
+    @classmethod
+    def parity_operations(cls) -> set[str]:
+        """Operations that both the name path and the config path must accept.
+
+        Empty by default; override to opt in to the drift check.
+        """
+        return set()
+
+    @classmethod
+    def malformed_operations(cls) -> set[str]:
+        """Operations that both the name path and the config path must reject.
+
+        Empty by default; override to opt in to the drift check.
+        """
+        return set()
 
     # -- No source column ------------------------------------------------------
 
@@ -199,3 +216,37 @@ class MatchValidationTestBase:
             feature_name = self.build_feature_name(mixed)
             result = self.feature_group_class().match_feature_group_criteria(feature_name, options, None)
             assert result is False, f"Should reject mixed case: {mixed}"
+
+    # -- Declaration / dispatch drift ----------------------------------------
+
+    def _match_by_name(self, operation: str) -> bool:
+        """Match verdict of the name-based path for the given operation."""
+        feature_name = self.build_feature_name(operation)
+        result = self.feature_group_class().match_feature_group_criteria(
+            feature_name, self.pattern_match_options(), None
+        )
+        return bool(result)
+
+    def _match_by_config(self, operation: str) -> bool:
+        """Match verdict of the configuration-based path for the given operation."""
+        context = {self.config_key(): operation, **self.additional_match_options()}
+        result = self.feature_group_class().match_feature_group_criteria("my_result", Options(context=context), None)
+        return bool(result)
+
+    def test_operations_match_on_both_paths(self) -> None:
+        """Operations accepted by one path must be accepted by the other."""
+        operations = self.parity_operations()
+        if not operations:
+            pytest.skip("no parity_operations declared for this operation")
+        for operation in sorted(operations):
+            assert self._match_by_name(operation) is True, f"Name path should accept: {operation!r}"
+            assert self._match_by_config(operation) is True, f"Config path should accept: {operation!r}"
+
+    def test_malformed_operations_rejected_on_both_paths(self) -> None:
+        """Operations rejected by one path must be rejected by the other."""
+        operations = self.malformed_operations()
+        if not operations:
+            pytest.skip("no malformed_operations declared for this operation")
+        for operation in sorted(operations):
+            assert self._match_by_name(operation) is False, f"Name path should reject: {operation!r}"
+            assert self._match_by_config(operation) is False, f"Config path should reject: {operation!r}"


### PR DESCRIPTION
Closes #326.

## What

Makes the `PROPERTY_MAPPING` declaration the authority for frame aggregation, rank and offset, so a supported operation is accepted the same way whether it arrives in a feature name or in `Options`.

**Frame aggregate** composed the base matcher instead of replacing it. Its four name shapes (rolling, time window, cumulative, expanding) became the class prefix patterns, the name path validates through `_validate_string_match`, and the override keeps only what a shared class-level declaration cannot express: the per-subclass `SUPPORTED_FRAME_TYPES` / `SUPPORTED_TIME_UNITS` narrowing and the `partition_by` / `order_by` shape checks. `aggregation_type` and `frame_type` dropped `default: None` so the config path really requires them, `frame_size` gained a positive-integer guard plus `required_when`, and `frame_unit` gained its declared value space plus `required_when`. A frame name carries its own size and unit, so those conditional requirements are exempted on the name path.

**Rank and offset** declare their parametric families through one predicate shared by both paths, so `ntile_N`, `top_N`, `bottom_N`, `lag_N`, `lead_N`, `diff_N` and `pct_change_N` now match identically from a name or from `Options`. `offset_type` became strict, which ends the acceptance of arbitrary strings such as `"banana"`.

Zero and negative suffixes, malformed parametric tokens and unsupported operations are now rejected while matching rather than at compute.

## Review findings folded in

Two independent deep reviews ran on the first commit; the second commit is their triage:

- zero-sized frames (`sales__sum_rolling_0`, `sales__avg_0_day_window`) matched on the name path and either crashed or silently computed a degenerate window; the size group is now `[1-9]\d*`, as binning already does
- a single-element container is legal syntax for one operation token, but the dispatch-side readers stringified it into `"('sum',)"`; `op_token_value` unwraps it for all three families and for the capability-hook resolvers
- `str.isdigit()` accepts superscripts that `int()` then rejects, so `value__ntile_²_ranked` raised out of the matcher and aborted resolution; it also accepts non-ASCII digits that reached compute. A parametric suffix is now an ASCII decimal
- hostile `in_features` values (`""`, `0`, `3.5`, `True`, a dict) raised from core's unguarded count check instead of failing to match; all three families guard that entry

## Tests

`MatchValidationTestBase` gained opt-in `parity_operations()` / `malformed_operations()` hooks that assert both creation paths agree, wired for the three families in scope. Frame adds a local parity test over all four of its name shapes, since the shared harness builds only the rolling one. Full `tox` gate green: 4442 passed, 168 skipped, plus ruff format, ruff check, strict mypy and bandit.