### PR TITLE
fix(data_operations): unwrap singleton operation tokens and turn on the parity check

### DIFF
--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
@@ -372,3 +372,7 @@ class TestAggregationMatchValidation(MatchValidationTestBase):
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
         return {"in_features": "value_int", "partition_by": ["region"]}
+
+    @classmethod
+    def pattern_match_options(cls) -> Options:
+        return Options(context={"partition_by": ["region"]})

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
@@ -300,6 +300,30 @@ class TestConfigBasedFeatures:
         assert result_map[None] == -10
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one aggregation token, so it must reach dispatch unwrapped."""
+
+    def _options(self, aggregation_type: Any) -> Options:
+        return Options(
+            context={
+                "aggregation_type": aggregation_type,
+                "in_features": "value_int",
+                "partition_by": ["region"],
+            }
+        )
+
+    @pytest.mark.parametrize("aggregation_type", ["sum", ("sum",), ["sum"]])
+    def test_single_element_aggregation_type(self, aggregation_type: Any) -> None:
+        """The bare token and its single-element container must dispatch identically."""
+        result = AggregationFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(aggregation_type), None
+        )
+        assert result is True, f"Config path should accept: {aggregation_type!r}"
+        feature = Feature("my_result", options=self._options(aggregation_type))
+        assert AggregationFeatureGroup._extract_aggregation_type(feature) == "sum"
+        assert AggregationFeatureGroup._resolve_agg_type("my_result", self._options(aggregation_type)) == "sum"
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.
 

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
@@ -323,6 +323,13 @@ class TestSingleTokenContainers:
         assert AggregationFeatureGroup._extract_aggregation_type(feature) == "sum"
         assert AggregationFeatureGroup._resolve_agg_type("my_result", self._options(aggregation_type)) == "sum"
 
+    @pytest.mark.parametrize("aggregation_type", [["sum", "max"], ("sum", "max")])
+    def test_multi_element_aggregation_type_rejected(self, aggregation_type: Any) -> None:
+        result = AggregationFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(aggregation_type), None
+        )
+        assert result is False, f"Config path should reject: {aggregation_type!r}"
+
 
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
@@ -300,37 +300,6 @@ class TestConfigBasedFeatures:
         assert result_map[None] == -10
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one aggregation token, so it must reach dispatch unwrapped."""
-
-    def _options(self, aggregation_type: Any) -> Options:
-        return Options(
-            context={
-                "aggregation_type": aggregation_type,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-            }
-        )
-
-    @pytest.mark.parametrize("aggregation_type", ["sum", ("sum",), ["sum"]])
-    def test_single_element_aggregation_type(self, aggregation_type: Any) -> None:
-        """The bare token and its single-element container must dispatch identically."""
-        result = AggregationFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(aggregation_type), None
-        )
-        assert result is True, f"Config path should accept: {aggregation_type!r}"
-        feature = Feature("my_result", options=self._options(aggregation_type))
-        assert AggregationFeatureGroup._extract_aggregation_type(feature) == "sum"
-        assert AggregationFeatureGroup._resolve_agg_type("my_result", self._options(aggregation_type)) == "sum"
-
-    @pytest.mark.parametrize("aggregation_type", [["sum", "max"], ("sum", "max")])
-    def test_multi_element_aggregation_type_rejected(self, aggregation_type: Any) -> None:
-        result = AggregationFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(aggregation_type), None
-        )
-        assert result is False, f"Config path should reject: {aggregation_type!r}"
-
-
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.
 
@@ -383,3 +352,11 @@ class TestAggregationMatchValidation(MatchValidationTestBase):
     @classmethod
     def pattern_match_options(cls) -> Options:
         return Options(context={"partition_by": ["region"]})
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        feature = Feature("my_result", options=options)
+        return [
+            AggregationFeatureGroup._extract_aggregation_type(feature),
+            AggregationFeatureGroup._resolve_agg_type("my_result", options),
+        ]

--- a/mloda/community/feature_groups/data_operations/aggregation_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation_base.py
@@ -24,6 +24,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import op_token_value
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 
 AGGREGATION_TYPES: dict[str, str] = {
@@ -83,7 +84,7 @@ class AggregationFeatureGroupBase(SubtypeCapabilityHook, FeatureChainParserMixin
         agg_type = feature.options.get(cls.AGGREGATION_TYPE)
         if agg_type is None:
             raise ValueError(f"Could not extract aggregation type for {feature_name}")
-        return str(agg_type)
+        return op_token_value(agg_type)
 
     @classmethod
     def _resolve_agg_type(cls, feature_name: str, options: Options) -> str | None:
@@ -95,7 +96,7 @@ class AggregationFeatureGroupBase(SubtypeCapabilityHook, FeatureChainParserMixin
         if operation_config is not None:
             return operation_config
         agg_type = options.get(cls.AGGREGATION_TYPE)
-        return None if agg_type is None else str(agg_type)
+        return None if agg_type is None else op_token_value(agg_type)
 
     @classmethod
     def _capability_subtype(cls, feature_name: str, options: Options) -> str | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/arithmetic/base.py
@@ -25,6 +25,8 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.provider import FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import op_token_value
+
 ARITHMETIC_OP_NAMES: frozenset[str] = frozenset({"add", "subtract", "multiply", "divide"})
 
 #: Shared SQL operator map; both SQL backends (DuckDB and SQLite) alias this same object.
@@ -60,7 +62,7 @@ class ArithmeticFeatureGroupBase(FeatureChainParserMixin, FeatureGroup):
         op = feature.options.get(cls.ARITHMETIC_OP)
         if op is None:
             raise ValueError(f"Could not extract arithmetic operation for {feature_name}")
-        return str(op)
+        return op_token_value(op)
 
     @classmethod
     def _raise_non_numeric_source(cls, source_col: str, got: object) -> None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -12,7 +12,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
-from mloda.community.feature_groups.data_operations.base import is_op_token, is_positive_int
+from mloda.community.feature_groups.data_operations.base import is_op_token, is_positive_int, op_token_value
 
 BINNING_OPS = {
     "bin": "Equal-width binning (value range divided into n equal intervals)",
@@ -84,7 +84,7 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             raise ValueError(f"Could not extract binning parameters for {feature_name}")
         n_bins = int(n)
         cls._validate_n_bins(n_bins, feature_name)
-        return str(op), n_bins
+        return op_token_value(op), n_bins
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -153,6 +153,27 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one binning token, so it must reach dispatch unwrapped."""
+
+    def _options(self, binning_op: Any) -> Options:
+        return Options(
+            context={
+                "binning_op": binning_op,
+                "n_bins": 5,
+                "in_features": "value_int",
+            }
+        )
+
+    @pytest.mark.parametrize("binning_op", ["bin", ("bin",), ["bin"]])
+    def test_single_element_binning_op(self, binning_op: Any) -> None:
+        """The bare token and its single-element container must dispatch identically."""
+        result = BinningFeatureGroup.match_feature_group_criteria("my_result", self._options(binning_op), None)
+        assert result is True, f"Config path should accept: {binning_op!r}"
+        feature = Feature("my_result", options=self._options(binning_op))
+        assert BinningFeatureGroup._extract_binning_params(feature) == ("bin", 5)
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type for deterministic ops.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -173,6 +173,11 @@ class TestSingleTokenContainers:
         feature = Feature("my_result", options=self._options(binning_op))
         assert BinningFeatureGroup._extract_binning_params(feature) == ("bin", 5)
 
+    @pytest.mark.parametrize("binning_op", [["bin", "qbin"], ("bin", "qbin")])
+    def test_multi_element_binning_op_rejected(self, binning_op: Any) -> None:
+        result = BinningFeatureGroup.match_feature_group_criteria("my_result", self._options(binning_op), None)
+        assert result is False, f"Config path should reject: {binning_op!r}"
+
 
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type for deterministic ops.

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -153,32 +153,6 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one binning token, so it must reach dispatch unwrapped."""
-
-    def _options(self, binning_op: Any) -> Options:
-        return Options(
-            context={
-                "binning_op": binning_op,
-                "n_bins": 5,
-                "in_features": "value_int",
-            }
-        )
-
-    @pytest.mark.parametrize("binning_op", ["bin", ("bin",), ["bin"]])
-    def test_single_element_binning_op(self, binning_op: Any) -> None:
-        """The bare token and its single-element container must dispatch identically."""
-        result = BinningFeatureGroup.match_feature_group_criteria("my_result", self._options(binning_op), None)
-        assert result is True, f"Config path should accept: {binning_op!r}"
-        feature = Feature("my_result", options=self._options(binning_op))
-        assert BinningFeatureGroup._extract_binning_params(feature) == ("bin", 5)
-
-    @pytest.mark.parametrize("binning_op", [["bin", "qbin"], ("bin", "qbin")])
-    def test_multi_element_binning_op_rejected(self, binning_op: Any) -> None:
-        result = BinningFeatureGroup.match_feature_group_criteria("my_result", self._options(binning_op), None)
-        assert result is False, f"Config path should reject: {binning_op!r}"
-
-
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type for deterministic ops.
 
@@ -218,3 +192,8 @@ class TestBinningMatchValidation(MatchValidationTestBase):
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
         return {"in_features": "value_int", "n_bins": 5}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        binning_op, _ = BinningFeatureGroup._extract_binning_params(Feature("my_result", options=options))
+        return [binning_op]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
@@ -12,7 +12,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import is_op_token, op_token_value
 
 DATETIME_OPS = {
     "year": "Extract year from datetime",
@@ -127,7 +127,7 @@ class DateTimeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         op = feature.options.get(cls.DATETIME_OP)
         if op is None:
             raise ValueError(f"Could not extract datetime operation for {feature_name}")
-        return str(op)
+        return op_token_value(op)
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
@@ -115,6 +115,26 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one datetime token, so it must reach dispatch unwrapped."""
+
+    def _options(self, datetime_op: Any) -> Options:
+        return Options(
+            context={
+                "datetime_op": datetime_op,
+                "in_features": "timestamp",
+            }
+        )
+
+    @pytest.mark.parametrize("datetime_op", ["year", ("year",), ["year"]])
+    def test_single_element_datetime_op(self, datetime_op: Any) -> None:
+        """The bare token and its single-element container must dispatch identically."""
+        result = DateTimeFeatureGroup.match_feature_group_criteria("my_result", self._options(datetime_op), None)
+        assert result is True, f"Config path should accept: {datetime_op!r}"
+        feature = Feature("my_result", options=self._options(datetime_op))
+        assert DateTimeFeatureGroup._extract_datetime_op(feature) == "year"
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type for deterministic ops.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
@@ -115,31 +115,6 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one datetime token, so it must reach dispatch unwrapped."""
-
-    def _options(self, datetime_op: Any) -> Options:
-        return Options(
-            context={
-                "datetime_op": datetime_op,
-                "in_features": "timestamp",
-            }
-        )
-
-    @pytest.mark.parametrize("datetime_op", ["year", ("year",), ["year"]])
-    def test_single_element_datetime_op(self, datetime_op: Any) -> None:
-        """The bare token and its single-element container must dispatch identically."""
-        result = DateTimeFeatureGroup.match_feature_group_criteria("my_result", self._options(datetime_op), None)
-        assert result is True, f"Config path should accept: {datetime_op!r}"
-        feature = Feature("my_result", options=self._options(datetime_op))
-        assert DateTimeFeatureGroup._extract_datetime_op(feature) == "year"
-
-    @pytest.mark.parametrize("datetime_op", [["year", "month"], ("year", "month")])
-    def test_multi_element_datetime_op_rejected(self, datetime_op: Any) -> None:
-        result = DateTimeFeatureGroup.match_feature_group_criteria("my_result", self._options(datetime_op), None)
-        assert result is False, f"Config path should reject: {datetime_op!r}"
-
-
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type for deterministic ops.
 
@@ -180,3 +155,7 @@ class TestDateTimeMatchValidation(MatchValidationTestBase):
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
         return {"in_features": "timestamp"}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [DateTimeFeatureGroup._extract_datetime_op(Feature("my_result", options=options))]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
@@ -134,6 +134,11 @@ class TestSingleTokenContainers:
         feature = Feature("my_result", options=self._options(datetime_op))
         assert DateTimeFeatureGroup._extract_datetime_op(feature) == "year"
 
+    @pytest.mark.parametrize("datetime_op", [["year", "month"], ("year", "month")])
+    def test_multi_element_datetime_op_rejected(self, datetime_op: Any) -> None:
+        result = DateTimeFeatureGroup.match_feature_group_criteria("my_result", self._options(datetime_op), None)
+        assert result is False, f"Config path should reject: {datetime_op!r}"
+
 
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type for deterministic ops.

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -49,20 +49,24 @@ _AGGREGATION_TYPES = frozenset({"sum", "avg", "count", "min", "max", "std", "var
 _TIME_UNITS = {"second", "minute", "hour", "day", "week", "month", "year"}
 
 
-def _frame_type_token(options: Options) -> str | None:
-    """The frame type as a bare token, unwrapped from its container; None when the option is absent."""
-    frame_type = options.get(_FRAME_TYPE_KEY)
-    return None if frame_type is None else op_token_value(frame_type)
+def _option_token(options: Options, key: str) -> str | None:
+    """An option as a bare token, unwrapped from its container; None when the option is absent.
+
+    Absent stays None instead of becoming the string ``"None"``, so a missing option
+    is a non-match by construction rather than by coincidence.
+    """
+    value = options.get(key)
+    return None if value is None else op_token_value(value)
 
 
 def _needs_frame_size(options: Options) -> bool:
     """Rolling and time frames are sized; cumulative and expanding are not."""
-    return _frame_type_token(options) in ("rolling", "time")
+    return _option_token(options, _FRAME_TYPE_KEY) in ("rolling", "time")
 
 
 def _needs_frame_unit(options: Options) -> bool:
     """Only a time-interval frame carries a unit."""
-    return _frame_type_token(options) == "time"
+    return _option_token(options, _FRAME_TYPE_KEY) == "time"
 
 
 @functools.lru_cache(maxsize=1024)
@@ -348,10 +352,10 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
 
         # Config path only: SUPPORTED_* narrows per subclass, so it cannot be declared once on the base.
         if cls._parse_frame_feature(str(feature_name)) is None:
-            frame_type = op_token_value(options.get(cls.FRAME_TYPE))
+            frame_type = _option_token(options, cls.FRAME_TYPE)
             if frame_type not in cls.SUPPORTED_FRAME_TYPES:
                 return False
-            if frame_type == "time" and op_token_value(options.get(cls.FRAME_UNIT)) not in cls.SUPPORTED_TIME_UNITS:
+            if frame_type == "time" and _option_token(options, cls.FRAME_UNIT) not in cls.SUPPORTED_TIME_UNITS:
                 return False
 
         partition_by = options.get(cls.PARTITION_BY)

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -49,14 +49,20 @@ _AGGREGATION_TYPES = frozenset({"sum", "avg", "count", "min", "max", "std", "var
 _TIME_UNITS = {"second", "minute", "hour", "day", "week", "month", "year"}
 
 
+def _frame_type_token(options: Options) -> str | None:
+    """The frame type as a bare token, unwrapped from its container; None when the option is absent."""
+    frame_type = options.get(_FRAME_TYPE_KEY)
+    return None if frame_type is None else op_token_value(frame_type)
+
+
 def _needs_frame_size(options: Options) -> bool:
     """Rolling and time frames are sized; cumulative and expanding are not."""
-    return options.get(_FRAME_TYPE_KEY) in ("rolling", "time")
+    return _frame_type_token(options) in ("rolling", "time")
 
 
 def _needs_frame_unit(options: Options) -> bool:
     """Only a time-interval frame carries a unit."""
-    return bool(options.get(_FRAME_TYPE_KEY) == "time")
+    return _frame_type_token(options) == "time"
 
 
 @functools.lru_cache(maxsize=1024)

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -13,6 +13,8 @@ from mloda.user import DataType, Feature
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.base import (
     FrameAggregateFeatureGroup,
     _AGGREGATION_TYPES,
+    _needs_frame_size,
+    _needs_frame_unit,
 )
 
 
@@ -479,6 +481,47 @@ class TestSingleTokenContainers:
             "my_result", self._options(aggregation_type=aggregation_type), None
         )
         assert result is False, f"Config path should reject: {aggregation_type!r}"
+
+
+class TestSingleTokenFrameTypeRequirements:
+    """The conditional-requirement predicates read frame_type raw, so a wrapped token must behave like a bare one."""
+
+    @pytest.mark.parametrize(
+        "frame_type",
+        ["rolling", ("rolling",), ["rolling"], "time", ("time",), ["time"]],
+    )
+    def test_sized_frame_types_need_frame_size(self, frame_type: Any) -> None:
+        assert _needs_frame_size(Options(context={"frame_type": frame_type})) is True
+
+    @pytest.mark.parametrize(
+        "frame_type",
+        ["cumulative", ("cumulative",), ["cumulative"], "expanding", ("expanding",), ["expanding"]],
+    )
+    def test_unsized_frame_types_do_not_need_frame_size(self, frame_type: Any) -> None:
+        assert _needs_frame_size(Options(context={"frame_type": frame_type})) is False
+
+    @pytest.mark.parametrize("frame_type", ["time", ("time",), ["time"]])
+    def test_time_frame_type_needs_frame_unit(self, frame_type: Any) -> None:
+        assert _needs_frame_unit(Options(context={"frame_type": frame_type})) is True
+
+    @pytest.mark.parametrize("frame_type", ["rolling", ("rolling",), ["rolling"]])
+    def test_non_time_frame_type_does_not_need_frame_unit(self, frame_type: Any) -> None:
+        assert _needs_frame_unit(Options(context={"frame_type": frame_type})) is False
+
+    @pytest.mark.parametrize("frame_type", ["rolling", ("rolling",), ["rolling"]])
+    def test_sized_frame_without_frame_size_rejected(self, frame_type: Any) -> None:
+        """A sized frame with no frame_size is a non-match, wrapped token or not."""
+        options = Options(
+            context={
+                "aggregation_type": "sum",
+                "frame_type": frame_type,
+                "in_features": "sales",
+                "partition_by": ["region"],
+                "order_by": "timestamp",
+            }
+        )
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False, f"Config path should reject a sized frame without frame_size: {frame_type!r}"
 
 
 class TestHostileInFeatures:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -434,7 +434,11 @@ class TestNameBasedFrameTypeInOptions:
 
 
 class TestSingleTokenContainers:
-    """A single-element container holds exactly one token, so it must reach dispatch unwrapped."""
+    """frame_type and frame_unit are operation tokens of their own, so they must reach dispatch unwrapped too.
+
+    The aggregation_type half of this contract is the shared
+    ``MatchValidationTestBase`` check, driven by ``config_key()``.
+    """
 
     def _options(self, **overrides: Any) -> Options:
         context: dict[str, Any] = {
@@ -447,15 +451,6 @@ class TestSingleTokenContainers:
         }
         context.update(overrides)
         return Options(context=context)
-
-    @pytest.mark.parametrize("aggregation_type", [("sum",), ["sum"]])
-    def test_single_element_aggregation_type(self, aggregation_type: Any) -> None:
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(aggregation_type=aggregation_type), None
-        )
-        assert result is True, f"Config path should accept: {aggregation_type!r}"
-        feature = Feature("my_result", options=self._options(aggregation_type=aggregation_type))
-        assert FrameAggregateFeatureGroup._extract_params(feature)["agg_type"] == "sum"
 
     @pytest.mark.parametrize("frame_type", [("rolling",), ["rolling"]])
     def test_single_element_frame_type(self, frame_type: Any) -> None:
@@ -475,12 +470,12 @@ class TestSingleTokenContainers:
         feature = Feature("my_result", options=self._options(frame_type="time", frame_size=7, frame_unit=frame_unit))
         assert FrameAggregateFeatureGroup._extract_params(feature)["frame_unit"] == "day"
 
-    @pytest.mark.parametrize("aggregation_type", [["sum", "max"], ("sum", "max")])
-    def test_multi_element_aggregation_type_rejected(self, aggregation_type: Any) -> None:
+    @pytest.mark.parametrize("frame_type", [["rolling", "time"], ("rolling", "time")])
+    def test_multi_element_frame_type_rejected(self, frame_type: Any) -> None:
         result = FrameAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(aggregation_type=aggregation_type), None
+            "my_result", self._options(frame_type=frame_type), None
         )
-        assert result is False, f"Config path should reject: {aggregation_type!r}"
+        assert result is False, f"Config path should reject: {frame_type!r}"
 
 
 class TestSingleTokenFrameTypeRequirements:
@@ -713,3 +708,7 @@ class TestFrameAggregateMatchValidation(MatchValidationTestBase):
     @classmethod
     def malformed_operations(cls) -> set[str]:
         return {"banana", "mode", "nunique", "first"}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [FrameAggregateFeatureGroup._extract_params(Feature("my_result", options=options))["agg_type"]]

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -711,10 +711,5 @@ class TestFrameAggregateMatchValidation(MatchValidationTestBase):
         return Options(context={"partition_by": ["region"], "order_by": "timestamp"})
 
     @classmethod
-    def parity_operations(cls) -> set[str]:
-        # No parametric family here: the fixed aggregation types are the whole value space.
-        return set(_AGGREGATION_TYPES)
-
-    @classmethod
     def malformed_operations(cls) -> set[str]:
         return {"banana", "mode", "nunique", "first"}

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -7,14 +7,12 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.base import (
     FrameAggregateFeatureGroup,
     _AGGREGATION_TYPES,
-    _needs_frame_size,
-    _needs_frame_unit,
 )
 
 
@@ -433,92 +431,6 @@ class TestNameBasedFrameTypeInOptions:
         assert result is True
 
 
-class TestSingleTokenContainers:
-    """frame_type and frame_unit are operation tokens of their own, so they must reach dispatch unwrapped too.
-
-    The aggregation_type half of this contract is the shared
-    ``MatchValidationTestBase`` check, driven by ``config_key()``.
-    """
-
-    def _options(self, **overrides: Any) -> Options:
-        context: dict[str, Any] = {
-            "aggregation_type": "sum",
-            "frame_type": "rolling",
-            "frame_size": 3,
-            "in_features": "sales",
-            "partition_by": ["region"],
-            "order_by": "timestamp",
-        }
-        context.update(overrides)
-        return Options(context=context)
-
-    @pytest.mark.parametrize("frame_type", [("rolling",), ["rolling"]])
-    def test_single_element_frame_type(self, frame_type: Any) -> None:
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(frame_type=frame_type), None
-        )
-        assert result is True, f"Config path should accept: {frame_type!r}"
-        feature = Feature("my_result", options=self._options(frame_type=frame_type))
-        assert FrameAggregateFeatureGroup._extract_params(feature)["frame_type"] == "rolling"
-
-    @pytest.mark.parametrize("frame_unit", [("day",), ["day"]])
-    def test_single_element_frame_unit(self, frame_unit: Any) -> None:
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(frame_type="time", frame_size=7, frame_unit=frame_unit), None
-        )
-        assert result is True, f"Config path should accept: {frame_unit!r}"
-        feature = Feature("my_result", options=self._options(frame_type="time", frame_size=7, frame_unit=frame_unit))
-        assert FrameAggregateFeatureGroup._extract_params(feature)["frame_unit"] == "day"
-
-    @pytest.mark.parametrize("frame_type", [["rolling", "time"], ("rolling", "time")])
-    def test_multi_element_frame_type_rejected(self, frame_type: Any) -> None:
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(frame_type=frame_type), None
-        )
-        assert result is False, f"Config path should reject: {frame_type!r}"
-
-
-class TestSingleTokenFrameTypeRequirements:
-    """The conditional-requirement predicates read frame_type raw, so a wrapped token must behave like a bare one."""
-
-    @pytest.mark.parametrize(
-        "frame_type",
-        ["rolling", ("rolling",), ["rolling"], "time", ("time",), ["time"]],
-    )
-    def test_sized_frame_types_need_frame_size(self, frame_type: Any) -> None:
-        assert _needs_frame_size(Options(context={"frame_type": frame_type})) is True
-
-    @pytest.mark.parametrize(
-        "frame_type",
-        ["cumulative", ("cumulative",), ["cumulative"], "expanding", ("expanding",), ["expanding"]],
-    )
-    def test_unsized_frame_types_do_not_need_frame_size(self, frame_type: Any) -> None:
-        assert _needs_frame_size(Options(context={"frame_type": frame_type})) is False
-
-    @pytest.mark.parametrize("frame_type", ["time", ("time",), ["time"]])
-    def test_time_frame_type_needs_frame_unit(self, frame_type: Any) -> None:
-        assert _needs_frame_unit(Options(context={"frame_type": frame_type})) is True
-
-    @pytest.mark.parametrize("frame_type", ["rolling", ("rolling",), ["rolling"]])
-    def test_non_time_frame_type_does_not_need_frame_unit(self, frame_type: Any) -> None:
-        assert _needs_frame_unit(Options(context={"frame_type": frame_type})) is False
-
-    @pytest.mark.parametrize("frame_type", ["rolling", ("rolling",), ["rolling"]])
-    def test_sized_frame_without_frame_size_rejected(self, frame_type: Any) -> None:
-        """A sized frame with no frame_size is a non-match, wrapped token or not."""
-        options = Options(
-            context={
-                "aggregation_type": "sum",
-                "frame_type": frame_type,
-                "in_features": "sales",
-                "partition_by": ["region"],
-                "order_by": "timestamp",
-            }
-        )
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is False, f"Config path should reject a sized frame without frame_size: {frame_type!r}"
-
-
 class TestHostileInFeatures:
     """A hostile in_features value is a plain non-match; no exception may escape the matcher."""
 
@@ -710,5 +622,23 @@ class TestFrameAggregateMatchValidation(MatchValidationTestBase):
         return {"banana", "mode", "nunique", "first"}
 
     @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        # frame_type and frame_unit are operation tokens of their own, and frame_type is what
+        # _needs_frame_size / _needs_frame_unit read to decide which of the two a state requires.
+        return [
+            *super().token_cases(),
+            TokenCase("frame_type", "rolling", "time"),
+            TokenCase("frame_unit", "day", "week", context={"frame_type": "time"}),
+            # Sized frames require frame_size, unsized ones do not.
+            TokenCase("frame_type", "rolling", without=("frame_size",), matches=False),
+            TokenCase("frame_type", "time", without=("frame_size",), matches=False),
+            TokenCase("frame_type", "cumulative", without=("frame_size",)),
+            TokenCase("frame_type", "expanding", without=("frame_size",)),
+            # Only a time frame requires frame_unit, which additional_match_options() does not carry.
+            TokenCase("frame_type", "time", matches=False),
+        ]
+
+    @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:
-        return [FrameAggregateFeatureGroup._extract_params(Feature("my_result", options=options))["agg_type"]]
+        params = FrameAggregateFeatureGroup._extract_params(Feature("my_result", options=options))
+        return [params["agg_type"], params["frame_type"], params["frame_unit"]]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -353,7 +353,9 @@ class TestOffsetMatchValidation(MatchValidationTestBase):
 
     @classmethod
     def parity_operations(cls) -> set[str]:
-        return {"first_value", "last_value", "lag_1", "lead_2", "diff_1", "pct_change_3"}
+        # Widen, never narrow: valid_operations() covers the fixed offset types plus one lag/lead
+        # instance, so add the remaining parametric families and a second lead arity on top of it.
+        return cls.valid_operations() | {"lag_1", "lead_2", "diff_1", "pct_change_3"}
 
     @classmethod
     def malformed_operations(cls) -> set[str]:

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -206,32 +206,6 @@ class TestConfigBasedOffsetTypeValidation:
         assert result is False, f"Config path should reject: {offset_type!r}"
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one offset token, so it must reach dispatch unwrapped."""
-
-    def _options(self, offset_type: Any) -> Options:
-        return Options(
-            context={
-                "offset_type": offset_type,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-                "order_by": "value_int",
-            }
-        )
-
-    @pytest.mark.parametrize("offset_type", [("lag_1",), ["lag_1"]])
-    def test_single_element_offset_type(self, offset_type: Any) -> None:
-        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(offset_type), None)
-        assert result is True, f"Config path should accept: {offset_type!r}"
-        feature = Feature("my_result", options=self._options(offset_type))
-        assert OffsetFeatureGroup._extract_offset_type(feature) == "lag_1"
-
-    @pytest.mark.parametrize("offset_type", [["lag_1", "lead_2"], ("lag_1", "lead_2")])
-    def test_multi_element_offset_type_rejected(self, offset_type: Any) -> None:
-        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(offset_type), None)
-        assert result is False, f"Config path should reject: {offset_type!r}"
-
-
 class TestDigitLikeOffsetSuffixes:
     """A suffix that str.isdigit accepts is not automatically an int; both paths must reject it without raising."""
 
@@ -360,3 +334,7 @@ class TestOffsetMatchValidation(MatchValidationTestBase):
     @classmethod
     def malformed_operations(cls) -> set[str]:
         return {"banana", "lag_0", "lag_abc", "lead_"}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [OffsetFeatureGroup._extract_offset_type(Feature("my_result", options=options))]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
@@ -292,5 +292,10 @@ class TestPercentileMatchValidation(MatchValidationTestBase):
         return Options(context={"partition_by": ["region"]})
 
     @classmethod
+    def config_value(cls, operation: str) -> Any:
+        # The name path uses pN tokens, the config path a float in [0.0, 1.0].
+        return int(operation[1:]) / 100.0
+
+    @classmethod
     def options_reject_invalid_types(cls) -> bool:
         return False

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
@@ -168,6 +168,13 @@ class TestSingleTokenContainers:
         feature = Feature("my_result", options=self._options(arithmetic_op))
         assert PointArithmeticFeatureGroup._extract_arithmetic_op(feature) == "add"
 
+    @pytest.mark.parametrize("arithmetic_op", [["add", "subtract"], ("add", "subtract")])
+    def test_multi_element_arithmetic_op_rejected(self, arithmetic_op: Any) -> None:
+        result = PointArithmeticFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(arithmetic_op), None
+        )
+        assert result is False, f"Config path should reject: {arithmetic_op!r}"
+
 
 class TestTwoColumnEnforcement:
     """Verify that MIN_IN_FEATURES=2 / MAX_IN_FEATURES=2 enforces two-column behavior."""

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
@@ -147,6 +147,28 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one arithmetic token, so it must reach dispatch unwrapped."""
+
+    def _options(self, arithmetic_op: Any) -> Options:
+        return Options(
+            context={
+                "arithmetic_op": arithmetic_op,
+                "in_features": ["value_int", "amount"],
+            }
+        )
+
+    @pytest.mark.parametrize("arithmetic_op", ["add", ("add",), ["add"]])
+    def test_single_element_arithmetic_op(self, arithmetic_op: Any) -> None:
+        """The bare token and its single-element container must dispatch identically."""
+        result = PointArithmeticFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(arithmetic_op), None
+        )
+        assert result is True, f"Config path should accept: {arithmetic_op!r}"
+        feature = Feature("my_result", options=self._options(arithmetic_op))
+        assert PointArithmeticFeatureGroup._extract_arithmetic_op(feature) == "add"
+
+
 class TestTwoColumnEnforcement:
     """Verify that MIN_IN_FEATURES=2 / MAX_IN_FEATURES=2 enforces two-column behavior."""
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
@@ -147,35 +147,6 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one arithmetic token, so it must reach dispatch unwrapped."""
-
-    def _options(self, arithmetic_op: Any) -> Options:
-        return Options(
-            context={
-                "arithmetic_op": arithmetic_op,
-                "in_features": ["value_int", "amount"],
-            }
-        )
-
-    @pytest.mark.parametrize("arithmetic_op", ["add", ("add",), ["add"]])
-    def test_single_element_arithmetic_op(self, arithmetic_op: Any) -> None:
-        """The bare token and its single-element container must dispatch identically."""
-        result = PointArithmeticFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(arithmetic_op), None
-        )
-        assert result is True, f"Config path should accept: {arithmetic_op!r}"
-        feature = Feature("my_result", options=self._options(arithmetic_op))
-        assert PointArithmeticFeatureGroup._extract_arithmetic_op(feature) == "add"
-
-    @pytest.mark.parametrize("arithmetic_op", [["add", "subtract"], ("add", "subtract")])
-    def test_multi_element_arithmetic_op_rejected(self, arithmetic_op: Any) -> None:
-        result = PointArithmeticFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(arithmetic_op), None
-        )
-        assert result is False, f"Config path should reject: {arithmetic_op!r}"
-
-
 class TestTwoColumnEnforcement:
     """Verify that MIN_IN_FEATURES=2 / MAX_IN_FEATURES=2 enforces two-column behavior."""
 
@@ -393,3 +364,7 @@ class TestPointArithmeticMatchValidation(MatchValidationTestBase):
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
         return {"in_features": ["value_int", "amount"]}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [PointArithmeticFeatureGroup._extract_arithmetic_op(Feature("my_result", options=options))]

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -464,7 +464,9 @@ class TestRankMatchValidation(MatchValidationTestBase):
 
     @classmethod
     def parity_operations(cls) -> set[str]:
-        return {"row_number", "percent_rank", "ntile_4", "top_5", "bottom_3"}
+        # Widen, never narrow: valid_operations() covers the fixed rank types only, so add one
+        # instance of each parametric family (ntile_N / top_N / bottom_N) on top of it.
+        return cls.valid_operations() | {"ntile_4", "top_5", "bottom_3"}
 
     @classmethod
     def malformed_operations(cls) -> set[str]:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -316,32 +316,6 @@ class TestConfigBasedParametricRankTypes:
         assert result is False, f"Config path should reject: {rank_type!r}"
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one rank token, so it must reach dispatch unwrapped."""
-
-    def _options(self, rank_type: Any) -> Options:
-        return Options(
-            context={
-                "rank_type": rank_type,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-                "order_by": "value_int",
-            }
-        )
-
-    @pytest.mark.parametrize("rank_type", [("ntile_4",), ["ntile_4"]])
-    def test_single_element_rank_type(self, rank_type: Any) -> None:
-        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(rank_type), None)
-        assert result is True, f"Config path should accept: {rank_type!r}"
-        feature = Feature("my_result", options=self._options(rank_type))
-        assert RankFeatureGroup._extract_rank_type(feature) == "ntile_4"
-
-    @pytest.mark.parametrize("rank_type", [["ntile_4", "top_5"], ("ntile_4", "top_5")])
-    def test_multi_element_rank_type_rejected(self, rank_type: Any) -> None:
-        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(rank_type), None)
-        assert result is False, f"Config path should reject: {rank_type!r}"
-
-
 class TestDigitLikeRankSuffixes:
     """A suffix that str.isdigit accepts is not automatically an int; both paths must reject it without raising."""
 
@@ -471,3 +445,7 @@ class TestRankMatchValidation(MatchValidationTestBase):
     @classmethod
     def malformed_operations(cls) -> set[str]:
         return {"ntile_0", "ntile_abc", "top_0", "bottom_0", "banana"}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [RankFeatureGroup._extract_rank_type(Feature("my_result", options=options))]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
@@ -121,6 +121,29 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one aggregation token, so it must reach dispatch unwrapped."""
+
+    def _options(self, aggregation_type: Any) -> Options:
+        return Options(
+            context={
+                "aggregation_type": aggregation_type,
+                "in_features": "value_int",
+            }
+        )
+
+    @pytest.mark.parametrize("aggregation_type", ["sum", ("sum",), ["sum"]])
+    def test_single_element_aggregation_type(self, aggregation_type: Any) -> None:
+        """The bare token and its single-element container must dispatch identically."""
+        result = ScalarAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(aggregation_type), None
+        )
+        assert result is True, f"Config path should accept: {aggregation_type!r}"
+        feature = Feature("my_result", options=self._options(aggregation_type))
+        assert ScalarAggregateFeatureGroup._extract_aggregation_type(feature) == "sum"
+        assert ScalarAggregateFeatureGroup._resolve_agg_type("my_result", self._options(aggregation_type)) == "sum"
+
+
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
@@ -121,36 +121,6 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one aggregation token, so it must reach dispatch unwrapped."""
-
-    def _options(self, aggregation_type: Any) -> Options:
-        return Options(
-            context={
-                "aggregation_type": aggregation_type,
-                "in_features": "value_int",
-            }
-        )
-
-    @pytest.mark.parametrize("aggregation_type", ["sum", ("sum",), ["sum"]])
-    def test_single_element_aggregation_type(self, aggregation_type: Any) -> None:
-        """The bare token and its single-element container must dispatch identically."""
-        result = ScalarAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(aggregation_type), None
-        )
-        assert result is True, f"Config path should accept: {aggregation_type!r}"
-        feature = Feature("my_result", options=self._options(aggregation_type))
-        assert ScalarAggregateFeatureGroup._extract_aggregation_type(feature) == "sum"
-        assert ScalarAggregateFeatureGroup._resolve_agg_type("my_result", self._options(aggregation_type)) == "sum"
-
-    @pytest.mark.parametrize("aggregation_type", [["sum", "max"], ("sum", "max")])
-    def test_multi_element_aggregation_type_rejected(self, aggregation_type: Any) -> None:
-        result = ScalarAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(aggregation_type), None
-        )
-        assert result is False, f"Config path should reject: {aggregation_type!r}"
-
-
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior.
 
@@ -308,3 +278,11 @@ class TestScalarAggregateMatchValidation(MatchValidationTestBase):
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
         return {"in_features": "value_int"}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        feature = Feature("my_result", options=options)
+        return [
+            ScalarAggregateFeatureGroup._extract_aggregation_type(feature),
+            ScalarAggregateFeatureGroup._resolve_agg_type("my_result", options),
+        ]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
@@ -143,6 +143,13 @@ class TestSingleTokenContainers:
         assert ScalarAggregateFeatureGroup._extract_aggregation_type(feature) == "sum"
         assert ScalarAggregateFeatureGroup._resolve_agg_type("my_result", self._options(aggregation_type)) == "sum"
 
+    @pytest.mark.parametrize("aggregation_type", [["sum", "max"], ("sum", "max")])
+    def test_multi_element_aggregation_type_rejected(self, aggregation_type: Any) -> None:
+        result = ScalarAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(aggregation_type), None
+        )
+        assert result is False, f"Config path should reject: {aggregation_type!r}"
+
 
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior.

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -153,36 +153,6 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one arithmetic token, so it must reach dispatch unwrapped."""
-
-    def _options(self, arithmetic_op: Any) -> Options:
-        return Options(
-            context={
-                "arithmetic_op": arithmetic_op,
-                "in_features": "value_int",
-                "constant": 5,
-            }
-        )
-
-    @pytest.mark.parametrize("arithmetic_op", ["add", ("add",), ["add"]])
-    def test_single_element_arithmetic_op(self, arithmetic_op: Any) -> None:
-        """The bare token and its single-element container must dispatch identically."""
-        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(arithmetic_op), None
-        )
-        assert result is True, f"Config path should accept: {arithmetic_op!r}"
-        feature = Feature("my_result", options=self._options(arithmetic_op))
-        assert ScalarArithmeticFeatureGroup._extract_arithmetic_op(feature) == "add"
-
-    @pytest.mark.parametrize("arithmetic_op", [["add", "subtract"], ("add", "subtract")])
-    def test_multi_element_arithmetic_op_rejected(self, arithmetic_op: Any) -> None:
-        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(arithmetic_op), None
-        )
-        assert result is False, f"Config path should reject: {arithmetic_op!r}"
-
-
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior."""
 
@@ -314,3 +284,7 @@ class TestScalarArithmeticMatchValidation(MatchValidationTestBase):
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
         return {"in_features": "value_int", "constant": 5}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [ScalarArithmeticFeatureGroup._extract_arithmetic_op(Feature("my_result", options=options))]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -175,6 +175,13 @@ class TestSingleTokenContainers:
         feature = Feature("my_result", options=self._options(arithmetic_op))
         assert ScalarArithmeticFeatureGroup._extract_arithmetic_op(feature) == "add"
 
+    @pytest.mark.parametrize("arithmetic_op", [["add", "subtract"], ("add", "subtract")])
+    def test_multi_element_arithmetic_op_rejected(self, arithmetic_op: Any) -> None:
+        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(arithmetic_op), None
+        )
+        assert result is False, f"Config path should reject: {arithmetic_op!r}"
+
 
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior."""

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -153,6 +153,29 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one arithmetic token, so it must reach dispatch unwrapped."""
+
+    def _options(self, arithmetic_op: Any) -> Options:
+        return Options(
+            context={
+                "arithmetic_op": arithmetic_op,
+                "in_features": "value_int",
+                "constant": 5,
+            }
+        )
+
+    @pytest.mark.parametrize("arithmetic_op", ["add", ("add",), ["add"]])
+    def test_single_element_arithmetic_op(self, arithmetic_op: Any) -> None:
+        """The bare token and its single-element container must dispatch identically."""
+        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(arithmetic_op), None
+        )
+        assert result is True, f"Config path should accept: {arithmetic_op!r}"
+        feature = Feature("my_result", options=self._options(arithmetic_op))
+        assert ScalarArithmeticFeatureGroup._extract_arithmetic_op(feature) == "add"
+
+
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior."""
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
@@ -45,7 +45,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import is_op_token, op_token_value
 
 TIME_BUCKETIZATION_OPS: dict[str, str] = {
     "floor": "Round timestamp down to the start of the enclosing bucket",
@@ -194,7 +194,7 @@ class TimeBucketizationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         op = feature.options.get(cls.BUCKET_OP)
         if op is None:
             raise ValueError(f"Could not extract bucket op for {feature_name}")
-        return str(op)
+        return op_token_value(op)
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         _feature_name = str(feature_name)

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
@@ -223,6 +223,11 @@ class TestSingleTokenContainers:
         feature = Feature("my_result", options=self._options(bucket_op))
         assert TimeBucketizationFeatureGroup._extract_bucket_op(feature) == "floor_1_day"
 
+    @pytest.mark.parametrize("bucket_op", [["floor_1_day", "ceil_1_day"], ("floor_1_day", "ceil_1_day")])
+    def test_multi_element_bucket_op_rejected(self, bucket_op: Any) -> None:
+        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("my_result", self._options(bucket_op), None)
+        assert result is False, f"Config path should reject: {bucket_op!r}"
+
 
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior."""

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
@@ -204,31 +204,6 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one bucket token, so it must reach dispatch unwrapped."""
-
-    def _options(self, bucket_op: Any) -> Options:
-        return Options(
-            context={
-                "bucket_op": bucket_op,
-                "in_features": "timestamp",
-            }
-        )
-
-    @pytest.mark.parametrize("bucket_op", ["floor_1_day", ("floor_1_day",), ["floor_1_day"]])
-    def test_single_element_bucket_op(self, bucket_op: Any) -> None:
-        """The bare token and its single-element container must dispatch identically."""
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("my_result", self._options(bucket_op), None)
-        assert result is True, f"Config path should accept: {bucket_op!r}"
-        feature = Feature("my_result", options=self._options(bucket_op))
-        assert TimeBucketizationFeatureGroup._extract_bucket_op(feature) == "floor_1_day"
-
-    @pytest.mark.parametrize("bucket_op", [["floor_1_day", "ceil_1_day"], ("floor_1_day", "ceil_1_day")])
-    def test_multi_element_bucket_op_rejected(self, bucket_op: Any) -> None:
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("my_result", self._options(bucket_op), None)
-        assert result is False, f"Config path should reject: {bucket_op!r}"
-
-
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior."""
 
@@ -387,3 +362,7 @@ class TestTimeBucketizationMatchValidation(MatchValidationTestBase):
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
         return {"in_features": "timestamp"}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [TimeBucketizationFeatureGroup._extract_bucket_op(Feature("my_result", options=options))]

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
@@ -204,6 +204,26 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one bucket token, so it must reach dispatch unwrapped."""
+
+    def _options(self, bucket_op: Any) -> Options:
+        return Options(
+            context={
+                "bucket_op": bucket_op,
+                "in_features": "timestamp",
+            }
+        )
+
+    @pytest.mark.parametrize("bucket_op", ["floor_1_day", ("floor_1_day",), ["floor_1_day"]])
+    def test_single_element_bucket_op(self, bucket_op: Any) -> None:
+        """The bare token and its single-element container must dispatch identically."""
+        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("my_result", self._options(bucket_op), None)
+        assert result is True, f"Config path should accept: {bucket_op!r}"
+        feature = Feature("my_result", options=self._options(bucket_op))
+        assert TimeBucketizationFeatureGroup._extract_bucket_op(feature) == "floor_1_day"
+
+
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior."""
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -13,7 +13,7 @@ from mloda.community.feature_groups.data_operations.aggregation_base import (
     AggregationFeatureGroupBase,
 )
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import is_op_token, op_token_value
 
 # Aggregation types that require an order_by column to be deterministic.
 _ORDER_DEPENDENT_AGG_TYPES = {"first", "last"}
@@ -184,7 +184,7 @@ class WindowAggregationFeatureGroup(AggregationFeatureGroupBase):
             return operation_config
         agg_type = options.get(cls.AGGREGATION_TYPE)
         if agg_type is not None:
-            return str(agg_type)
+            return op_token_value(agg_type)
         return None
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -300,6 +300,12 @@ class TestSingleTokenContainers:
         result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", with_order_by, None)
         assert result is True, f"Config path should accept with order_by: {aggregation_type!r}"
 
+    @pytest.mark.parametrize("aggregation_type", [["sum", "max"], ("sum", "max")])
+    def test_multi_element_aggregation_type_rejected(self, aggregation_type: Any) -> None:
+        options = self._options(aggregation_type=aggregation_type)
+        result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False, f"Config path should reject: {aggregation_type!r}"
+
 
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.base import (
@@ -266,34 +266,6 @@ class TestConfigBasedFeatures:
         assert result_col == expected
 
 
-class TestSingleTokenOrderRequirement:
-    """The order_by requirement is keyed off the aggregation type, so a wrapped token must trigger it too.
-
-    The rest of the single-token contract is the shared ``MatchValidationTestBase`` check.
-    """
-
-    def _options(self, **overrides: Any) -> Options:
-        context: dict[str, Any] = {
-            "aggregation_type": "sum",
-            "in_features": "value_int",
-            "partition_by": ["region"],
-        }
-        context.update(overrides)
-        return Options(context=context)
-
-    @pytest.mark.parametrize("aggregation_type", ["first", ("first",), ["first"]])
-    def test_single_element_order_dependent_agg_type_requires_order_by(self, aggregation_type: Any) -> None:
-        """first/last need order_by, and a wrapped token must trigger that requirement just like a bare one."""
-        without_order_by = self._options(aggregation_type=aggregation_type)
-        assert WindowAggregationFeatureGroup._resolve_agg_type("my_result", without_order_by) == "first"
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", without_order_by, None)
-        assert result is False, f"Config path should reject without order_by: {aggregation_type!r}"
-
-        with_order_by = self._options(aggregation_type=aggregation_type, order_by="timestamp")
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", with_order_by, None)
-        assert result is True, f"Config path should accept with order_by: {aggregation_type!r}"
-
-
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.
 
@@ -346,6 +318,15 @@ class TestWindowAggregationMatchValidation(MatchValidationTestBase):
     @classmethod
     def pattern_match_options(cls) -> Options:
         return Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+
+    @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        # first/last are the aggregation types that require order_by.
+        return [
+            *super().token_cases(),
+            TokenCase(cls.config_key(), "first", without=("order_by",), matches=False),
+            TokenCase(cls.config_key(), "first"),
+        ]
 
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -266,6 +266,41 @@ class TestConfigBasedFeatures:
         assert result_col == expected
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one aggregation token, so it must reach dispatch unwrapped."""
+
+    def _options(self, **overrides: Any) -> Options:
+        context: dict[str, Any] = {
+            "aggregation_type": "sum",
+            "in_features": "value_int",
+            "partition_by": ["region"],
+        }
+        context.update(overrides)
+        return Options(context=context)
+
+    @pytest.mark.parametrize("aggregation_type", ["sum", ("sum",), ["sum"]])
+    def test_single_element_aggregation_type(self, aggregation_type: Any) -> None:
+        """The bare token and its single-element container must dispatch identically."""
+        options = self._options(aggregation_type=aggregation_type)
+        result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is True, f"Config path should accept: {aggregation_type!r}"
+        feature = Feature("my_result", options=options)
+        assert WindowAggregationFeatureGroup._extract_aggregation_type(feature) == "sum"
+        assert WindowAggregationFeatureGroup._resolve_agg_type("my_result", options) == "sum"
+
+    @pytest.mark.parametrize("aggregation_type", ["first", ("first",), ["first"]])
+    def test_single_element_order_dependent_agg_type_requires_order_by(self, aggregation_type: Any) -> None:
+        """first/last need order_by, and a wrapped token must trigger that requirement just like a bare one."""
+        without_order_by = self._options(aggregation_type=aggregation_type)
+        assert WindowAggregationFeatureGroup._resolve_agg_type("my_result", without_order_by) == "first"
+        result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", without_order_by, None)
+        assert result is False, f"Config path should reject without order_by: {aggregation_type!r}"
+
+        with_order_by = self._options(aggregation_type=aggregation_type, order_by="timestamp")
+        result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", with_order_by, None)
+        assert result is True, f"Config path should accept with order_by: {aggregation_type!r}"
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -347,4 +347,9 @@ class TestWindowAggregationMatchValidation(MatchValidationTestBase):
 
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
-        return {"in_features": "value_int", "partition_by": ["region"]}
+        # order_by is required for first/last and harmless for the other types.
+        return {"in_features": "value_int", "partition_by": ["region"], "order_by": "timestamp"}
+
+    @classmethod
+    def pattern_match_options(cls) -> Options:
+        return Options(context={"partition_by": ["region"], "order_by": "timestamp"})

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -266,8 +266,11 @@ class TestConfigBasedFeatures:
         assert result_col == expected
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one aggregation token, so it must reach dispatch unwrapped."""
+class TestSingleTokenOrderRequirement:
+    """The order_by requirement is keyed off the aggregation type, so a wrapped token must trigger it too.
+
+    The rest of the single-token contract is the shared ``MatchValidationTestBase`` check.
+    """
 
     def _options(self, **overrides: Any) -> Options:
         context: dict[str, Any] = {
@@ -277,16 +280,6 @@ class TestSingleTokenContainers:
         }
         context.update(overrides)
         return Options(context=context)
-
-    @pytest.mark.parametrize("aggregation_type", ["sum", ("sum",), ["sum"]])
-    def test_single_element_aggregation_type(self, aggregation_type: Any) -> None:
-        """The bare token and its single-element container must dispatch identically."""
-        options = self._options(aggregation_type=aggregation_type)
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is True, f"Config path should accept: {aggregation_type!r}"
-        feature = Feature("my_result", options=options)
-        assert WindowAggregationFeatureGroup._extract_aggregation_type(feature) == "sum"
-        assert WindowAggregationFeatureGroup._resolve_agg_type("my_result", options) == "sum"
 
     @pytest.mark.parametrize("aggregation_type", ["first", ("first",), ["first"]])
     def test_single_element_order_dependent_agg_type_requires_order_by(self, aggregation_type: Any) -> None:
@@ -299,12 +292,6 @@ class TestSingleTokenContainers:
         with_order_by = self._options(aggregation_type=aggregation_type, order_by="timestamp")
         result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", with_order_by, None)
         assert result is True, f"Config path should accept with order_by: {aggregation_type!r}"
-
-    @pytest.mark.parametrize("aggregation_type", [["sum", "max"], ("sum", "max")])
-    def test_multi_element_aggregation_type_rejected(self, aggregation_type: Any) -> None:
-        options = self._options(aggregation_type=aggregation_type)
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is False, f"Config path should reject: {aggregation_type!r}"
 
 
 class TestReturnDataTypeRule:
@@ -359,3 +346,11 @@ class TestWindowAggregationMatchValidation(MatchValidationTestBase):
     @classmethod
     def pattern_match_options(cls) -> Options:
         return Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        feature = Feature("my_result", options=options)
+        return [
+            WindowAggregationFeatureGroup._extract_aggregation_type(feature),
+            WindowAggregationFeatureGroup._resolve_agg_type("my_result", options),
+        ]

--- a/mloda/community/feature_groups/data_operations/string/base.py
+++ b/mloda/community/feature_groups/data_operations/string/base.py
@@ -10,7 +10,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.provider import DefaultOptionKeys, FeatureGroup
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import is_op_token, op_token_value
 
 STRING_OPS = {
     "upper": "Convert string to uppercase",
@@ -110,7 +110,7 @@ class StringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         op = feature.options.get(cls.STRING_OP)
         if op is None:
             raise ValueError(f"Could not extract string operation for {feature_name}")
-        return str(op)
+        return op_token_value(op)
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:

--- a/mloda/community/feature_groups/data_operations/string/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_base.py
@@ -148,6 +148,11 @@ class TestSingleTokenContainers:
         feature = Feature("my_result", options=self._options(string_op))
         assert StringFeatureGroup._extract_string_op(feature) == "upper"
 
+    @pytest.mark.parametrize("string_op", [["upper", "lower"], ("upper", "lower")])
+    def test_multi_element_string_op_rejected(self, string_op: Any) -> None:
+        result = StringFeatureGroup.match_feature_group_criteria("my_result", self._options(string_op), None)
+        assert result is False, f"Config path should reject: {string_op!r}"
+
 
 class TestValidateStringMatch:
     def test_base_class_validates_known_ops(self) -> None:

--- a/mloda/community/feature_groups/data_operations/string/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_base.py
@@ -129,6 +129,26 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestSingleTokenContainers:
+    """A single-element container holds exactly one string token, so it must reach dispatch unwrapped."""
+
+    def _options(self, string_op: Any) -> Options:
+        return Options(
+            context={
+                "string_op": string_op,
+                "in_features": "name",
+            }
+        )
+
+    @pytest.mark.parametrize("string_op", ["upper", ("upper",), ["upper"]])
+    def test_single_element_string_op(self, string_op: Any) -> None:
+        """The bare token and its single-element container must dispatch identically."""
+        result = StringFeatureGroup.match_feature_group_criteria("my_result", self._options(string_op), None)
+        assert result is True, f"Config path should accept: {string_op!r}"
+        feature = Feature("my_result", options=self._options(string_op))
+        assert StringFeatureGroup._extract_string_op(feature) == "upper"
+
+
 class TestValidateStringMatch:
     def test_base_class_validates_known_ops(self) -> None:
         """Base class _validate_string_match accepts all STRING_OPS."""

--- a/mloda/community/feature_groups/data_operations/string/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_base.py
@@ -129,31 +129,6 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
-class TestSingleTokenContainers:
-    """A single-element container holds exactly one string token, so it must reach dispatch unwrapped."""
-
-    def _options(self, string_op: Any) -> Options:
-        return Options(
-            context={
-                "string_op": string_op,
-                "in_features": "name",
-            }
-        )
-
-    @pytest.mark.parametrize("string_op", ["upper", ("upper",), ["upper"]])
-    def test_single_element_string_op(self, string_op: Any) -> None:
-        """The bare token and its single-element container must dispatch identically."""
-        result = StringFeatureGroup.match_feature_group_criteria("my_result", self._options(string_op), None)
-        assert result is True, f"Config path should accept: {string_op!r}"
-        feature = Feature("my_result", options=self._options(string_op))
-        assert StringFeatureGroup._extract_string_op(feature) == "upper"
-
-    @pytest.mark.parametrize("string_op", [["upper", "lower"], ("upper", "lower")])
-    def test_multi_element_string_op_rejected(self, string_op: Any) -> None:
-        result = StringFeatureGroup.match_feature_group_criteria("my_result", self._options(string_op), None)
-        assert result is False, f"Config path should reject: {string_op!r}"
-
-
 class TestValidateStringMatch:
     def test_base_class_validates_known_ops(self) -> None:
         """Base class _validate_string_match accepts all STRING_OPS."""
@@ -207,3 +182,7 @@ class TestStringMatchValidation(MatchValidationTestBase):
     @classmethod
     def additional_match_options(cls) -> dict[str, Any]:
         return {"in_features": "name"}
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [StringFeatureGroup._extract_string_op(Feature("my_result", options=options))]

--- a/mloda/testing/feature_groups/data_operations/match_validation.py
+++ b/mloda/testing/feature_groups/data_operations/match_validation.py
@@ -6,8 +6,9 @@ Provides ``MatchValidationTestBase`` with reusable test methods covering:
 - Invalid operation types (pattern-based and options-based)
 - Special characters in the operation portion of feature names
 - Type confusion via Options (None, int)
-- Single-element containers holding exactly one operation token, and the
-  multi-element containers that must stay rejected
+- Single-element containers holding exactly one operation token, over every
+  token-valued key and option state a family declares (``token_cases``), and
+  the multi-element containers that must stay rejected
 - Case sensitivity enforcement (lowercase only)
 - Declaration/dispatch drift between the name path and the config path: the
   acceptance half is opt-out (``parity_operations``), the rejection half is
@@ -20,11 +21,35 @@ to each specific operation.
 from __future__ import annotations
 
 from abc import abstractmethod
+from dataclasses import dataclass, field
 from typing import Any
 
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import DefaultOptionKeys
+
+
+@dataclass(frozen=True)
+class TokenCase:
+    """One state of one token-valued config key, declared for the single-token checks.
+
+    ``context`` adds to and ``without`` drops from ``additional_match_options()``,
+    which is how a state that turns a conditional requirement on or off is declared
+    (a sized frame type without its ``frame_size``, ``first`` without its ``order_by``).
+    ``matches`` is the verdict that state must produce, bare and wrapped alike.
+
+    ``other`` is a second valid value for the same key, used for the multi-element
+    rejection; ``None`` skips it. Only string tokens take part in the single-element
+    checks, since a container is caller syntax for one *token*.
+    """
+
+    key: str
+    token: Any
+    other: Any = None
+    context: dict[str, Any] = field(default_factory=dict)
+    without: tuple[str, ...] = ()
+    matches: bool = True
 
 
 class MatchValidationTestBase:
@@ -94,18 +119,22 @@ class MatchValidationTestBase:
         return operation
 
     @classmethod
-    def single_token_operation(cls) -> str | None:
-        """The config-path operation token used for the single-element-container checks.
+    def token_cases(cls) -> list[TokenCase]:
+        """States whose token must behave the same bare and in a single-element container.
 
-        Defaults to the first parity operation whose config value is a string.
-        Families whose config vocabulary is not a token (percentile's float) get
-        ``None``, and the checks are skipped.
+        Core unwraps a one-element container when it reads a property value, so
+        ``("sum",)`` is valid caller syntax for one token: it must produce the same
+        verdict as ``"sum"`` and reach dispatch as ``"sum"``, not as ``"('sum',)"``.
+
+        Defaults to the primary operation key holding parity operations. Override to
+        append the other keys a family dispatches on, and the states where a token
+        turns a conditional requirement on or off.
         """
-        for operation in sorted(cls.parity_operations()):
-            value = cls.config_value(operation)
-            if isinstance(value, str):
-                return value
-        return None
+        operations = sorted(cls.parity_operations())
+        if not operations:
+            return []
+        values = [cls.config_value(operation) for operation in operations[:2]]
+        return [TokenCase(cls.config_key(), values[0], values[1] if len(values) > 1 else None)]
 
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:
@@ -142,9 +171,18 @@ class MatchValidationTestBase:
         """
         return set()
 
+    @classmethod
+    def _primary_value(cls) -> Any:
+        """The value the primary operation key holds while another key is under test."""
+        return cls.config_value(sorted(cls.parity_operations())[0])
+
     def _config_options(self, value: Any) -> Options:
         """Options carrying ``value`` as the operation on the configuration path."""
         return Options(context={self.config_key(): value, **self.additional_match_options()})
+
+    def _match(self, options: Options) -> bool:
+        """Match verdict of the configuration-based path for the given options."""
+        return bool(self.feature_group_class().match_feature_group_criteria("my_result", options, None))
 
     # -- No source column ------------------------------------------------------
 
@@ -191,10 +229,7 @@ class MatchValidationTestBase:
         for bad_type in self.INVALID_TYPES:
             if bad_type == "":
                 continue
-            result = self.feature_group_class().match_feature_group_criteria(
-                "my_result", self._config_options(bad_type), None
-            )
-            assert result is False, f"Should reject via options: {bad_type!r}"
+            assert self._match(self._config_options(bad_type)) is False, f"Should reject via options: {bad_type!r}"
 
     # -- Special characters --------------------------------------------------
 
@@ -215,43 +250,86 @@ class MatchValidationTestBase:
 
     def test_none_type_rejected(self) -> None:
         """None as operation type in options must not match."""
-        result = self.feature_group_class().match_feature_group_criteria("my_result", self._config_options(None), None)
-        assert result is False
+        assert self._match(self._config_options(None)) is False
 
     def test_integer_type_rejected(self) -> None:
         """An integer as operation type in options must not match."""
-        result = self.feature_group_class().match_feature_group_criteria("my_result", self._config_options(42), None)
-        assert result is False
+        assert self._match(self._config_options(42)) is False
 
     # -- Single-token containers ---------------------------------------------
 
-    def test_single_element_container_matches(self) -> None:
-        """A bare token and its single-element containers must dispatch identically.
+    def _case_options(self, case: TokenCase, value: Any) -> Options:
+        """Options for ``case`` with its key holding ``value``."""
+        context: dict[str, Any] = {self.config_key(): self._primary_value(), **self.additional_match_options()}
+        context.update(case.context)
+        for key in case.without:
+            context.pop(key, None)
+        context[case.key] = value
+        return Options(context=context)
 
-        Core unwraps a one-element container when it reads a property value, so
-        ``("sum",)`` is valid caller syntax for one token: it has to match, and it
-        has to reach dispatch as ``"sum"`` rather than as ``"('sum',)"``.
-        """
-        operation = self.single_token_operation()
-        if operation is None:
+    @classmethod
+    def _required_when_predicates(cls) -> dict[str, Any]:
+        """The conditional-requirement predicates the feature group declares in PROPERTY_MAPPING."""
+        mapping = getattr(cls.feature_group_class(), "PROPERTY_MAPPING", None) or {}
+        predicates = {}
+        for key, entry in mapping.items():
+            predicate = entry.get(DefaultOptionKeys.required_when) if isinstance(entry, dict) else None
+            if callable(predicate):
+                predicates[key] = predicate
+        return predicates
+
+    def _dispatch_or_none(self, options: Options) -> list[Any] | None:
+        """Values the dispatch path resolves, or None for a state its extractors reject."""
+        try:
+            return self.dispatch_values(options)
+        except ValueError:
+            return None
+
+    def test_single_element_container_matches(self) -> None:
+        """A bare token and its single-element containers must match alike and dispatch alike."""
+        cases = [case for case in self.token_cases() if isinstance(case.token, str)]
+        if not cases:
             pytest.skip("config vocabulary is not a single string token")
-        for value in (operation, (operation,), [operation]):
-            options = self._config_options(value)
-            result = self.feature_group_class().match_feature_group_criteria("my_result", options, None)
-            assert result is True, f"Config path should accept: {value!r}"
-            for resolved in self.dispatch_values(options):
-                assert resolved == operation, f"Dispatch should resolve {value!r} to {operation!r}, got {resolved!r}"
+        for case in cases:
+            bare = self._case_options(case, case.token)
+            assert self._match(bare) is case.matches, f"{case.key}={case.token!r} should match: {case.matches}"
+            expected = self._dispatch_or_none(bare)
+            for value in ((case.token,), [case.token]):
+                options = self._case_options(case, value)
+                assert self._match(options) is case.matches, f"{case.key}={value!r} should match: {case.matches}"
+                assert self._dispatch_or_none(options) == expected, (
+                    f"{case.key}={value!r} should dispatch as {case.token!r}"
+                )
+
+    def test_single_element_container_preserves_requirements(self) -> None:
+        """A wrapped token must switch the same conditional requirements on as a bare one.
+
+        ``required_when`` predicates read the option raw, so this is where a container
+        that never gets unwrapped drops a requirement and lets an under-specified
+        feature match at discovery and fail at compute.
+        """
+        predicates = self._required_when_predicates()
+        cases = [case for case in self.token_cases() if isinstance(case.token, str)]
+        if not predicates or not cases:
+            pytest.skip("no required_when predicate keyed off a string token")
+        for case in cases:
+            bare = self._case_options(case, case.token)
+            expected = {key: bool(predicate(bare)) for key, predicate in predicates.items()}
+            for value in ((case.token,), [case.token]):
+                options = self._case_options(case, value)
+                resolved = {key: bool(predicate(options)) for key, predicate in predicates.items()}
+                assert resolved == expected, f"{case.key}={value!r} should require what {case.token!r} requires"
 
     def test_multi_element_container_rejected(self) -> None:
         """Two operations in one container are not one operation, whatever the container type."""
-        operations = [self.config_value(op) for op in sorted(self.parity_operations())[:2]]
-        if len(operations) < 2:
-            pytest.skip("fewer than two operations declared for this family")
-        for value in (operations, tuple(operations)):
-            result = self.feature_group_class().match_feature_group_criteria(
-                "my_result", self._config_options(value), None
-            )
-            assert result is False, f"Config path should reject: {value!r}"
+        cases = [case for case in self.token_cases() if case.other is not None and case.matches]
+        if not cases:
+            pytest.skip("no token key declares a second operation")
+        for case in cases:
+            for value in ([case.token, case.other], (case.token, case.other)):
+                assert self._match(self._case_options(case, value)) is False, (
+                    f"Config path should reject {case.key}={value!r}"
+                )
 
     # -- Case sensitivity ----------------------------------------------------
 
@@ -289,9 +367,7 @@ class MatchValidationTestBase:
 
     def _match_by_config(self, operation: str) -> bool:
         """Match verdict of the configuration-based path for the given operation."""
-        options = self._config_options(self.config_value(operation))
-        result = self.feature_group_class().match_feature_group_criteria("my_result", options, None)
-        return bool(result)
+        return self._match(self._config_options(self.config_value(operation)))
 
     def test_operations_match_on_both_paths(self) -> None:
         """Operations accepted by one path must be accepted by the other."""

--- a/mloda/testing/feature_groups/data_operations/match_validation.py
+++ b/mloda/testing/feature_groups/data_operations/match_validation.py
@@ -7,7 +7,7 @@ Provides ``MatchValidationTestBase`` with reusable test methods covering:
 - Special characters in the operation portion of feature names
 - Type confusion via Options (None, int, list)
 - Case sensitivity enforcement (lowercase only)
-- Declaration/dispatch drift between the name path and the config path (opt-in)
+- Declaration/dispatch drift between the name path and the config path
 
 Concrete test classes implement abstract methods to adapt these tests
 to each specific operation.
@@ -81,6 +81,15 @@ class MatchValidationTestBase:
         return Options()
 
     @classmethod
+    def config_value(cls, operation: str) -> Any:
+        """Map a name-path operation token to the value the config path expects.
+
+        Identity by default; override for families whose config vocabulary
+        differs from the feature name token (e.g. percentile's float).
+        """
+        return operation
+
+    @classmethod
     def options_reject_invalid_types(cls) -> bool:
         """Whether options-based matching rejects invalid operation types.
 
@@ -92,9 +101,10 @@ class MatchValidationTestBase:
     def parity_operations(cls) -> set[str]:
         """Operations that both the name path and the config path must accept.
 
-        Empty by default; override to opt in to the drift check.
+        Defaults to ``valid_operations()``; the drift check is opt-out, so
+        override only to narrow the set or to exempt an operation.
         """
-        return set()
+        return cls.valid_operations()
 
     @classmethod
     def malformed_operations(cls) -> set[str]:
@@ -187,7 +197,7 @@ class MatchValidationTestBase:
 
     def test_list_type_rejected(self) -> None:
         """A list as operation type in options must not match."""
-        valid_ops = list(self.valid_operations())[:2] or ["sum"]
+        valid_ops = [self.config_value(op) for op in list(self.valid_operations())[:2]] or ["sum"]
         context = {self.config_key(): valid_ops, **self.additional_match_options()}
         options = Options(context=context)
         result = self.feature_group_class().match_feature_group_criteria("my_result", options, None)
@@ -229,7 +239,7 @@ class MatchValidationTestBase:
 
     def _match_by_config(self, operation: str) -> bool:
         """Match verdict of the configuration-based path for the given operation."""
-        context = {self.config_key(): operation, **self.additional_match_options()}
+        context = {self.config_key(): self.config_value(operation), **self.additional_match_options()}
         result = self.feature_group_class().match_feature_group_criteria("my_result", Options(context=context), None)
         return bool(result)
 

--- a/mloda/testing/feature_groups/data_operations/match_validation.py
+++ b/mloda/testing/feature_groups/data_operations/match_validation.py
@@ -7,7 +7,9 @@ Provides ``MatchValidationTestBase`` with reusable test methods covering:
 - Special characters in the operation portion of feature names
 - Type confusion via Options (None, int, list)
 - Case sensitivity enforcement (lowercase only)
-- Declaration/dispatch drift between the name path and the config path
+- Declaration/dispatch drift between the name path and the config path: the
+  acceptance half is opt-out (``parity_operations``), the rejection half is
+  opt-in (``malformed_operations``)
 
 Concrete test classes implement abstract methods to adapt these tests
 to each specific operation.

--- a/mloda/testing/feature_groups/data_operations/match_validation.py
+++ b/mloda/testing/feature_groups/data_operations/match_validation.py
@@ -5,7 +5,9 @@ Provides ``MatchValidationTestBase`` with reusable test methods covering:
 - SQL injection in feature names
 - Invalid operation types (pattern-based and options-based)
 - Special characters in the operation portion of feature names
-- Type confusion via Options (None, int, list)
+- Type confusion via Options (None, int)
+- Single-element containers holding exactly one operation token, and the
+  multi-element containers that must stay rejected
 - Case sensitivity enforcement (lowercase only)
 - Declaration/dispatch drift between the name path and the config path: the
   acceptance half is opt-out (``parity_operations``), the rejection half is
@@ -92,6 +94,30 @@ class MatchValidationTestBase:
         return operation
 
     @classmethod
+    def single_token_operation(cls) -> str | None:
+        """The config-path operation token used for the single-element-container checks.
+
+        Defaults to the first parity operation whose config value is a string.
+        Families whose config vocabulary is not a token (percentile's float) get
+        ``None``, and the checks are skipped.
+        """
+        for operation in sorted(cls.parity_operations()):
+            value = cls.config_value(operation)
+            if isinstance(value, str):
+                return value
+        return None
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        """Operation values the dispatch path resolves from ``options``.
+
+        Empty by default, which checks the match verdict only. Override with the
+        family's extractors to also assert that a wrapped token reaches dispatch
+        unwrapped, rather than as the string form of its container.
+        """
+        return []
+
+    @classmethod
     def options_reject_invalid_types(cls) -> bool:
         """Whether options-based matching rejects invalid operation types.
 
@@ -115,6 +141,10 @@ class MatchValidationTestBase:
         Empty by default; override to opt in to the drift check.
         """
         return set()
+
+    def _config_options(self, value: Any) -> Options:
+        """Options carrying ``value`` as the operation on the configuration path."""
+        return Options(context={self.config_key(): value, **self.additional_match_options()})
 
     # -- No source column ------------------------------------------------------
 
@@ -161,9 +191,9 @@ class MatchValidationTestBase:
         for bad_type in self.INVALID_TYPES:
             if bad_type == "":
                 continue
-            context = {self.config_key(): bad_type, **self.additional_match_options()}
-            options = Options(context=context)
-            result = self.feature_group_class().match_feature_group_criteria("my_result", options, None)
+            result = self.feature_group_class().match_feature_group_criteria(
+                "my_result", self._config_options(bad_type), None
+            )
             assert result is False, f"Should reject via options: {bad_type!r}"
 
     # -- Special characters --------------------------------------------------
@@ -185,25 +215,43 @@ class MatchValidationTestBase:
 
     def test_none_type_rejected(self) -> None:
         """None as operation type in options must not match."""
-        context = {self.config_key(): None, **self.additional_match_options()}
-        options = Options(context=context)
-        result = self.feature_group_class().match_feature_group_criteria("my_result", options, None)
+        result = self.feature_group_class().match_feature_group_criteria("my_result", self._config_options(None), None)
         assert result is False
 
     def test_integer_type_rejected(self) -> None:
         """An integer as operation type in options must not match."""
-        context = {self.config_key(): 42, **self.additional_match_options()}
-        options = Options(context=context)
-        result = self.feature_group_class().match_feature_group_criteria("my_result", options, None)
+        result = self.feature_group_class().match_feature_group_criteria("my_result", self._config_options(42), None)
         assert result is False
 
-    def test_list_type_rejected(self) -> None:
-        """A list as operation type in options must not match."""
-        valid_ops = [self.config_value(op) for op in list(self.valid_operations())[:2]] or ["sum"]
-        context = {self.config_key(): valid_ops, **self.additional_match_options()}
-        options = Options(context=context)
-        result = self.feature_group_class().match_feature_group_criteria("my_result", options, None)
-        assert result is False
+    # -- Single-token containers ---------------------------------------------
+
+    def test_single_element_container_matches(self) -> None:
+        """A bare token and its single-element containers must dispatch identically.
+
+        Core unwraps a one-element container when it reads a property value, so
+        ``("sum",)`` is valid caller syntax for one token: it has to match, and it
+        has to reach dispatch as ``"sum"`` rather than as ``"('sum',)"``.
+        """
+        operation = self.single_token_operation()
+        if operation is None:
+            pytest.skip("config vocabulary is not a single string token")
+        for value in (operation, (operation,), [operation]):
+            options = self._config_options(value)
+            result = self.feature_group_class().match_feature_group_criteria("my_result", options, None)
+            assert result is True, f"Config path should accept: {value!r}"
+            for resolved in self.dispatch_values(options):
+                assert resolved == operation, f"Dispatch should resolve {value!r} to {operation!r}, got {resolved!r}"
+
+    def test_multi_element_container_rejected(self) -> None:
+        """Two operations in one container are not one operation, whatever the container type."""
+        operations = [self.config_value(op) for op in sorted(self.parity_operations())[:2]]
+        if len(operations) < 2:
+            pytest.skip("fewer than two operations declared for this family")
+        for value in (operations, tuple(operations)):
+            result = self.feature_group_class().match_feature_group_criteria(
+                "my_result", self._config_options(value), None
+            )
+            assert result is False, f"Config path should reject: {value!r}"
 
     # -- Case sensitivity ----------------------------------------------------
 
@@ -241,8 +289,8 @@ class MatchValidationTestBase:
 
     def _match_by_config(self, operation: str) -> bool:
         """Match verdict of the configuration-based path for the given operation."""
-        context = {self.config_key(): self.config_value(operation), **self.additional_match_options()}
-        result = self.feature_group_class().match_feature_group_criteria("my_result", Options(context=context), None)
+        options = self._config_options(self.config_value(operation))
+        result = self.feature_group_class().match_feature_group_criteria("my_result", options, None)
         return bool(result)
 
     def test_operations_match_on_both_paths(self) -> None:


### PR DESCRIPTION
Two issues in the `data_operations` tree. Nothing outside `mloda/` is touched.

## #332 Unwrap singleton operation tokens

`is_op_token` accepts `("sum",)` on purpose: core unwraps a one-element container when it reads a property value, so it is valid caller syntax for a single token. Matching therefore succeeded while dispatch stringified the raw option into `"('sum',)"`, matching no backend branch, and the feature failed at compute with an unsupported-operation error.

#330 covered frame_aggregate, rank and offset. This covers the nine families left, through eight sites, since `aggregation_base` and `arithmetic/base` are each shared by several families.

Two sites were not cosmetic. Both silently skipped a `required_when` check, so an under-specified feature matched at discovery and failed later:

- window_aggregation: `aggregation_type=("first",)` with no `order_by` matched, because `"('first',)"` is not in the order-dependent set.
- frame_aggregate: `frame_type=("rolling",)` with no `frame_size` matched, because `_needs_frame_size` compared the raw container against bare strings. #330 missed these two predicates in a family it otherwise covered.

The check lives in the shared `MatchValidationTestBase`, not once per family. It pairs the plain token with both container forms, asserts identical dispatch through a new `dispatch_values()` hook, and guards `is_op_token`'s arity contract with the multi-element rejection case (which subsumes the old `test_list_type_rejected` and covers tuples too). It reads the family's existing declarations, so a family opts in by declaring nothing; percentile, whose config vocabulary is a float rather than a token, skips instead of needing an exemption.

Families declare `TokenCase` entries rather than writing tests: a case names the token key, the options its state adds or drops, and the verdict that state must produce. That covers a second token-valued key (frame_aggregate's `frame_type` / `frame_unit`) and a state where a token turns a conditional requirement on or off (a sized frame with no `frame_size`, `first` with no `order_by`), so no family hand-rolls the check any more.

The `required_when` predicates get their own shared check, with nothing to declare: the base walks the family's `PROPERTY_MAPPING` and asserts a wrapped token switches the same requirements on as a bare one. That is where `_needs_frame_unit` reading its option raw shows up, since the matcher's own frame-unit guard hides it from the match verdict.

## #331 Turn the parity check on everywhere

`parity_operations()` defaulted to an empty set, so the name/config drift check was skipped by every family that did not opt in: 6 passed, 20 skipped. A green run was weak evidence that declarations match dispatch. It now defaults to `valid_operations()`.

Turning it on found **no genuine declaration/dispatch drift**. All three failures were gaps in the test scaffolding, which is itself the finding: those options were only ever exercised for rejection, so nothing required them to be complete.

- aggregation and window_aggregation were missing `partition_by` (and `order_by` for `first`/`last`). Several of their rejection tests had been passing because the name path could not match at all, not because the operation was invalid.
- percentile needed a `config_value()` hook: its config vocabulary is a float in `[0.0, 1.0]` while its name token is `pN`. Exempting the family would have dropped all 8 operations from coverage.

`malformed_operations()` stays opt-in, since malformed tokens are family-specific.

## Gate

```
4476 passed, 171 skipped
ruff format --check   435 files already formatted
ruff check            All checks passed
mypy --strict         no issues found in 435 source files
bandit                OK
```

Skips moved from 168 to 171: the 10 parity checks #331 switched on, less the single-token check percentile skips, plus the 12 families that declare no `required_when` predicate. The passed count falls because the hand-written single-token classes collapse into three inherited tests per family.

Checked by mutation, not by a green run: reverting `op_token_value` to `str` fails all twelve families, reverting either frame_aggregate predicate to read its option raw fails the requirements check, and reverting window's `_resolve_agg_type` flips `first`-without-`order_by` from reject to match.

## Scope note

This PR originally also carried #335 and #310. Both were pulled back out.

- **#335** is already fixed on main by #333, which switched the gate to tox-uv's `uv-venv-lock-runner` with `--frozen`. That is the same fix mloda core applied in mloda-ai/mloda#806. The version ceilings this PR had added to `pyproject.toml` were verified inert: with all seven removed, a wiped tox env still installs the identical locked versions, because `--frozen` never re-resolves. They would only have added a hand-edited ceiling to every dependency bump that is otherwise a reviewable lock diff.
- **#310** needs a published mloda carrying the core constructor change. The interim patch it offers as a fallback would be deleted by the real fix, so it was not worth shipping.

## Review

Two independent deep reviews. Findings that applied to the two issues here are folded into the third commit: two silent narrowings in the rank and offset parity overrides (they predated the default flip and became narrowings once it landed), a dead override, the missing multi-element rejection cases, two sites still leaning on `op_token_value(None)` comparing unequal, and a docstring that overstated coverage.

Filed separately: #339, where `scalar_arithmetic`'s `constant` and the shared `order_by` accept a container at match time and then raise at compute, the same shape #332 fixes for operation keys.

Closes #332, closes #331.

