### PR TITLE
fix(data_operations): guard the arity of every scalar PROPERTY_MAPPING key

### DIFF
--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -110,9 +110,9 @@ def _unwrap_singleton(value: Any) -> Any:
     The arity rule every scalar guard and unwrapper below shares, in one place. Core unwraps a
     singleton container when it reads a property value (``_unpack_property_value``,
     ``FeatureGroup.resolve_subtype``), so a one-element container is valid caller syntax for one
-    value. A multi-element or empty container is returned unchanged, which fails every guard's
-    type check: strict membership checks the elements one by one and would otherwise wrongly
-    match a composite value such as ``["sum", "max"]``.
+    value. A multi-element or empty container is returned unchanged, which fails every scalar
+    guard's type check: strict membership checks the elements one by one and would otherwise
+    wrongly match a composite value such as ``["sum", "max"]``.
     """
     if isinstance(value, (list, tuple, set, frozenset)) and len(value) == 1:
         (element,) = value

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from enum import Enum
+from typing import Any, TypeVar
+
+from mloda.core.abstract_plugins.components.options import Options
+
+T = TypeVar("T")
 
 
 # ---------------------------------------------------------------------------
@@ -94,31 +100,75 @@ class NullPolicy(str, Enum):
 
 
 # ---------------------------------------------------------------------------
-# Shared PROPERTY_MAPPING guards
+# Shared PROPERTY_MAPPING guards and their read-site unwrappers
 # ---------------------------------------------------------------------------
+
+
+def _unwrap_singleton(value: Any) -> Any:
+    """The one element of a single-element container, or the value itself.
+
+    The arity rule every scalar guard and unwrapper below shares, in one place. Core unwraps a
+    singleton container when it reads a property value (``_unpack_property_value``,
+    ``FeatureGroup.resolve_subtype``), so a one-element container is valid caller syntax for one
+    value. A multi-element or empty container is returned unchanged, which fails every guard's
+    type check: strict membership checks the elements one by one and would otherwise wrongly
+    match a composite value such as ``["sum", "max"]``.
+    """
+    if isinstance(value, (list, tuple, set, frozenset)) and len(value) == 1:
+        (element,) = value
+        return element
+    return value
+
+
+def option_value(options: Options, key: str, unwrap: Callable[[Any], T]) -> T | None:
+    """The option under ``key`` unwrapped from its container; None when the option is absent.
+
+    Absent stays None instead of being routed through an unwrapper (which would turn it into
+    the string ``"None"``), so a missing option keeps its family's absent-value behavior.
+    """
+    value = options.get(key)
+    return None if value is None else unwrap(value)
 
 
 def is_op_token(value: object) -> bool:
     """True for exactly one operation token: a non-empty string, bare or in a single-element container.
 
-    The guard is about arity, not Python syntax. Core unwraps a singleton container when it
-    reads a property value (``_unpack_property_value``, ``FeatureGroup.resolve_subtype``), so
-    ``("sum",)`` is valid caller syntax for one token. Multi-element and empty values are rejected:
-    strict membership checks the elements one by one and would otherwise wrongly match a composite
-    value such as ``["sum", "max"]``.
+    The guard is about arity, not Python syntax: ``("sum",)`` is one token, while ``["sum", "max"]``
+    is a composite value that strict membership would otherwise wrongly match element by element.
     """
-    if isinstance(value, (list, tuple, set, frozenset)):
-        if len(value) != 1:
-            return False
-        (value,) = value
-    return isinstance(value, str) and bool(value)
+    token = _unwrap_singleton(value)
+    return isinstance(token, str) and bool(token)
 
 
 def op_token_value(value: object) -> str:
     """The single token of a value is_op_token accepts, unwrapped from its container."""
-    if isinstance(value, (list, tuple, set, frozenset)) and len(value) == 1:
-        (value,) = value
-    return str(value)
+    return str(_unwrap_singleton(value))
+
+
+def is_column_ref(value: object) -> bool:
+    """True for exactly one column name: a non-empty string, bare or in a single-element container.
+
+    Same value space and arity rule as is_op_token, delegated rather than copied; the second name
+    exists for the declaration sites, where a column reference reads nothing like an op token.
+    """
+    return is_op_token(value)
+
+
+def column_ref_value(value: object) -> str:
+    """The single column name of a value is_column_ref accepts, unwrapped from its container."""
+    return op_token_value(value)
+
+
+def is_scalar_number(value: object) -> bool:
+    """True for exactly one int or float, bare or in a single-element container (bool is not a number)."""
+    number = _unwrap_singleton(value)
+    return isinstance(number, (int, float)) and not isinstance(number, bool)
+
+
+def scalar_number_value(value: object) -> int | float:
+    """The single number of a value is_scalar_number accepts, unwrapped from its container."""
+    number: int | float = _unwrap_singleton(value)
+    return number
 
 
 def _is_feature_ref(value: object) -> bool:
@@ -137,8 +187,15 @@ def is_in_features_value(value: object) -> bool:
 
 
 def is_positive_int(value: object) -> bool:
-    """True only for a positive int (rejects bool, non-int, and n < 1)."""
-    return isinstance(value, int) and not isinstance(value, bool) and value >= 1
+    """True only for exactly one positive int, bare or in a single-element container (rejects bool, non-int, n < 1)."""
+    n = _unwrap_singleton(value)
+    return isinstance(n, int) and not isinstance(n, bool) and n >= 1
+
+
+def positive_int_value(value: object) -> int:
+    """The single int of a value is_positive_int accepts, unwrapped from its container."""
+    n: int = _unwrap_singleton(value)
+    return n
 
 
 #: ASCII decimal >= 1. str.isdigit also accepts superscripts (int() raises) and non-ASCII digits.

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -46,6 +46,13 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import (
+    column_ref_value,
+    is_column_ref,
+    is_op_token,
+    op_token_value,
+)
+
 # Order-independent aggregations supported in v1. Order-dependent aggregations
 # (e.g. ``first`` / ``last``) and ``median`` are deliberately excluded.
 RESAMPLE_AGGS: dict[str, str] = {
@@ -100,11 +107,11 @@ def _parse_resample_op(token: str) -> tuple[int, str, str]:
 
 
 def _is_valid_resample_op(value: object) -> bool:
-    """True when value is a parseable '{n}_{unit}_{agg}' resample token."""
-    if not isinstance(value, str):
+    """True when value is exactly one parseable '{n}_{unit}_{agg}' resample token, bare or in a container."""
+    if not is_op_token(value):
         return False
     try:
-        _parse_resample_op(value)
+        _parse_resample_op(op_token_value(value))
     except ValueError:
         return False
     return True
@@ -141,6 +148,7 @@ class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Column to floor into fixed-freq buckets",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_column_ref,
         },
         RESAMPLE_OP: {
             "explanation": "Resample token '{n}_{unit}_{agg}' (e.g. '1_hour_mean') when the op is not encoded in the feature name.",
@@ -225,7 +233,7 @@ class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         op = feature.options.get(cls.RESAMPLE_OP)
         if op is None:
             raise ValueError(f"Could not extract resample op for {feature.name}")
-        return str(op)
+        return op_token_value(op)
 
     @classmethod
     def _extract_partition_by(cls, feature: Feature) -> list[str]:
@@ -241,7 +249,7 @@ class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         time_column = feature.options.get(cls.TIME_COLUMN)
         if time_column is None:
             raise ValueError("resample requires a 'time_column' in Options context.")
-        return str(time_column)
+        return column_ref_value(time_column)
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import pytest
@@ -67,51 +68,6 @@ class TestResampleOpConfig:
         assert ResampleFeatureGroup.RESAMPLE_OP in ResampleFeatureGroup.PROPERTY_MAPPING
 
 
-class TestScalarKeyArity:
-    """Scalar-key checks the shared harness cannot express.
-
-    The bare / single-element / multi-element verdicts for ``time_column`` and
-    ``resample_op`` live in ``TestResampleMatchValidation``; what stays here is the
-    wrong-type and value-space rejections plus the direct extractor calls.
-    """
-
-    def _options(self, **overrides: Any) -> Options:
-        context: dict[str, Any] = {
-            "in_features": "value_int",
-            "time_column": "timestamp",
-            "resample_op": "1_hour_mean",
-            "partition_by": ["region"],
-        }
-        context.update(overrides)
-        return Options(context=context)
-
-    def test_wrong_type_time_column_rejected(self) -> None:
-        result = ResampleFeatureGroup.match_feature_group_criteria("my_result", self._options(time_column=123), None)
-        assert result is False
-
-    def test_invalid_singleton_resample_op_rejected(self) -> None:
-        """Unwrapping does not widen the value space: the token parser still owns it."""
-        result = ResampleFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(resample_op=("not_a_token",)), None
-        )
-        assert result is False
-
-    @pytest.mark.parametrize("time_column", ["timestamp", ("timestamp",), ["timestamp"]])
-    def test_extract_time_column_unwraps_to_bare_column(self, time_column: Any) -> None:
-        feature = Feature("my_result", options=self._options(time_column=time_column))
-        assert ResampleFeatureGroup._extract_time_column(feature) == "timestamp"
-
-    def test_extract_time_column_raises_when_missing(self) -> None:
-        feature = Feature("my_result", options=Options())
-        with pytest.raises(ValueError, match="time_column"):
-            ResampleFeatureGroup._extract_time_column(feature)
-
-    @pytest.mark.parametrize("resample_op", ["1_hour_mean", ("1_hour_mean",), ["1_hour_mean"]])
-    def test_extract_resample_op_unwraps_to_bare_token(self, resample_op: Any) -> None:
-        feature = Feature("my_result", options=self._options(resample_op=resample_op))
-        assert ResampleFeatureGroup._extract_resample_op(feature) == "1_hour_mean"
-
-
 class TestResampleMatchValidation(MatchValidationTestBase):
     """Shared match-validation tests adapted for resample.
 
@@ -153,8 +109,10 @@ class TestResampleMatchValidation(MatchValidationTestBase):
 
     @classmethod
     def token_cases(cls) -> list[TokenCase]:
-        # time_column names one column.
-        return [*super().token_cases(), TokenCase("time_column", "timestamp", "event_date")]
+        # Unwrapping does not widen the value space: the token parser still owns resample_op.
+        primary = replace(super().token_cases()[0], invalid=("not_a_token",))
+        # time_column names one column, and resampling cannot pick a time axis without it.
+        return [primary, TokenCase("time_column", "timestamp", "event_date", required=True)]
 
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_changing.resample.base import (
@@ -67,7 +68,12 @@ class TestResampleOpConfig:
 
 
 class TestScalarKeyArity:
-    """``time_column`` and ``resample_op`` are scalar keys: one value, bare or in a one-element container."""
+    """Scalar-key checks the shared harness cannot express.
+
+    The bare / single-element / multi-element verdicts for ``time_column`` and
+    ``resample_op`` live in ``TestResampleMatchValidation``; what stays here is the
+    wrong-type and value-space rejections plus the direct extractor calls.
+    """
 
     def _options(self, **overrides: Any) -> Options:
         context: dict[str, Any] = {
@@ -79,32 +85,14 @@ class TestScalarKeyArity:
         context.update(overrides)
         return Options(context=context)
 
-    @pytest.mark.parametrize("time_column", ["timestamp", ("timestamp",), ["timestamp"]])
-    def test_singleton_time_column_matches(self, time_column: Any) -> None:
-        result = ResampleFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(time_column=time_column), None
-        )
-        assert result is True
-
-    @pytest.mark.parametrize("time_column", [["timestamp", "region"], ("timestamp", "region"), 123])
-    def test_invalid_time_column_rejected(self, time_column: Any) -> None:
-        result = ResampleFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(time_column=time_column), None
-        )
+    def test_wrong_type_time_column_rejected(self) -> None:
+        result = ResampleFeatureGroup.match_feature_group_criteria("my_result", self._options(time_column=123), None)
         assert result is False
 
-    @pytest.mark.parametrize("resample_op", ["1_hour_mean", ("1_hour_mean",), ["1_hour_mean"]])
-    def test_singleton_resample_op_matches(self, resample_op: Any) -> None:
-        result = ResampleFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(resample_op=resample_op), None
-        )
-        assert result is True
-
-    @pytest.mark.parametrize("resample_op", [["1_hour_mean", "1_day_sum"], ("not_a_token",)])
-    def test_invalid_resample_op_rejected(self, resample_op: Any) -> None:
+    def test_invalid_singleton_resample_op_rejected(self) -> None:
         """Unwrapping does not widen the value space: the token parser still owns it."""
         result = ResampleFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(resample_op=resample_op), None
+            "my_result", self._options(resample_op=("not_a_token",)), None
         )
         assert result is False
 
@@ -122,3 +110,56 @@ class TestScalarKeyArity:
     def test_extract_resample_op_unwraps_to_bare_token(self, resample_op: Any) -> None:
         feature = Feature("my_result", options=self._options(resample_op=resample_op))
         assert ResampleFeatureGroup._extract_resample_op(feature) == "1_hour_mean"
+
+
+class TestResampleMatchValidation(MatchValidationTestBase):
+    """Shared match-validation tests adapted for resample.
+
+    The operation is the whole ``{n}_{unit}_{agg}`` token, on the name path as the
+    suffix of ``__resample_`` and on the config path as ``resample_op``.
+    """
+
+    @classmethod
+    def feature_group_class(cls) -> Any:
+        return ResampleFeatureGroup
+
+    @classmethod
+    def valid_operations(cls) -> set[str]:
+        return {"1_hour_mean", "15_minute_sum", "2_day_count", "1_hour_min", "3_hour_max"}
+
+    @classmethod
+    def config_key(cls) -> str:
+        return "resample_op"
+
+    @classmethod
+    def build_feature_name(cls, operation: str) -> str:
+        return f"value_int__resample_{operation}"
+
+    @classmethod
+    def build_feature_name_no_source(cls) -> str:
+        return "resample_1_hour_mean"
+
+    @classmethod
+    def additional_match_options(cls) -> dict[str, Any]:
+        return {"in_features": "value_int", "time_column": "timestamp", "partition_by": ["region"]}
+
+    @classmethod
+    def pattern_match_options(cls) -> Options:
+        return Options(context={"time_column": "timestamp", "partition_by": ["region"]})
+
+    @classmethod
+    def malformed_operations(cls) -> set[str]:
+        return {"0_hour_mean", "1_century_mean", "1_hour_median"}
+
+    @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        # time_column names one column.
+        return [*super().token_cases(), TokenCase("time_column", "timestamp", "event_date")]
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        feature = Feature("my_result", options=options)
+        return [
+            ResampleFeatureGroup._extract_resample_op(feature),
+            ResampleFeatureGroup._extract_time_column(feature),
+        ]

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
@@ -62,3 +64,61 @@ class TestResampleOpConfig:
 
     def test_resample_op_in_property_mapping(self) -> None:
         assert ResampleFeatureGroup.RESAMPLE_OP in ResampleFeatureGroup.PROPERTY_MAPPING
+
+
+class TestScalarKeyArity:
+    """``time_column`` and ``resample_op`` are scalar keys: one value, bare or in a one-element container."""
+
+    def _options(self, **overrides: Any) -> Options:
+        context: dict[str, Any] = {
+            "in_features": "value_int",
+            "time_column": "timestamp",
+            "resample_op": "1_hour_mean",
+            "partition_by": ["region"],
+        }
+        context.update(overrides)
+        return Options(context=context)
+
+    @pytest.mark.parametrize("time_column", ["timestamp", ("timestamp",), ["timestamp"]])
+    def test_singleton_time_column_matches(self, time_column: Any) -> None:
+        result = ResampleFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(time_column=time_column), None
+        )
+        assert result is True
+
+    @pytest.mark.parametrize("time_column", [["timestamp", "region"], ("timestamp", "region"), 123])
+    def test_invalid_time_column_rejected(self, time_column: Any) -> None:
+        result = ResampleFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(time_column=time_column), None
+        )
+        assert result is False
+
+    @pytest.mark.parametrize("resample_op", ["1_hour_mean", ("1_hour_mean",), ["1_hour_mean"]])
+    def test_singleton_resample_op_matches(self, resample_op: Any) -> None:
+        result = ResampleFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(resample_op=resample_op), None
+        )
+        assert result is True
+
+    @pytest.mark.parametrize("resample_op", [["1_hour_mean", "1_day_sum"], ("not_a_token",)])
+    def test_invalid_resample_op_rejected(self, resample_op: Any) -> None:
+        """Unwrapping does not widen the value space: the token parser still owns it."""
+        result = ResampleFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(resample_op=resample_op), None
+        )
+        assert result is False
+
+    @pytest.mark.parametrize("time_column", ["timestamp", ("timestamp",), ["timestamp"]])
+    def test_extract_time_column_unwraps_to_bare_column(self, time_column: Any) -> None:
+        feature = Feature("my_result", options=self._options(time_column=time_column))
+        assert ResampleFeatureGroup._extract_time_column(feature) == "timestamp"
+
+    def test_extract_time_column_raises_when_missing(self) -> None:
+        feature = Feature("my_result", options=Options())
+        with pytest.raises(ValueError, match="time_column"):
+            ResampleFeatureGroup._extract_time_column(feature)
+
+    @pytest.mark.parametrize("resample_op", ["1_hour_mean", ("1_hour_mean",), ["1_hour_mean"]])
+    def test_extract_resample_op_unwraps_to_bare_token(self, resample_op: Any) -> None:
+        feature = Feature("my_result", options=self._options(resample_op=resample_op))
+        assert ResampleFeatureGroup._extract_resample_op(feature) == "1_hour_mean"

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -12,7 +12,12 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
-from mloda.community.feature_groups.data_operations.base import is_op_token, is_positive_int, op_token_value
+from mloda.community.feature_groups.data_operations.base import (
+    is_op_token,
+    is_positive_int,
+    op_token_value,
+    positive_int_value,
+)
 
 BINNING_OPS = {
     "bin": "Equal-width binning (value range divided into n equal intervals)",
@@ -82,7 +87,7 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         n = feature.options.get(cls.N_BINS)
         if op is None or n is None:
             raise ValueError(f"Could not extract binning parameters for {feature_name}")
-        n_bins = int(n)
+        n_bins = positive_int_value(n)
         cls._validate_n_bins(n_bins, feature_name)
         return op_token_value(op), n_bins
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -87,7 +87,8 @@ class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         n = feature.options.get(cls.N_BINS)
         if op is None or n is None:
             raise ValueError(f"Could not extract binning parameters for {feature_name}")
-        n_bins = positive_int_value(n)
+        # Unwrap, then coerce: the guard keeps a float out at match time, a direct call still gets an int.
+        n_bins = int(positive_int_value(n))
         cls._validate_n_bins(n_bins, feature_name)
         return op_token_value(op), n_bins
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -153,27 +153,13 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
-class TestNBinsArity:
-    """``n_bins`` checks the shared harness cannot express.
+class TestNBinsCoercion:
+    """The ``n_bins`` check the arity harness cannot express.
 
-    The bare / single-element / multi-element verdicts live in
-    ``TestBinningMatchValidation.token_cases``; what stays here is the value-space
-    rejections and what ``_extract_binning_params`` must return on a direct call.
+    Every arity verdict for ``n_bins`` (bare, wrapped, multi-element, wrong type and the
+    values outside its value space) is declared on ``TestBinningMatchValidation``; what
+    stays here is the return type a direct extractor call owes its caller.
     """
-
-    def _options(self, n_bins: Any) -> Options:
-        return Options(context={"binning_op": "bin", "n_bins": n_bins, "in_features": "value_int"})
-
-    @pytest.mark.parametrize("n_bins", [(0,), (True,), ("5",)])
-    def test_invalid_singleton_rejected(self, n_bins: Any) -> None:
-        """Unwrapping does not widen the value space: the positive-int rule still applies."""
-        result = BinningFeatureGroup.match_feature_group_criteria("my_result", self._options(n_bins), None)
-        assert result is False
-
-    @pytest.mark.parametrize("n_bins", [5, (5,), [5]])
-    def test_extract_binning_params_unwraps_to_bare_value(self, n_bins: Any) -> None:
-        feature = Feature("my_result", options=self._options(n_bins))
-        assert BinningFeatureGroup._extract_binning_params(feature) == ("bin", 5)
 
     @pytest.mark.parametrize("n_bins", [5, (5,), 5.9, (5.9,)])
     def test_extract_binning_params_returns_an_int(self, n_bins: Any) -> None:
@@ -182,7 +168,8 @@ class TestNBinsArity:
         ``is_positive_int`` keeps a float out at match time, so only a direct call can
         reach here with one, and it must still hand the backend an int bin count.
         """
-        _, extracted = BinningFeatureGroup._extract_binning_params(Feature("my_result", options=self._options(n_bins)))
+        options = Options(context={"binning_op": "bin", "n_bins": n_bins, "in_features": "value_int"})
+        _, extracted = BinningFeatureGroup._extract_binning_params(Feature("my_result", options=options))
         assert extracted == 5
         assert isinstance(extracted, int)
 
@@ -229,8 +216,8 @@ class TestBinningMatchValidation(MatchValidationTestBase):
 
     @classmethod
     def token_cases(cls) -> list[TokenCase]:
-        # n_bins is scalar too: one positive int.
-        return [*super().token_cases(), TokenCase("n_bins", 5, 10)]
+        # n_bins is scalar too: one positive int, so zero, a bool and a digit string stay out.
+        return [*super().token_cases(), TokenCase("n_bins", 5, 10, invalid=(0, True, "5"))]
 
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.binning.base import (
@@ -154,18 +154,18 @@ class TestConfigBasedFeatures:
 
 
 class TestNBinsArity:
-    """``n_bins`` is a scalar key: one positive int, bare or in a single-element container."""
+    """``n_bins`` checks the shared harness cannot express.
+
+    The bare / single-element / multi-element verdicts live in
+    ``TestBinningMatchValidation.token_cases``; what stays here is the value-space
+    rejections and what ``_extract_binning_params`` must return on a direct call.
+    """
 
     def _options(self, n_bins: Any) -> Options:
         return Options(context={"binning_op": "bin", "n_bins": n_bins, "in_features": "value_int"})
 
-    @pytest.mark.parametrize("n_bins", [5, (5,), [5]])
-    def test_singleton_matches(self, n_bins: Any) -> None:
-        result = BinningFeatureGroup.match_feature_group_criteria("my_result", self._options(n_bins), None)
-        assert result is True
-
-    @pytest.mark.parametrize("n_bins", [[5, 10], (5, 10), (0,), (True,), ("5",)])
-    def test_multi_element_and_invalid_singleton_rejected(self, n_bins: Any) -> None:
+    @pytest.mark.parametrize("n_bins", [(0,), (True,), ("5",)])
+    def test_invalid_singleton_rejected(self, n_bins: Any) -> None:
         """Unwrapping does not widen the value space: the positive-int rule still applies."""
         result = BinningFeatureGroup.match_feature_group_criteria("my_result", self._options(n_bins), None)
         assert result is False
@@ -174,6 +174,17 @@ class TestNBinsArity:
     def test_extract_binning_params_unwraps_to_bare_value(self, n_bins: Any) -> None:
         feature = Feature("my_result", options=self._options(n_bins))
         assert BinningFeatureGroup._extract_binning_params(feature) == ("bin", 5)
+
+    @pytest.mark.parametrize("n_bins", [5, (5,), 5.9, (5.9,)])
+    def test_extract_binning_params_returns_an_int(self, n_bins: Any) -> None:
+        """The signature says ``tuple[str, int]``: a direct call must coerce, not just unwrap.
+
+        ``is_positive_int`` keeps a float out at match time, so only a direct call can
+        reach here with one, and it must still hand the backend an int bin count.
+        """
+        _, extracted = BinningFeatureGroup._extract_binning_params(Feature("my_result", options=self._options(n_bins)))
+        assert extracted == 5
+        assert isinstance(extracted, int)
 
 
 class TestReturnDataTypeRule:
@@ -217,6 +228,10 @@ class TestBinningMatchValidation(MatchValidationTestBase):
         return {"in_features": "value_int", "n_bins": 5}
 
     @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        # n_bins is scalar too: one positive int.
+        return [*super().token_cases(), TokenCase("n_bins", 5, 10)]
+
+    @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:
-        binning_op, _ = BinningFeatureGroup._extract_binning_params(Feature("my_result", options=options))
-        return [binning_op]
+        return list(BinningFeatureGroup._extract_binning_params(Feature("my_result", options=options)))

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -153,6 +153,29 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestNBinsArity:
+    """``n_bins`` is a scalar key: one positive int, bare or in a single-element container."""
+
+    def _options(self, n_bins: Any) -> Options:
+        return Options(context={"binning_op": "bin", "n_bins": n_bins, "in_features": "value_int"})
+
+    @pytest.mark.parametrize("n_bins", [5, (5,), [5]])
+    def test_singleton_matches(self, n_bins: Any) -> None:
+        result = BinningFeatureGroup.match_feature_group_criteria("my_result", self._options(n_bins), None)
+        assert result is True
+
+    @pytest.mark.parametrize("n_bins", [[5, 10], (5, 10), (0,), (True,), ("5",)])
+    def test_multi_element_and_invalid_singleton_rejected(self, n_bins: Any) -> None:
+        """Unwrapping does not widen the value space: the positive-int rule still applies."""
+        result = BinningFeatureGroup.match_feature_group_criteria("my_result", self._options(n_bins), None)
+        assert result is False
+
+    @pytest.mark.parametrize("n_bins", [5, (5,), [5]])
+    def test_extract_binning_params_unwraps_to_bare_value(self, n_bins: Any) -> None:
+        feature = Feature("my_result", options=self._options(n_bins))
+        assert BinningFeatureGroup._extract_binning_params(feature) == ("bin", 5)
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type for deterministic ops.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
@@ -50,6 +50,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import column_ref_value, is_column_ref
+
 
 class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """Base class for exponential-moving-average operations that preserve row count."""
@@ -77,6 +79,7 @@ class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Column to order by (ascending) within each partition",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_column_ref,
         },
     }
 
@@ -150,7 +153,7 @@ class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         order_by = feature.options.get(cls.ORDER_BY)
         if order_by is None:
             raise ValueError("ema requires an 'order_by' column in Options context.")
-        return str(order_by)
+        return column_ref_value(order_by)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/tests/test_base.py
@@ -25,7 +25,11 @@ from mloda.community.feature_groups.data_operations.row_preserving.ema.pandas_em
 
 
 class TestOrderByArity:
-    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+    """``order_by`` is a scalar key: one column, bare or in a single-element container.
+
+    ema declares no operation config key (the span is part of the feature name), so
+    ``MatchValidationTestBase`` does not fit it and these checks are hand-rolled.
+    """
 
     def _options(self, order_by: Any) -> Options:
         return Options(context={"order_by": order_by, "partition_by": ["region"]})

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/tests/test_base.py
@@ -1,0 +1,61 @@
+"""Tests for EmaFeatureGroup base class.
+
+Covers the arity contract of the scalar ``order_by`` key: core unwraps a
+one-element container when it reads a property value, so ``("timestamp",)`` is
+valid caller syntax for one column and must dispatch to ``"timestamp"`` rather
+than to the container's string form. Match tests use ``PandasEma`` (the ema
+convention, mirroring ``TestEmaMatchFeatureGroupCriteria`` in test_integration).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.testing.data_creator.base import DataOperationsTestDataCreator
+from mloda.user import Feature
+
+from mloda.community.feature_groups.data_operations.row_preserving.ema.base import EmaFeatureGroup
+from mloda.community.feature_groups.data_operations.row_preserving.ema.pandas_ema import PandasEma
+
+
+class TestOrderByArity:
+    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+
+    def _options(self, order_by: Any) -> Options:
+        return Options(context={"order_by": order_by, "partition_by": ["region"]})
+
+    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
+    def test_singleton_matches(self, order_by: Any) -> None:
+        assert PandasEma.match_feature_group_criteria("value_float__ema_2", self._options(order_by)) is True
+
+    @pytest.mark.parametrize("order_by", [["timestamp", "region"], ("timestamp", "region")])
+    def test_multi_element_rejected(self, order_by: Any) -> None:
+        assert PandasEma.match_feature_group_criteria("value_float__ema_2", self._options(order_by)) is False
+
+    def test_wrong_type_rejected(self) -> None:
+        assert PandasEma.match_feature_group_criteria("value_float__ema_2", self._options(123)) is False
+
+    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
+    def test_extract_order_by_unwraps_to_bare_column(self, order_by: Any) -> None:
+        feature = Feature("value_float__ema_2", options=self._options(order_by))
+        assert EmaFeatureGroup._extract_order_by(feature) == "timestamp"
+
+    def test_extract_order_by_raises_when_missing(self) -> None:
+        feature = Feature("value_float__ema_2", options=Options())
+        with pytest.raises(ValueError, match="order_by"):
+            EmaFeatureGroup._extract_order_by(feature)
+
+    def test_singleton_order_by_dispatches_like_bare(self) -> None:
+        def _compute(order_by: Any) -> list[Any]:
+            df = pd.DataFrame(DataOperationsTestDataCreator.get_raw_data())
+            fs = FeatureSet()
+            fs.add(Feature("value_float__ema_2", options=self._options(order_by)))
+            return list(PandasEma.calculate_feature(df, fs)["value_float__ema_2"].astype(str))
+
+        assert _compute(("timestamp",)) == _compute("timestamp")

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/tests/test_base.py
@@ -15,51 +15,52 @@ import pytest
 
 pd = pytest.importorskip("pandas")
 
-from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.base import DataOperationsTestDataCreator
+from mloda.testing.feature_groups.data_operations.helpers import extract_column, feature_set_for
+from mloda.testing.feature_groups.data_operations.match_validation import ScalarArityTestBase, TokenCase
 from mloda.user import Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.ema.base import EmaFeatureGroup
 from mloda.community.feature_groups.data_operations.row_preserving.ema.pandas_ema import PandasEma
 
+FEATURE_NAME = "value_float__ema_2"
 
-class TestOrderByArity:
+
+class TestOrderByArity(ScalarArityTestBase):
     """``order_by`` is a scalar key: one column, bare or in a single-element container.
 
-    ema declares no operation config key (the span is part of the feature name), so
-    ``MatchValidationTestBase`` does not fit it and these checks are hand-rolled.
+    ema declares no operation config key (the span is part of the feature name), so it
+    declares the arity base directly instead of ``MatchValidationTestBase``.
     """
 
-    def _options(self, order_by: Any) -> Options:
-        return Options(context={"order_by": order_by, "partition_by": ["region"]})
+    @classmethod
+    def feature_group_class(cls) -> Any:
+        return EmaFeatureGroup
 
-    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
-    def test_singleton_matches(self, order_by: Any) -> None:
-        assert PandasEma.match_feature_group_criteria("value_float__ema_2", self._options(order_by)) is True
+    @classmethod
+    def match_class(cls) -> Any:
+        return PandasEma
 
-    @pytest.mark.parametrize("order_by", [["timestamp", "region"], ("timestamp", "region")])
-    def test_multi_element_rejected(self, order_by: Any) -> None:
-        assert PandasEma.match_feature_group_criteria("value_float__ema_2", self._options(order_by)) is False
+    @classmethod
+    def match_feature_name(cls) -> str:
+        return FEATURE_NAME
 
-    def test_wrong_type_rejected(self) -> None:
-        assert PandasEma.match_feature_group_criteria("value_float__ema_2", self._options(123)) is False
+    @classmethod
+    def base_context(cls) -> dict[str, Any]:
+        return {"partition_by": ["region"]}
 
-    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
-    def test_extract_order_by_unwraps_to_bare_column(self, order_by: Any) -> None:
-        feature = Feature("value_float__ema_2", options=self._options(order_by))
-        assert EmaFeatureGroup._extract_order_by(feature) == "timestamp"
+    @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        return [TokenCase("order_by", "timestamp", "region", required=True)]
 
-    def test_extract_order_by_raises_when_missing(self) -> None:
-        feature = Feature("value_float__ema_2", options=Options())
-        with pytest.raises(ValueError, match="order_by"):
-            EmaFeatureGroup._extract_order_by(feature)
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [EmaFeatureGroup._extract_order_by(Feature(FEATURE_NAME, options=options))]
 
-    def test_singleton_order_by_dispatches_like_bare(self) -> None:
-        def _compute(order_by: Any) -> list[Any]:
-            df = pd.DataFrame(DataOperationsTestDataCreator.get_raw_data())
-            fs = FeatureSet()
-            fs.add(Feature("value_float__ema_2", options=self._options(order_by)))
-            return list(PandasEma.calculate_feature(df, fs)["value_float__ema_2"].astype(str))
-
-        assert _compute(("timestamp",)) == _compute("timestamp")
+    @classmethod
+    def compute_values(cls, options: Options) -> list[Any] | None:
+        # Compared as strings so that NaN, which never equals itself, stays comparable.
+        df = pd.DataFrame(DataOperationsTestDataCreator.get_raw_data())
+        result = PandasEma.calculate_feature(df, feature_set_for(FEATURE_NAME, options))
+        return [str(value) for value in extract_column(result, FEATURE_NAME)]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
@@ -41,6 +41,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import column_ref_value, is_column_ref
+
 
 class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """Base class for forward-fill-by-time operations that preserve row count.
@@ -72,6 +74,7 @@ class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Column to order by (ascending) within each partition",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_column_ref,
         },
     }
 
@@ -133,7 +136,7 @@ class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         order_by = feature.options.get(cls.ORDER_BY)
         if order_by is None:
             raise ValueError("ffill requires an 'order_by' column in Options context.")
-        return str(order_by)
+        return column_ref_value(order_by)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_base.py
@@ -11,54 +11,52 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
-from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+from mloda.testing.feature_groups.data_operations.helpers import extract_column, feature_set_for
+from mloda.testing.feature_groups.data_operations.match_validation import ScalarArityTestBase, TokenCase
 from mloda.user import Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
 from mloda.community.feature_groups.data_operations.row_preserving.ffill.pyarrow_ffill import PyArrowFfill
 
+FEATURE_NAME = "amount__ffill"
 
-class TestOrderByArity:
+
+class TestOrderByArity(ScalarArityTestBase):
     """``order_by`` is a scalar key: one column, bare or in a single-element container.
 
-    ffill is a single-op family with no operation config key at all, so
-    ``MatchValidationTestBase`` does not fit it and these checks are hand-rolled.
+    ffill is a single-op family with no operation config key at all, so it declares the
+    arity base directly instead of ``MatchValidationTestBase``.
     """
 
-    def _options(self, order_by: Any) -> Options:
-        return Options(context={"order_by": order_by, "partition_by": ["region"]})
+    @classmethod
+    def feature_group_class(cls) -> Any:
+        return FfillFeatureGroup
 
-    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
-    def test_singleton_matches(self, order_by: Any) -> None:
-        assert PyArrowFfill.match_feature_group_criteria("amount__ffill", self._options(order_by)) is True
+    @classmethod
+    def match_class(cls) -> Any:
+        return PyArrowFfill
 
-    @pytest.mark.parametrize("order_by", [["timestamp", "region"], ("timestamp", "region")])
-    def test_multi_element_rejected(self, order_by: Any) -> None:
-        assert PyArrowFfill.match_feature_group_criteria("amount__ffill", self._options(order_by)) is False
+    @classmethod
+    def match_feature_name(cls) -> str:
+        return FEATURE_NAME
 
-    def test_wrong_type_rejected(self) -> None:
-        assert PyArrowFfill.match_feature_group_criteria("amount__ffill", self._options(123)) is False
+    @classmethod
+    def base_context(cls) -> dict[str, Any]:
+        return {"partition_by": ["region"]}
 
-    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
-    def test_extract_order_by_unwraps_to_bare_column(self, order_by: Any) -> None:
-        feature = Feature("amount__ffill", options=self._options(order_by))
-        assert FfillFeatureGroup._extract_order_by(feature) == "timestamp"
+    @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        return [TokenCase("order_by", "timestamp", "region", required=True)]
 
-    def test_extract_order_by_raises_when_missing(self) -> None:
-        feature = Feature("amount__ffill", options=Options())
-        with pytest.raises(ValueError, match="order_by"):
-            FfillFeatureGroup._extract_order_by(feature)
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [FfillFeatureGroup._extract_order_by(Feature(FEATURE_NAME, options=options))]
 
-    def test_singleton_order_by_dispatches_like_bare(self) -> None:
-        table = PyArrowDataOpsTestDataCreator.create()
-
-        def _compute(order_by: Any) -> list[Any]:
-            fs = FeatureSet()
-            fs.add(Feature("amount__ffill", options=self._options(order_by)))
-            return list(PyArrowFfill.calculate_feature(table, fs).column("amount__ffill").to_pylist())
-
-        assert _compute(("timestamp",)) == _compute("timestamp")
+    @classmethod
+    def compute_values(cls, options: Options) -> list[Any] | None:
+        result = PyArrowFfill.calculate_feature(
+            PyArrowDataOpsTestDataCreator.create(), feature_set_for(FEATURE_NAME, options)
+        )
+        return extract_column(result, FEATURE_NAME)

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_base.py
@@ -1,0 +1,60 @@
+"""Tests for FfillFeatureGroup base class.
+
+Covers the arity contract of the scalar ``order_by`` key: core unwraps a
+one-element container when it reads a property value, so ``("timestamp",)`` is
+valid caller syntax for one column and must dispatch to ``"timestamp"`` rather
+than to the container's string form. Match tests use ``PyArrowFfill`` (the ffill
+convention, mirroring test_integration).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+from mloda.user import Feature
+
+from mloda.community.feature_groups.data_operations.row_preserving.ffill.base import FfillFeatureGroup
+from mloda.community.feature_groups.data_operations.row_preserving.ffill.pyarrow_ffill import PyArrowFfill
+
+
+class TestOrderByArity:
+    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+
+    def _options(self, order_by: Any) -> Options:
+        return Options(context={"order_by": order_by, "partition_by": ["region"]})
+
+    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
+    def test_singleton_matches(self, order_by: Any) -> None:
+        assert PyArrowFfill.match_feature_group_criteria("amount__ffill", self._options(order_by)) is True
+
+    @pytest.mark.parametrize("order_by", [["timestamp", "region"], ("timestamp", "region")])
+    def test_multi_element_rejected(self, order_by: Any) -> None:
+        assert PyArrowFfill.match_feature_group_criteria("amount__ffill", self._options(order_by)) is False
+
+    def test_wrong_type_rejected(self) -> None:
+        assert PyArrowFfill.match_feature_group_criteria("amount__ffill", self._options(123)) is False
+
+    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
+    def test_extract_order_by_unwraps_to_bare_column(self, order_by: Any) -> None:
+        feature = Feature("amount__ffill", options=self._options(order_by))
+        assert FfillFeatureGroup._extract_order_by(feature) == "timestamp"
+
+    def test_extract_order_by_raises_when_missing(self) -> None:
+        feature = Feature("amount__ffill", options=Options())
+        with pytest.raises(ValueError, match="order_by"):
+            FfillFeatureGroup._extract_order_by(feature)
+
+    def test_singleton_order_by_dispatches_like_bare(self) -> None:
+        table = PyArrowDataOpsTestDataCreator.create()
+
+        def _compute(order_by: Any) -> list[Any]:
+            fs = FeatureSet()
+            fs.add(Feature("amount__ffill", options=self._options(order_by)))
+            return list(PyArrowFfill.calculate_feature(table, fs).column("amount__ffill").to_pylist())
+
+        assert _compute(("timestamp",)) == _compute("timestamp")

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_base.py
@@ -23,7 +23,11 @@ from mloda.community.feature_groups.data_operations.row_preserving.ffill.pyarrow
 
 
 class TestOrderByArity:
-    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+    """``order_by`` is a scalar key: one column, bare or in a single-element container.
+
+    ffill is a single-op family with no operation config key at all, so
+    ``MatchValidationTestBase`` does not fit it and these checks are hand-rolled.
+    """
 
     def _options(self, order_by: Any) -> Options:
         return Options(context={"order_by": order_by, "partition_by": ["region"]})

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -243,6 +243,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
             DefaultOptionKeys.allowed_values: {unit: f"{unit} interval" for unit in sorted(_TIME_UNITS)},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.match_guard: is_op_token,
             DefaultOptionKeys.required_when: _needs_frame_unit,
         },
         DefaultOptionKeys.in_features: {

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -18,10 +18,14 @@ from mloda.community.feature_groups.data_operations.base import (
     FRAME_SIZE as _FRAME_SIZE_KEY,
     FRAME_TYPE as _FRAME_TYPE_KEY,
     FRAME_UNIT as _FRAME_UNIT_KEY,
+    column_ref_value,
+    is_column_ref,
     is_in_features_value,
     is_op_token,
     is_positive_int,
     op_token_value,
+    option_value,
+    positive_int_value,
 )
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
@@ -50,13 +54,8 @@ _TIME_UNITS = {"second", "minute", "hour", "day", "week", "month", "year"}
 
 
 def _option_token(options: Options, key: str) -> str | None:
-    """An option as a bare token, unwrapped from its container; None when the option is absent.
-
-    Absent stays None instead of becoming the string ``"None"``, so a missing option
-    is a non-match by construction rather than by coincidence.
-    """
-    value = options.get(key)
-    return None if value is None else op_token_value(value)
+    """An option as a bare token, unwrapped from its container; None when the option is absent."""
+    return option_value(options, key, op_token_value)
 
 
 def _needs_frame_size(options: Options) -> bool:
@@ -261,6 +260,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
             "explanation": "Column to order by within each partition",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_column_ref,
         },
         MASK_KEY: {
             "explanation": "Conditional mask: (column, operator, value) tuple or list of tuples",
@@ -364,8 +364,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
         if not all(isinstance(item, str) for item in partition_by):
             return False
 
-        order_by = options.get(cls.ORDER_BY)
-        if not isinstance(order_by, str):
+        if not is_column_ref(options.get(cls.ORDER_BY)):
             return False
 
         return True
@@ -415,19 +414,18 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin,
                 "frame_size": parsed["frame_size"],
                 "frame_unit": parsed["frame_unit"],
                 "partition_by": feature.options.get(cls.PARTITION_BY),
-                "order_by": feature.options.get(cls.ORDER_BY),
+                "order_by": option_value(feature.options, cls.ORDER_BY, column_ref_value),
             }
 
         source_features = cls._extract_source_features(feature)
-        frame_unit = feature.options.get(cls.FRAME_UNIT)
         return {
             "source_col": source_features[0],
             "agg_type": op_token_value(feature.options.get(cls.AGGREGATION_TYPE)),
             "frame_type": op_token_value(feature.options.get(cls.FRAME_TYPE)),
-            "frame_size": feature.options.get(cls.FRAME_SIZE),
-            "frame_unit": None if frame_unit is None else op_token_value(frame_unit),
+            "frame_size": option_value(feature.options, cls.FRAME_SIZE, positive_int_value),
+            "frame_unit": _option_token(feature.options, cls.FRAME_UNIT),
             "partition_by": feature.options.get(cls.PARTITION_BY),
-            "order_by": feature.options.get(cls.ORDER_BY),
+            "order_by": option_value(feature.options, cls.ORDER_BY, column_ref_value),
         }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -348,56 +348,6 @@ class TestConfigBasedFrameSizeValidation:
         assert result is True, f"Config path should accept {frame_type} without frame_size"
 
 
-class TestScalarKeyArity:
-    """Scalar-key checks the shared harness cannot express.
-
-    The bare / single-element / multi-element verdicts for ``order_by``,
-    ``frame_size`` and ``frame_unit`` live in
-    ``TestFrameAggregateMatchValidation.token_cases``; what stays here is the
-    wrong-type and value-space rejections plus the absolute values ``_extract_params``
-    must return.
-    """
-
-    def _options(self, **overrides: Any) -> Options:
-        context: dict[str, Any] = {
-            "aggregation_type": "sum",
-            "in_features": "sales",
-            "partition_by": ["region"],
-            "frame_type": "rolling",
-            "frame_size": 3,
-            "order_by": "timestamp",
-        }
-        context.update(overrides)
-        return Options(context=context)
-
-    def test_wrong_type_order_by_rejected(self) -> None:
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by=123), None)
-        assert result is False
-
-    @pytest.mark.parametrize("frame_size", [(0,), (True,)])
-    def test_invalid_singleton_frame_size_rejected(self, frame_size: Any) -> None:
-        """Unwrapping does not widen the value space: the positive-int rule still applies."""
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(frame_size=frame_size), None
-        )
-        assert result is False
-
-    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
-    def test_extract_params_unwraps_order_by(self, order_by: Any) -> None:
-        feature = Feature("my_result", options=self._options(order_by=order_by))
-        assert FrameAggregateFeatureGroup._extract_params(feature)["order_by"] == "timestamp"
-
-    @pytest.mark.parametrize("frame_size", [3, (3,), [3]])
-    def test_extract_params_unwraps_frame_size(self, frame_size: Any) -> None:
-        feature = Feature("my_result", options=self._options(frame_size=frame_size))
-        assert FrameAggregateFeatureGroup._extract_params(feature)["frame_size"] == 3
-
-    @pytest.mark.parametrize("frame_unit", ["day", ("day",), ["day"]])
-    def test_extract_params_unwraps_frame_unit(self, frame_unit: Any) -> None:
-        feature = Feature("my_result", options=self._options(frame_type="time", frame_size=7, frame_unit=frame_unit))
-        assert FrameAggregateFeatureGroup._extract_params(feature)["frame_unit"] == "day"
-
-
 class TestNameBasedZeroFrameSizeRejected:
     """A zero-sized frame is not a window, so the name path must reject it exactly as the config path does."""
 
@@ -689,9 +639,10 @@ class TestFrameAggregateMatchValidation(MatchValidationTestBase):
             # A rolling frame ignores frame_unit, so nothing but the key's own guard rejects a
             # multi-element value there; under "time" the unit table would mask a missing guard.
             TokenCase("frame_unit", "day", "week", context={"frame_type": "rolling"}),
-            # order_by and frame_size are scalar too: one column, one positive int.
+            # order_by and frame_size are scalar too: one column, one positive int, so a
+            # zero-sized frame and a bool stay out at every arity.
             TokenCase("order_by", "timestamp", "region"),
-            TokenCase("frame_size", 3, 5),
+            TokenCase("frame_size", 3, 5, invalid=(0, True)),
         ]
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -349,7 +349,14 @@ class TestConfigBasedFrameSizeValidation:
 
 
 class TestScalarKeyArity:
-    """``order_by`` and ``frame_size`` are scalar keys: one value, bare or in a one-element container."""
+    """Scalar-key checks the shared harness cannot express.
+
+    The bare / single-element / multi-element verdicts for ``order_by``,
+    ``frame_size`` and ``frame_unit`` live in
+    ``TestFrameAggregateMatchValidation.token_cases``; what stays here is the
+    wrong-type and value-space rejections plus the absolute values ``_extract_params``
+    must return.
+    """
 
     def _options(self, **overrides: Any) -> Options:
         context: dict[str, Any] = {
@@ -363,29 +370,13 @@ class TestScalarKeyArity:
         context.update(overrides)
         return Options(context=context)
 
-    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
-    def test_singleton_order_by_matches(self, order_by: Any) -> None:
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(order_by=order_by), None
-        )
-        assert result is True
-
-    @pytest.mark.parametrize("order_by", [["timestamp", "region"], ("timestamp", "region"), 123])
-    def test_invalid_order_by_rejected(self, order_by: Any) -> None:
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(order_by=order_by), None
-        )
+    def test_wrong_type_order_by_rejected(self) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by=123), None)
         assert result is False
 
-    @pytest.mark.parametrize("frame_size", [3, (3,), [3]])
-    def test_singleton_frame_size_matches(self, frame_size: Any) -> None:
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
-            "my_result", self._options(frame_size=frame_size), None
-        )
-        assert result is True
-
-    @pytest.mark.parametrize("frame_size", [[3, 4], (3, 4), (0,), (True,)])
-    def test_invalid_frame_size_rejected(self, frame_size: Any) -> None:
+    @pytest.mark.parametrize("frame_size", [(0,), (True,)])
+    def test_invalid_singleton_frame_size_rejected(self, frame_size: Any) -> None:
+        """Unwrapping does not widen the value space: the positive-int rule still applies."""
         result = FrameAggregateFeatureGroup.match_feature_group_criteria(
             "my_result", self._options(frame_size=frame_size), None
         )
@@ -400,6 +391,11 @@ class TestScalarKeyArity:
     def test_extract_params_unwraps_frame_size(self, frame_size: Any) -> None:
         feature = Feature("my_result", options=self._options(frame_size=frame_size))
         assert FrameAggregateFeatureGroup._extract_params(feature)["frame_size"] == 3
+
+    @pytest.mark.parametrize("frame_unit", ["day", ("day",), ["day"]])
+    def test_extract_params_unwraps_frame_unit(self, frame_unit: Any) -> None:
+        feature = Feature("my_result", options=self._options(frame_type="time", frame_size=7, frame_unit=frame_unit))
+        assert FrameAggregateFeatureGroup._extract_params(feature)["frame_unit"] == "day"
 
 
 class TestNameBasedZeroFrameSizeRejected:
@@ -690,9 +686,21 @@ class TestFrameAggregateMatchValidation(MatchValidationTestBase):
             TokenCase("frame_type", "expanding", without=("frame_size",)),
             # Only a time frame requires frame_unit, which additional_match_options() does not carry.
             TokenCase("frame_type", "time", matches=False),
+            # A rolling frame ignores frame_unit, so nothing but the key's own guard rejects a
+            # multi-element value there; under "time" the unit table would mask a missing guard.
+            TokenCase("frame_unit", "day", "week", context={"frame_type": "rolling"}),
+            # order_by and frame_size are scalar too: one column, one positive int.
+            TokenCase("order_by", "timestamp", "region"),
+            TokenCase("frame_size", 3, 5),
         ]
 
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:
         params = FrameAggregateFeatureGroup._extract_params(Feature("my_result", options=options))
-        return [params["agg_type"], params["frame_type"], params["frame_unit"]]
+        return [
+            params["agg_type"],
+            params["frame_type"],
+            params["frame_unit"],
+            params["order_by"],
+            params["frame_size"],
+        ]

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -348,6 +348,60 @@ class TestConfigBasedFrameSizeValidation:
         assert result is True, f"Config path should accept {frame_type} without frame_size"
 
 
+class TestScalarKeyArity:
+    """``order_by`` and ``frame_size`` are scalar keys: one value, bare or in a one-element container."""
+
+    def _options(self, **overrides: Any) -> Options:
+        context: dict[str, Any] = {
+            "aggregation_type": "sum",
+            "in_features": "sales",
+            "partition_by": ["region"],
+            "frame_type": "rolling",
+            "frame_size": 3,
+            "order_by": "timestamp",
+        }
+        context.update(overrides)
+        return Options(context=context)
+
+    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
+    def test_singleton_order_by_matches(self, order_by: Any) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(order_by=order_by), None
+        )
+        assert result is True
+
+    @pytest.mark.parametrize("order_by", [["timestamp", "region"], ("timestamp", "region"), 123])
+    def test_invalid_order_by_rejected(self, order_by: Any) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(order_by=order_by), None
+        )
+        assert result is False
+
+    @pytest.mark.parametrize("frame_size", [3, (3,), [3]])
+    def test_singleton_frame_size_matches(self, frame_size: Any) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(frame_size=frame_size), None
+        )
+        assert result is True
+
+    @pytest.mark.parametrize("frame_size", [[3, 4], (3, 4), (0,), (True,)])
+    def test_invalid_frame_size_rejected(self, frame_size: Any) -> None:
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(
+            "my_result", self._options(frame_size=frame_size), None
+        )
+        assert result is False
+
+    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
+    def test_extract_params_unwraps_order_by(self, order_by: Any) -> None:
+        feature = Feature("my_result", options=self._options(order_by=order_by))
+        assert FrameAggregateFeatureGroup._extract_params(feature)["order_by"] == "timestamp"
+
+    @pytest.mark.parametrize("frame_size", [3, (3,), [3]])
+    def test_extract_params_unwraps_frame_size(self, frame_size: Any) -> None:
+        feature = Feature("my_result", options=self._options(frame_size=frame_size))
+        assert FrameAggregateFeatureGroup._extract_params(feature)["frame_size"] == 3
+
+
 class TestNameBasedZeroFrameSizeRejected:
     """A zero-sized frame is not a window, so the name path must reject it exactly as the config path does."""
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -12,10 +12,13 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.base import (
+    column_ref_value,
+    is_column_ref,
     is_in_features_value,
     is_op_token,
     is_parametric_suffix,
     op_token_value,
+    option_value,
 )
 
 
@@ -146,6 +149,7 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Column to order by within each partition",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_column_ref,
         },
     }
 
@@ -177,10 +181,7 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if not all(isinstance(item, str) for item in partition_by):
             return False
 
-        order_by = options.get(cls.ORDER_BY)
-        if order_by is None:
-            return False
-        if not isinstance(order_by, str):
+        if not is_column_ref(options.get(cls.ORDER_BY)):
             return False
 
         in_features_raw = options.get(DefaultOptionKeys.in_features)
@@ -233,7 +234,8 @@ class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             source_col = source_features[0]
             offset_type = cls._extract_offset_type(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)
-            order_by = feature.options.get(cls.ORDER_BY)
+            # Any: matching requires order_by, but a direct call still passes an absent one through.
+            order_by: Any = option_value(feature.options, cls.ORDER_BY, column_ref_value)
 
             table = cls._compute_offset(table, feature_name, source_col, partition_by, order_by, offset_type)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.offset.base import OffsetFeatureGroup
@@ -176,7 +176,13 @@ class TestConfigBasedFeatures:
 
 
 class TestOrderByArity:
-    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+    """``order_by`` checks the shared harness cannot express.
+
+    The bare / single-element / multi-element verdicts live in
+    ``TestOffsetMatchValidation.token_cases``; what stays here is the wrong-type
+    rejection and the dispatch check, since offset reads ``order_by`` inline in
+    calculate_feature rather than through an extractor.
+    """
 
     def _options(self, order_by: Any) -> Options:
         return Options(
@@ -187,16 +193,6 @@ class TestOrderByArity:
                 "order_by": order_by,
             }
         )
-
-    @pytest.mark.parametrize("order_by", ["value_int", ("value_int",), ["value_int"]])
-    def test_singleton_matches(self, order_by: Any) -> None:
-        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by), None)
-        assert result is True
-
-    @pytest.mark.parametrize("order_by", [["value_int", "region"], ("value_int", "region")])
-    def test_multi_element_rejected(self, order_by: Any) -> None:
-        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by), None)
-        assert result is False
 
     def test_wrong_type_rejected(self) -> None:
         result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(123), None)
@@ -377,6 +373,11 @@ class TestOffsetMatchValidation(MatchValidationTestBase):
     @classmethod
     def malformed_operations(cls) -> set[str]:
         return {"banana", "lag_0", "lag_abc", "lead_"}
+
+    @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        # order_by names one column, and offset requires it on both paths.
+        return [*super().token_cases(), TokenCase("order_by", "timestamp", "region")]
 
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -175,6 +175,49 @@ class TestConfigBasedFeatures:
         assert result.num_rows == 12
 
 
+class TestOrderByArity:
+    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+
+    def _options(self, order_by: Any) -> Options:
+        return Options(
+            context={
+                "offset_type": "lag_1",
+                "in_features": "value_int",
+                "partition_by": ["region"],
+                "order_by": order_by,
+            }
+        )
+
+    @pytest.mark.parametrize("order_by", ["value_int", ("value_int",), ["value_int"]])
+    def test_singleton_matches(self, order_by: Any) -> None:
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by), None)
+        assert result is True
+
+    @pytest.mark.parametrize("order_by", [["value_int", "region"], ("value_int", "region")])
+    def test_multi_element_rejected(self, order_by: Any) -> None:
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by), None)
+        assert result is False
+
+    def test_wrong_type_rejected(self) -> None:
+        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(123), None)
+        assert result is False
+
+    def test_singleton_order_by_dispatches_like_bare(self) -> None:
+        """The singleton must reach the backend as the column name, not as its string form."""
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+        from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+        from mloda.testing.feature_groups.data_operations.row_preserving.offset.reference import ReferenceOffset
+
+        table = PyArrowDataOpsTestDataCreator.create()
+
+        def _compute(order_by: Any) -> list[Any]:
+            fs = FeatureSet()
+            fs.add(Feature("my_lag", options=self._options(order_by)))
+            return list(ReferenceOffset.calculate_feature(table, fs).column("my_lag").to_pylist())
+
+        assert _compute(("value_int",)) == _compute("value_int")
+
+
 class TestConfigBasedOffsetTypeValidation:
     """The config path must reject exactly the offset types the feature-name path rejects.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -7,7 +7,10 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+from mloda.testing.feature_groups.data_operations.helpers import extract_column, feature_set_for
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
+from mloda.testing.feature_groups.data_operations.row_preserving.offset.reference import ReferenceOffset
 from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.offset.base import OffsetFeatureGroup
@@ -173,45 +176,6 @@ class TestConfigBasedFeatures:
         assert isinstance(result, pa.Table)
         assert "my_lag" in result.column_names
         assert result.num_rows == 12
-
-
-class TestOrderByArity:
-    """``order_by`` checks the shared harness cannot express.
-
-    The bare / single-element / multi-element verdicts live in
-    ``TestOffsetMatchValidation.token_cases``; what stays here is the wrong-type
-    rejection and the dispatch check, since offset reads ``order_by`` inline in
-    calculate_feature rather than through an extractor.
-    """
-
-    def _options(self, order_by: Any) -> Options:
-        return Options(
-            context={
-                "offset_type": "lag_1",
-                "in_features": "value_int",
-                "partition_by": ["region"],
-                "order_by": order_by,
-            }
-        )
-
-    def test_wrong_type_rejected(self) -> None:
-        result = OffsetFeatureGroup.match_feature_group_criteria("my_result", self._options(123), None)
-        assert result is False
-
-    def test_singleton_order_by_dispatches_like_bare(self) -> None:
-        """The singleton must reach the backend as the column name, not as its string form."""
-        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-        from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
-        from mloda.testing.feature_groups.data_operations.row_preserving.offset.reference import ReferenceOffset
-
-        table = PyArrowDataOpsTestDataCreator.create()
-
-        def _compute(order_by: Any) -> list[Any]:
-            fs = FeatureSet()
-            fs.add(Feature("my_lag", options=self._options(order_by)))
-            return list(ReferenceOffset.calculate_feature(table, fs).column("my_lag").to_pylist())
-
-        assert _compute(("value_int",)) == _compute("value_int")
 
 
 class TestConfigBasedOffsetTypeValidation:
@@ -382,3 +346,12 @@ class TestOffsetMatchValidation(MatchValidationTestBase):
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:
         return [OffsetFeatureGroup._extract_offset_type(Feature("my_result", options=options))]
+
+    @classmethod
+    def compute_values(cls, options: Options) -> list[Any] | None:
+        # Offset reads order_by inline in calculate_feature rather than through an extractor,
+        # so only a run through the backend shows a container reaching it unwrapped.
+        result = ReferenceOffset.calculate_feature(
+            PyArrowDataOpsTestDataCreator.create(), feature_set_for("my_lag", options)
+        )
+        return extract_column(result, "my_lag")

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
@@ -12,12 +12,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import is_scalar_number, scalar_number_value
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
-
-
-def _is_real_number(value: Any) -> bool:
-    """True for a non-bool int/float (bool subclasses int)."""
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -68,6 +64,7 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Percentile value (float between 0.0 and 1.0)",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_scalar_number,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature for percentile computation",
@@ -148,8 +145,8 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if operation_config is not None:
             return cls._parse_percentile_from_config(operation_config)
         percentile = options.get(cls.PERCENTILE)
-        if _is_real_number(percentile):
-            return float(percentile)
+        if is_scalar_number(percentile):
+            return float(scalar_number_value(percentile))
         return None
 
     @classmethod
@@ -180,9 +177,9 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             if result is not None:
                 return result
         percentile = feature.options.get(cls.PERCENTILE)
-        if not _is_real_number(percentile):
+        if not is_scalar_number(percentile):
             raise ValueError(f"Could not extract percentile for {feature_name}")
-        return float(percentile)
+        return float(scalar_number_value(percentile))
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Parse input features from feature name or options."""

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
@@ -16,6 +16,21 @@ from mloda.community.feature_groups.data_operations.base import is_scalar_number
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
 
+def _unit_percentile(value: object) -> float | None:
+    """The option as a float in 0.0-1.0, or None when it is not one number in that range.
+
+    The range check runs BEFORE the conversion on purpose: an int-to-float comparison is exact
+    at any magnitude, while ``float(10**400)`` raises OverflowError, which discovery does not
+    catch and which a user-supplied option must never trigger.
+    """
+    if not is_scalar_number(value):
+        return None
+    number = scalar_number_value(value)
+    if number < 0.0 or number > 1.0:
+        return None
+    return float(number)
+
+
 class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """Base class for percentile operations that preserve row count.
 
@@ -126,28 +141,21 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         if not all(isinstance(item, str) for item in partition_by):
             return False
 
-        percentile = cls._resolve_percentile(feature_name, options)
-        if percentile is None:
-            return False
-        if not isinstance(percentile, (int, float)):
-            return False
-        if percentile < 0.0 or percentile > 1.0:
+        # None covers both halves: unresolvable, and resolved but outside 0.0-1.0.
+        if cls._resolve_percentile(feature_name, options) is None:
             return False
 
         return True
 
     @classmethod
     def _resolve_percentile(cls, feature_name: Any, options: Any) -> float | None:
-        """Extract percentile as float from feature name or options."""
+        """Extract percentile as a float in 0.0-1.0 from feature name or options; None if there is none."""
         name = str(feature_name)
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(name, prefix_patterns)
         if operation_config is not None:
             return cls._parse_percentile_from_config(operation_config)
-        percentile = options.get(cls.PERCENTILE)
-        if is_scalar_number(percentile):
-            return float(scalar_number_value(percentile))
-        return None
+        return _unit_percentile(options.get(cls.PERCENTILE))
 
     @classmethod
     def get_percentile_value(cls, feature_name: str) -> float:
@@ -176,10 +184,10 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             result = cls._parse_percentile_from_config(operation_config)
             if result is not None:
                 return result
-        percentile = feature.options.get(cls.PERCENTILE)
-        if not is_scalar_number(percentile):
+        percentile = _unit_percentile(feature.options.get(cls.PERCENTILE))
+        if percentile is None:
             raise ValueError(f"Could not extract percentile for {feature_name}")
-        return float(scalar_number_value(percentile))
+        return percentile
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Parse input features from feature name or options."""

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.percentile.base import (
@@ -262,39 +263,6 @@ class TestConfigBasedExtraction:
         assert result == 1.0
 
 
-class TestPercentileArity:
-    """``percentile`` checks the shared harness cannot express.
-
-    The bare / single-element / multi-element verdicts live in
-    ``TestPercentileMatchValidation``, whose primary config key IS ``percentile``;
-    what stays here is the value-space rejections and the direct extractor call.
-    """
-
-    def _options(self, percentile: Any) -> Options:
-        return Options(context={"percentile": percentile, "in_features": "value_int", "partition_by": ["region"]})
-
-    @pytest.mark.parametrize("percentile", [10**400, (10**400,)])
-    def test_unconvertible_int_is_a_non_match(self, percentile: Any) -> None:
-        """An int too large for float is a plain non-match, never an OverflowError out of discovery.
-
-        The mixin only catches TypeError / ValueError / AttributeError, so a conversion
-        that overflows escapes the matcher and aborts discovery for every feature group.
-        """
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", self._options(percentile), None)
-        assert result is False
-
-    @pytest.mark.parametrize("percentile", [(1.5,), (True,)])
-    def test_singleton_out_of_range_or_bool_rejected(self, percentile: Any) -> None:
-        """Unwrapping does not widen the value space: range and bool rules still apply."""
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", self._options(percentile), None)
-        assert result is False
-
-    @pytest.mark.parametrize("percentile", [0.75, (0.75,), [0.75]])
-    def test_extract_percentile_unwraps_to_bare_value(self, percentile: Any) -> None:
-        feature = Feature("my_result", options=self._options(percentile))
-        assert PercentileFeatureGroup._extract_percentile(feature) == 0.75
-
-
 class TestPercentileMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:
@@ -332,6 +300,15 @@ class TestPercentileMatchValidation(MatchValidationTestBase):
     @classmethod
     def options_reject_invalid_types(cls) -> bool:
         return False
+
+    @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        # A percentile is one float in [0.0, 1.0]: out of range, a bool, and an int too large
+        # for float all stay out. The last one must be a plain non-match rather than an
+        # OverflowError, which the mixin does not catch and which would abort discovery for
+        # every feature group.
+        primary = super().token_cases()[0]
+        return [replace(primary, invalid=(1.5, True, 10**400))]
 
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
@@ -262,6 +262,34 @@ class TestConfigBasedExtraction:
         assert result == 1.0
 
 
+class TestPercentileArity:
+    """``percentile`` is a scalar key: one number, bare or in a single-element container."""
+
+    def _options(self, percentile: Any) -> Options:
+        return Options(context={"percentile": percentile, "in_features": "value_int", "partition_by": ["region"]})
+
+    @pytest.mark.parametrize("percentile", [0.75, (0.75,), [0.75]])
+    def test_singleton_matches(self, percentile: Any) -> None:
+        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", self._options(percentile), None)
+        assert result is True
+
+    @pytest.mark.parametrize("percentile", [[0.25, 0.75], (0.25, 0.75)])
+    def test_multi_element_rejected(self, percentile: Any) -> None:
+        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", self._options(percentile), None)
+        assert result is False
+
+    @pytest.mark.parametrize("percentile", [(1.5,), (True,)])
+    def test_singleton_out_of_range_or_bool_rejected(self, percentile: Any) -> None:
+        """Unwrapping does not widen the value space: range and bool rules still apply."""
+        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", self._options(percentile), None)
+        assert result is False
+
+    @pytest.mark.parametrize("percentile", [0.75, (0.75,), [0.75]])
+    def test_extract_percentile_unwraps_to_bare_value(self, percentile: Any) -> None:
+        feature = Feature("my_result", options=self._options(percentile))
+        assert PercentileFeatureGroup._extract_percentile(feature) == 0.75
+
+
 class TestPercentileMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
@@ -263,18 +263,23 @@ class TestConfigBasedExtraction:
 
 
 class TestPercentileArity:
-    """``percentile`` is a scalar key: one number, bare or in a single-element container."""
+    """``percentile`` checks the shared harness cannot express.
+
+    The bare / single-element / multi-element verdicts live in
+    ``TestPercentileMatchValidation``, whose primary config key IS ``percentile``;
+    what stays here is the value-space rejections and the direct extractor call.
+    """
 
     def _options(self, percentile: Any) -> Options:
         return Options(context={"percentile": percentile, "in_features": "value_int", "partition_by": ["region"]})
 
-    @pytest.mark.parametrize("percentile", [0.75, (0.75,), [0.75]])
-    def test_singleton_matches(self, percentile: Any) -> None:
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", self._options(percentile), None)
-        assert result is True
+    @pytest.mark.parametrize("percentile", [10**400, (10**400,)])
+    def test_unconvertible_int_is_a_non_match(self, percentile: Any) -> None:
+        """An int too large for float is a plain non-match, never an OverflowError out of discovery.
 
-    @pytest.mark.parametrize("percentile", [[0.25, 0.75], (0.25, 0.75)])
-    def test_multi_element_rejected(self, percentile: Any) -> None:
+        The mixin only catches TypeError / ValueError / AttributeError, so a conversion
+        that overflows escapes the matcher and aborts discovery for every feature group.
+        """
         result = PercentileFeatureGroup.match_feature_group_criteria("my_result", self._options(percentile), None)
         assert result is False
 
@@ -327,3 +332,7 @@ class TestPercentileMatchValidation(MatchValidationTestBase):
     @classmethod
     def options_reject_invalid_types(cls) -> bool:
         return False
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        return [PercentileFeatureGroup._extract_percentile(Feature("my_result", options=options))]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_security.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_security.py
@@ -175,8 +175,10 @@ class TestConfigBasedPercentileValidation:
         assert result is False, f"Invalid config percentile {percentile_value} should be rejected"
 
     @pytest.mark.parametrize(
+        # A one-element container is valid caller syntax for one percentile, so the
+        # container case here has to be genuinely multi-valued.
         "bad_type",
-        ["fifty", [0.5], None],
+        ["fifty", [0.5, 0.9], None],
     )
     def test_wrong_type_config_percentile_rejected(self, bad_type: object) -> None:
         options = Options(

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -14,10 +14,13 @@ from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 from mloda.community.feature_groups.data_operations.base import (
+    column_ref_value,
+    is_column_ref,
     is_in_features_value,
     is_op_token,
     is_parametric_suffix,
     op_token_value,
+    option_value,
 )
 
 
@@ -162,6 +165,7 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
             "explanation": "Column to order by within each partition",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_column_ref,
         },
     }
 
@@ -197,10 +201,7 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
         if not all(isinstance(item, str) for item in partition_by):
             return False
 
-        order_by = options.get(cls.ORDER_BY)
-        if order_by is None:
-            return False
-        if not isinstance(order_by, str):
+        if not is_column_ref(options.get(cls.ORDER_BY)):
             return False
 
         in_features_raw = options.get(DefaultOptionKeys.in_features)
@@ -286,7 +287,8 @@ class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGr
 
             rank_type = cls._extract_rank_type(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)
-            order_by = feature.options.get(cls.ORDER_BY)
+            # Any: matching requires order_by, but a direct call still passes an absent one through.
+            order_by: Any = option_value(feature.options, cls.ORDER_BY, column_ref_value)
 
             table = cls._compute_rank(table, feature_name, partition_by, order_by, rank_type)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -8,7 +8,10 @@ import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys
+from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+from mloda.testing.feature_groups.data_operations.helpers import extract_column, feature_set_for
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
+from mloda.testing.feature_groups.data_operations.row_preserving.rank.reference import ReferenceRank
 from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.rank.base import (
@@ -286,45 +289,6 @@ class TestConfigBasedFeatures:
         assert result.num_rows == 12
 
 
-class TestOrderByArity:
-    """``order_by`` checks the shared harness cannot express.
-
-    The bare / single-element / multi-element verdicts live in
-    ``TestRankMatchValidation.token_cases``; what stays here is the wrong-type
-    rejection and the dispatch check, since rank reads ``order_by`` inline in
-    calculate_feature rather than through an extractor.
-    """
-
-    def _options(self, order_by: Any) -> Options:
-        return Options(
-            context={
-                "rank_type": "row_number",
-                "in_features": "value_int",
-                "partition_by": ["region"],
-                "order_by": order_by,
-            }
-        )
-
-    def test_wrong_type_rejected(self) -> None:
-        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(123), None)
-        assert result is False
-
-    def test_singleton_order_by_dispatches_like_bare(self) -> None:
-        """The singleton must reach the backend as the column name, not as its string form."""
-        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-        from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
-        from mloda.testing.feature_groups.data_operations.row_preserving.rank.reference import ReferenceRank
-
-        table = PyArrowDataOpsTestDataCreator.create()
-
-        def _compute(order_by: Any) -> list[Any]:
-            fs = FeatureSet()
-            fs.add(Feature("my_rank_result", options=self._options(order_by)))
-            return list(ReferenceRank.calculate_feature(table, fs).column("my_rank_result").to_pylist())
-
-        assert _compute(("value_int",)) == _compute("value_int")
-
-
 class TestConfigBasedParametricRankTypes:
     """The config path must accept exactly the rank types the feature-name path accepts.
 
@@ -500,3 +464,12 @@ class TestRankMatchValidation(MatchValidationTestBase):
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:
         return [RankFeatureGroup._extract_rank_type(Feature("my_result", options=options))]
+
+    @classmethod
+    def compute_values(cls, options: Options) -> list[Any] | None:
+        # Rank reads order_by inline in calculate_feature rather than through an extractor,
+        # so only a run through the backend shows a container reaching it unwrapped.
+        result = ReferenceRank.calculate_feature(
+            PyArrowDataOpsTestDataCreator.create(), feature_set_for("my_rank_result", options)
+        )
+        return extract_column(result, "my_rank_result")

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -212,8 +212,15 @@ class TestConfigValidation:
         result = RankFeatureGroup.match_feature_group_criteria("value_int__rank_ranked", options, None)
         assert result is False
 
-    def test_order_by_must_be_string(self) -> None:
-        options = Options(context={"partition_by": ["region"], "order_by": ["value_int"]})
+    def test_order_by_rejects_multiple_columns(self) -> None:
+        # order_by names ONE column; a one-element container is valid caller syntax for it
+        # (see TestOrderByArity), so only a genuinely multi-valued container is invalid here.
+        options = Options(context={"partition_by": ["region"], "order_by": ["value_int", "region"]})
+        result = RankFeatureGroup.match_feature_group_criteria("value_int__rank_ranked", options, None)
+        assert result is False
+
+    def test_order_by_rejects_non_string(self) -> None:
+        options = Options(context={"partition_by": ["region"], "order_by": 42})
         result = RankFeatureGroup.match_feature_group_criteria("value_int__rank_ranked", options, None)
         assert result is False
 
@@ -277,6 +284,49 @@ class TestConfigBasedFeatures:
         assert isinstance(result, pa.Table)
         assert "my_rank_result" in result.column_names
         assert result.num_rows == 12
+
+
+class TestOrderByArity:
+    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+
+    def _options(self, order_by: Any) -> Options:
+        return Options(
+            context={
+                "rank_type": "row_number",
+                "in_features": "value_int",
+                "partition_by": ["region"],
+                "order_by": order_by,
+            }
+        )
+
+    @pytest.mark.parametrize("order_by", ["value_int", ("value_int",), ["value_int"]])
+    def test_singleton_matches(self, order_by: Any) -> None:
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by), None)
+        assert result is True
+
+    @pytest.mark.parametrize("order_by", [["value_int", "region"], ("value_int", "region")])
+    def test_multi_element_rejected(self, order_by: Any) -> None:
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by), None)
+        assert result is False
+
+    def test_wrong_type_rejected(self) -> None:
+        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(123), None)
+        assert result is False
+
+    def test_singleton_order_by_dispatches_like_bare(self) -> None:
+        """The singleton must reach the backend as the column name, not as its string form."""
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+        from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+        from mloda.testing.feature_groups.data_operations.row_preserving.rank.reference import ReferenceRank
+
+        table = PyArrowDataOpsTestDataCreator.create()
+
+        def _compute(order_by: Any) -> list[Any]:
+            fs = FeatureSet()
+            fs.add(Feature("my_rank_result", options=self._options(order_by)))
+            return list(ReferenceRank.calculate_feature(table, fs).column("my_rank_result").to_pylist())
+
+        assert _compute(("value_int",)) == _compute("value_int")
 
 
 class TestConfigBasedParametricRankTypes:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -8,7 +8,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys
-from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.rank.base import (
@@ -287,7 +287,13 @@ class TestConfigBasedFeatures:
 
 
 class TestOrderByArity:
-    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+    """``order_by`` checks the shared harness cannot express.
+
+    The bare / single-element / multi-element verdicts live in
+    ``TestRankMatchValidation.token_cases``; what stays here is the wrong-type
+    rejection and the dispatch check, since rank reads ``order_by`` inline in
+    calculate_feature rather than through an extractor.
+    """
 
     def _options(self, order_by: Any) -> Options:
         return Options(
@@ -298,16 +304,6 @@ class TestOrderByArity:
                 "order_by": order_by,
             }
         )
-
-    @pytest.mark.parametrize("order_by", ["value_int", ("value_int",), ["value_int"]])
-    def test_singleton_matches(self, order_by: Any) -> None:
-        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by), None)
-        assert result is True
-
-    @pytest.mark.parametrize("order_by", [["value_int", "region"], ("value_int", "region")])
-    def test_multi_element_rejected(self, order_by: Any) -> None:
-        result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(order_by), None)
-        assert result is False
 
     def test_wrong_type_rejected(self) -> None:
         result = RankFeatureGroup.match_feature_group_criteria("my_result", self._options(123), None)
@@ -495,6 +491,11 @@ class TestRankMatchValidation(MatchValidationTestBase):
     @classmethod
     def malformed_operations(cls) -> set[str]:
         return {"ntile_0", "ntile_abc", "top_0", "bottom_0", "banana"}
+
+    @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        # order_by names one column, and rank requires it on both paths.
+        return [*super().token_cases(), TokenCase("order_by", "value_int", "region")]
 
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
@@ -27,7 +27,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys
 
 from mloda.community.feature_groups.data_operations.row_preserving.arithmetic.base import ArithmeticFeatureGroupBase
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import is_op_token, is_scalar_number, scalar_number_value
 
 ARITHMETIC_OPERATIONS: dict[str, str] = {
     "add": "Element-wise addition of a constant",
@@ -63,6 +63,7 @@ class ScalarArithmeticFeatureGroup(ArithmeticFeatureGroupBase):
             "explanation": "Numeric constant applied element-wise to the source column",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_scalar_number,
         },
     }
 
@@ -107,6 +108,28 @@ class ScalarArithmeticFeatureGroup(ArithmeticFeatureGroupBase):
         return source_names
 
     @classmethod
+    def _extract_constant(cls, feature: Feature) -> int | float:
+        """Return the constant as a bare number, unwrapped from its container.
+
+        Owns the compute-time rejections: missing, non-numeric, and dividing by zero.
+        """
+        feature_name = feature.name
+
+        constant = feature.options.get(cls.CONSTANT)
+        if constant is None:
+            raise ValueError(f"Missing required option 'constant' for feature {feature_name!r}")
+        if not is_scalar_number(constant):
+            raise ValueError(
+                f"Option 'constant' for feature {feature_name!r} must be int or float, got {type(constant).__name__}"
+            )
+
+        value = scalar_number_value(constant)
+        # Resolve the op only when it can matter, so a constant read never depends on the op path.
+        if value == 0 and cls._extract_arithmetic_op(feature) == "divide":
+            raise ValueError(f"Cannot divide by zero for feature {feature_name!r}")
+        return value
+
+    @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         """Compute an element-wise arithmetic operation per source column.
 
@@ -125,16 +148,7 @@ class ScalarArithmeticFeatureGroup(ArithmeticFeatureGroupBase):
 
             cls._assert_source_column_is_numeric(data, source_col)
 
-            constant = feature.options.get(cls.CONSTANT)
-            if constant is None:
-                raise ValueError(f"Missing required option 'constant' for feature {feature_name!r}")
-            if isinstance(constant, bool) or not isinstance(constant, (int, float)):
-                raise ValueError(
-                    f"Option 'constant' for feature {feature_name!r} must be int or float, "
-                    f"got {type(constant).__name__}"
-                )
-            if op == "divide" and constant == 0:
-                raise ValueError(f"Cannot divide by zero for feature {feature_name!r}")
+            constant = cls._extract_constant(feature)
 
             table = cls._compute_arithmetic(table, feature_name, source_col, op, constant)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -153,6 +153,65 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
+class TestConstantArity:
+    """``constant`` is a scalar key: one value, bare or in a single-element container.
+
+    #339 regression: the singleton form matched at discovery and then raised
+    ``must be int or float, got tuple`` inside calculate_feature.
+    """
+
+    def _options(self, constant: Any) -> Options:
+        return Options(context={"arithmetic_op": "add", "constant": constant, "in_features": "value_int"})
+
+    @pytest.mark.parametrize("constant", [5, (5,), [5]])
+    def test_singleton_matches(self, constant: Any) -> None:
+        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("my_result", self._options(constant), None)
+        assert result is True
+
+    @pytest.mark.parametrize("constant", [[5, 10], (5, 10)])
+    def test_multi_element_rejected(self, constant: Any) -> None:
+        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("my_result", self._options(constant), None)
+        assert result is False
+
+    @pytest.mark.parametrize("constant", ["five", True])
+    def test_wrong_type_rejected_at_match(self, constant: Any) -> None:
+        """A non-numeric constant is a non-match at discovery, never a compute-time error."""
+        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("my_result", self._options(constant), None)
+        assert result is False
+
+    @pytest.mark.parametrize("constant", [5, (5,), [5]])
+    def test_extract_constant_unwraps_to_bare_value(self, constant: Any) -> None:
+        feature = Feature("my_result", options=self._options(constant))
+        assert ScalarArithmeticFeatureGroup._extract_constant(feature) == 5
+
+    def test_extract_constant_raises_when_missing(self) -> None:
+        feature = Feature("value_int__add_constant", options=Options())
+        with pytest.raises(ValueError, match="constant"):
+            ScalarArithmeticFeatureGroup._extract_constant(feature)
+
+    def test_extract_constant_raises_for_non_numeric(self) -> None:
+        feature = Feature("value_int__add_constant", options=Options(context={"constant": "five"}))
+        with pytest.raises(ValueError, match="int or float"):
+            ScalarArithmeticFeatureGroup._extract_constant(feature)
+
+    def test_singleton_constant_computes_instead_of_raising(self) -> None:
+        """The exact #339 reproduction: ``constant=(5,)`` must compute like ``constant=5``."""
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+        from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.pyarrow_scalar_arithmetic import (
+            PyArrowScalarArithmetic,
+        )
+
+        table = PyArrowDataOpsTestDataCreator.create()
+
+        def _compute(constant: Any) -> list[Any]:
+            fs = FeatureSet()
+            fs.add(Feature("my_result", options=self._options(constant)))
+            return list(PyArrowScalarArithmetic.calculate_feature(table, fs).column("my_result").to_pylist())
+
+        assert _compute((5,)) == _compute(5)
+
+
 class TestSingleColumnEnforcement:
     """Verify that MAX_IN_FEATURES=1 enforces single-column behavior."""
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -8,12 +8,17 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+from mloda.testing.feature_groups.data_operations.helpers import extract_column, feature_set_for
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.base import (
     ARITHMETIC_OPERATIONS,
     ScalarArithmeticFeatureGroup,
+)
+from mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.pyarrow_scalar_arithmetic import (
+    PyArrowScalarArithmetic,
 )
 
 
@@ -153,56 +158,19 @@ class TestConfigBasedFeatures:
         assert result is False
 
 
-class TestConstantArity:
-    """``constant`` checks the shared harness cannot express.
+class TestConstantExtraction:
+    """The ``constant`` check the arity harness cannot express.
 
-    The bare / single-element / multi-element verdicts live in
-    ``TestScalarArithmeticMatchValidation.token_cases``; what stays here is the
-    wrong-type rejection, the direct extractor calls and the #339 regression, where
-    the singleton form matched at discovery and then raised
-    ``must be int or float, got tuple`` inside calculate_feature.
+    Every arity verdict for ``constant`` (bare, wrapped, multi-element, wrong type,
+    bool, absent, and the #339 compute regression) is declared on
+    ``TestScalarArithmeticMatchValidation``; only the message a direct extractor call
+    raises for a value the matcher would already have rejected stays here.
     """
-
-    def _options(self, constant: Any) -> Options:
-        return Options(context={"arithmetic_op": "add", "constant": constant, "in_features": "value_int"})
-
-    @pytest.mark.parametrize("constant", ["five", True])
-    def test_wrong_type_rejected_at_match(self, constant: Any) -> None:
-        """A non-numeric constant is a non-match at discovery, never a compute-time error."""
-        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("my_result", self._options(constant), None)
-        assert result is False
-
-    @pytest.mark.parametrize("constant", [5, (5,), [5]])
-    def test_extract_constant_unwraps_to_bare_value(self, constant: Any) -> None:
-        feature = Feature("my_result", options=self._options(constant))
-        assert ScalarArithmeticFeatureGroup._extract_constant(feature) == 5
-
-    def test_extract_constant_raises_when_missing(self) -> None:
-        feature = Feature("value_int__add_constant", options=Options())
-        with pytest.raises(ValueError, match="constant"):
-            ScalarArithmeticFeatureGroup._extract_constant(feature)
 
     def test_extract_constant_raises_for_non_numeric(self) -> None:
         feature = Feature("value_int__add_constant", options=Options(context={"constant": "five"}))
         with pytest.raises(ValueError, match="int or float"):
             ScalarArithmeticFeatureGroup._extract_constant(feature)
-
-    def test_singleton_constant_computes_instead_of_raising(self) -> None:
-        """The exact #339 reproduction: ``constant=(5,)`` must compute like ``constant=5``."""
-        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-        from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
-        from mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.pyarrow_scalar_arithmetic import (
-            PyArrowScalarArithmetic,
-        )
-
-        table = PyArrowDataOpsTestDataCreator.create()
-
-        def _compute(constant: Any) -> list[Any]:
-            fs = FeatureSet()
-            fs.add(Feature("my_result", options=self._options(constant)))
-            return list(PyArrowScalarArithmetic.calculate_feature(table, fs).column("my_result").to_pylist())
-
-        assert _compute((5,)) == _compute(5)
 
 
 class TestSingleColumnEnforcement:
@@ -339,8 +307,8 @@ class TestScalarArithmeticMatchValidation(MatchValidationTestBase):
 
     @classmethod
     def token_cases(cls) -> list[TokenCase]:
-        # constant is scalar too: one number.
-        return [*super().token_cases(), TokenCase("constant", 5, 10)]
+        # constant is scalar too: one number, never a bool, and the op cannot run without it.
+        return [*super().token_cases(), TokenCase("constant", 5, 10, invalid=(True,), required=True)]
 
     @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:
@@ -349,3 +317,12 @@ class TestScalarArithmeticMatchValidation(MatchValidationTestBase):
             ScalarArithmeticFeatureGroup._extract_arithmetic_op(feature),
             ScalarArithmeticFeatureGroup._extract_constant(feature),
         ]
+
+    @classmethod
+    def compute_values(cls, options: Options) -> list[Any] | None:
+        # The #339 regression: constant=(5,) matched at discovery and then raised
+        # "must be int or float, got tuple" inside calculate_feature.
+        result = PyArrowScalarArithmetic.calculate_feature(
+            PyArrowDataOpsTestDataCreator.create(), feature_set_for("my_result", options)
+        )
+        return extract_column(result, "my_result")

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -8,7 +8,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase
+from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.base import (
@@ -154,24 +154,17 @@ class TestConfigBasedFeatures:
 
 
 class TestConstantArity:
-    """``constant`` is a scalar key: one value, bare or in a single-element container.
+    """``constant`` checks the shared harness cannot express.
 
-    #339 regression: the singleton form matched at discovery and then raised
+    The bare / single-element / multi-element verdicts live in
+    ``TestScalarArithmeticMatchValidation.token_cases``; what stays here is the
+    wrong-type rejection, the direct extractor calls and the #339 regression, where
+    the singleton form matched at discovery and then raised
     ``must be int or float, got tuple`` inside calculate_feature.
     """
 
     def _options(self, constant: Any) -> Options:
         return Options(context={"arithmetic_op": "add", "constant": constant, "in_features": "value_int"})
-
-    @pytest.mark.parametrize("constant", [5, (5,), [5]])
-    def test_singleton_matches(self, constant: Any) -> None:
-        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("my_result", self._options(constant), None)
-        assert result is True
-
-    @pytest.mark.parametrize("constant", [[5, 10], (5, 10)])
-    def test_multi_element_rejected(self, constant: Any) -> None:
-        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("my_result", self._options(constant), None)
-        assert result is False
 
     @pytest.mark.parametrize("constant", ["five", True])
     def test_wrong_type_rejected_at_match(self, constant: Any) -> None:
@@ -345,5 +338,14 @@ class TestScalarArithmeticMatchValidation(MatchValidationTestBase):
         return {"in_features": "value_int", "constant": 5}
 
     @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        # constant is scalar too: one number.
+        return [*super().token_cases(), TokenCase("constant", 5, 10)]
+
+    @classmethod
     def dispatch_values(cls, options: Options) -> list[Any]:
-        return [ScalarArithmeticFeatureGroup._extract_arithmetic_op(Feature("my_result", options=options))]
+        feature = Feature("my_result", options=options)
+        return [
+            ScalarArithmeticFeatureGroup._extract_arithmetic_op(feature),
+            ScalarArithmeticFeatureGroup._extract_constant(feature),
+        ]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_security.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_security.py
@@ -297,9 +297,11 @@ class TestConstantTypeValidation:
         with pytest.raises(ValueError, match=r"int or float"):
             PyArrowScalarArithmetic.calculate_feature(arrow_table, fs)
 
-    def test_constant_list_rejected(self) -> None:
+    def test_constant_multi_element_list_rejected(self) -> None:
+        # A one-element list is valid caller syntax for one constant (see TestConstantArity);
+        # a list holding several values is not a scalar and must still be rejected.
         arrow_table = PyArrowDataOpsTestDataCreator.create()
-        fs = _make_fs_with_constant("value_int__add_constant", [5])
+        fs = _make_fs_with_constant("value_int__add_constant", [5, 10])
         with pytest.raises(ValueError, match=r"int or float"):
             PyArrowScalarArithmetic.calculate_feature(arrow_table, fs)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
@@ -54,6 +54,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
+from mloda.community.feature_groups.data_operations.base import column_ref_value, is_column_ref
+
 # Supported sessionization units mapped to their length in seconds. The four
 # keys also define the units accepted by the feature-name regex.
 SESSIONIZATION_UNITS: dict[str, int] = {
@@ -128,6 +130,7 @@ class SessionizationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Column to order by (ascending); defaults to the source timestamp column",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: is_column_ref,
         },
     }
 
@@ -206,7 +209,7 @@ class SessionizationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         order_by = feature.options.get(cls.ORDER_BY)
         if order_by is None:
             return source_col
-        return str(order_by)
+        return column_ref_value(order_by)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/tests/test_base.py
@@ -19,6 +19,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.testing.feature_groups.data_operations.match_validation import ScalarArityTestBase, TokenCase
 from mloda.user import Feature
 
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.base import (
@@ -30,6 +31,9 @@ from mloda.community.feature_groups.data_operations.row_preserving.sessionizatio
 from mloda.community.feature_groups.data_operations.row_preserving.sessionization.pandas_sessionization import (
     PandasSessionization,
 )
+
+
+SESSIONIZE_FEATURE_NAME = "ts__sessionize_30_minute"
 
 
 def _match_options() -> Options:
@@ -138,38 +142,43 @@ class TestThresholdParser:
             _parse_sessionize_op("sessionize_0_minute")
 
 
-class TestOrderByArity:
+class TestOrderByArity(ScalarArityTestBase):
     """``order_by`` is a scalar key: one column, bare or in a single-element container.
 
-    Sessionization declares no operation config key (the threshold is part of the
-    feature name), so ``MatchValidationTestBase`` does not fit it and these checks
-    are hand-rolled. ``order_by`` uses a column DISTINCT from the source column, so
-    an unwrap is distinguishable from the absent-value fallback to the source.
+    Sessionization declares no operation config key (the threshold is part of the feature
+    name), so it declares the arity base directly instead of ``MatchValidationTestBase``.
+    ``order_by`` uses a column DISTINCT from the source column, so an unwrap is
+    distinguishable from the absent-value fallback to the source.
     """
 
-    def _options(self, order_by: Any) -> Options:
-        return Options(context={"order_by": order_by, "partition_by": ["user"]})
+    @classmethod
+    def feature_group_class(cls) -> Any:
+        return SessionizationFeatureGroup
 
-    @pytest.mark.parametrize("order_by", ["event_ts", ("event_ts",), ["event_ts"]])
-    def test_singleton_matches(self, order_by: Any) -> None:
-        assert PandasSessionization.match_feature_group_criteria("ts__sessionize_30_minute", self._options(order_by))
+    @classmethod
+    def match_class(cls) -> Any:
+        return PandasSessionization
 
-    @pytest.mark.parametrize("order_by", [["event_ts", "user"], ("event_ts", "user")])
-    def test_multi_element_rejected(self, order_by: Any) -> None:
-        result = PandasSessionization.match_feature_group_criteria("ts__sessionize_30_minute", self._options(order_by))
-        assert result is False
+    @classmethod
+    def match_feature_name(cls) -> str:
+        return SESSIONIZE_FEATURE_NAME
 
-    def test_wrong_type_rejected(self) -> None:
-        result = PandasSessionization.match_feature_group_criteria("ts__sessionize_30_minute", self._options(123))
-        assert result is False
+    @classmethod
+    def base_context(cls) -> dict[str, Any]:
+        return {"partition_by": ["user"]}
 
-    @pytest.mark.parametrize("order_by", ["event_ts", ("event_ts",), ["event_ts"]])
-    def test_extract_order_by_unwraps_to_bare_column(self, order_by: Any) -> None:
-        feature = Feature("ts__sessionize_30_minute", options=self._options(order_by))
-        assert SessionizationFeatureGroup._extract_order_by(feature, "ts") == "event_ts"
+    @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        return [TokenCase("order_by", "event_ts", "user")]
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        feature = Feature(SESSIONIZE_FEATURE_NAME, options=options)
+        return [SessionizationFeatureGroup._extract_order_by(feature, "ts")]
 
     def test_extract_order_by_defaults_to_source_column(self) -> None:
-        feature = Feature("ts__sessionize_30_minute", options=Options())
+        """The one state the arity harness cannot express: absent is not wrapped, it is absent."""
+        feature = Feature(SESSIONIZE_FEATURE_NAME, options=Options())
         assert SessionizationFeatureGroup._extract_order_by(feature, "ts") == "ts"
 
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/tests/test_base.py
@@ -139,16 +139,22 @@ class TestThresholdParser:
 
 
 class TestOrderByArity:
-    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+    """``order_by`` is a scalar key: one column, bare or in a single-element container.
+
+    Sessionization declares no operation config key (the threshold is part of the
+    feature name), so ``MatchValidationTestBase`` does not fit it and these checks
+    are hand-rolled. ``order_by`` uses a column DISTINCT from the source column, so
+    an unwrap is distinguishable from the absent-value fallback to the source.
+    """
 
     def _options(self, order_by: Any) -> Options:
         return Options(context={"order_by": order_by, "partition_by": ["user"]})
 
-    @pytest.mark.parametrize("order_by", ["ts", ("ts",), ["ts"]])
+    @pytest.mark.parametrize("order_by", ["event_ts", ("event_ts",), ["event_ts"]])
     def test_singleton_matches(self, order_by: Any) -> None:
         assert PandasSessionization.match_feature_group_criteria("ts__sessionize_30_minute", self._options(order_by))
 
-    @pytest.mark.parametrize("order_by", [["ts", "user"], ("ts", "user")])
+    @pytest.mark.parametrize("order_by", [["event_ts", "user"], ("event_ts", "user")])
     def test_multi_element_rejected(self, order_by: Any) -> None:
         result = PandasSessionization.match_feature_group_criteria("ts__sessionize_30_minute", self._options(order_by))
         assert result is False
@@ -157,10 +163,10 @@ class TestOrderByArity:
         result = PandasSessionization.match_feature_group_criteria("ts__sessionize_30_minute", self._options(123))
         assert result is False
 
-    @pytest.mark.parametrize("order_by", ["ts", ("ts",), ["ts"]])
+    @pytest.mark.parametrize("order_by", ["event_ts", ("event_ts",), ["event_ts"]])
     def test_extract_order_by_unwraps_to_bare_column(self, order_by: Any) -> None:
         feature = Feature("ts__sessionize_30_minute", options=self._options(order_by))
-        assert SessionizationFeatureGroup._extract_order_by(feature, "ts") == "ts"
+        assert SessionizationFeatureGroup._extract_order_by(feature, "ts") == "event_ts"
 
     def test_extract_order_by_defaults_to_source_column(self) -> None:
         feature = Feature("ts__sessionize_30_minute", options=Options())

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/tests/test_base.py
@@ -13,6 +13,8 @@ ema's ``ema_0`` handling).
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -134,6 +136,35 @@ class TestThresholdParser:
     def test_parse_rejects_n_zero(self) -> None:
         with pytest.raises(ValueError, match=r"(?i)positive|> 0|n"):
             _parse_sessionize_op("sessionize_0_minute")
+
+
+class TestOrderByArity:
+    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+
+    def _options(self, order_by: Any) -> Options:
+        return Options(context={"order_by": order_by, "partition_by": ["user"]})
+
+    @pytest.mark.parametrize("order_by", ["ts", ("ts",), ["ts"]])
+    def test_singleton_matches(self, order_by: Any) -> None:
+        assert PandasSessionization.match_feature_group_criteria("ts__sessionize_30_minute", self._options(order_by))
+
+    @pytest.mark.parametrize("order_by", [["ts", "user"], ("ts", "user")])
+    def test_multi_element_rejected(self, order_by: Any) -> None:
+        result = PandasSessionization.match_feature_group_criteria("ts__sessionize_30_minute", self._options(order_by))
+        assert result is False
+
+    def test_wrong_type_rejected(self) -> None:
+        result = PandasSessionization.match_feature_group_criteria("ts__sessionize_30_minute", self._options(123))
+        assert result is False
+
+    @pytest.mark.parametrize("order_by", ["ts", ("ts",), ["ts"]])
+    def test_extract_order_by_unwraps_to_bare_column(self, order_by: Any) -> None:
+        feature = Feature("ts__sessionize_30_minute", options=self._options(order_by))
+        assert SessionizationFeatureGroup._extract_order_by(feature, "ts") == "ts"
+
+    def test_extract_order_by_defaults_to_source_column(self) -> None:
+        feature = Feature("ts__sessionize_30_minute", options=Options())
+        assert SessionizationFeatureGroup._extract_order_by(feature, "ts") == "ts"
 
 
 class TestSingleColumnEnforcement:

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -13,7 +13,13 @@ from mloda.community.feature_groups.data_operations.aggregation_base import (
     AggregationFeatureGroupBase,
 )
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
-from mloda.community.feature_groups.data_operations.base import is_op_token, op_token_value
+from mloda.community.feature_groups.data_operations.base import (
+    column_ref_value,
+    is_column_ref,
+    is_op_token,
+    op_token_value,
+    option_value,
+)
 
 # Aggregation types that require an order_by column to be deterministic.
 _ORDER_DEPENDENT_AGG_TYPES = {"first", "last"}
@@ -129,6 +135,7 @@ class WindowAggregationFeatureGroup(AggregationFeatureGroupBase):
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: None,
+            DefaultOptionKeys.match_guard: is_column_ref,
         },
         MASK_KEY: {
             "explanation": "Conditional mask: (column, operator, value) tuple or list of tuples",
@@ -154,7 +161,7 @@ class WindowAggregationFeatureGroup(AggregationFeatureGroupBase):
 
         We add:
         - partition_by type validation (must be a list of strings)
-        - order_by required for first/last (must be a string)
+        - order_by required for first/last (must be one column reference)
         """
         if not super().match_feature_group_criteria(feature_name, options, _data_access_collection):
             return False
@@ -168,8 +175,7 @@ class WindowAggregationFeatureGroup(AggregationFeatureGroupBase):
         # Determine the aggregation type to check if order_by is required
         agg_type = cls._resolve_agg_type(feature_name, options)
         if agg_type in _ORDER_DEPENDENT_AGG_TYPES:
-            order_by = options.get(cls.ORDER_BY)
-            if not isinstance(order_by, str):
+            if not is_column_ref(options.get(cls.ORDER_BY)):
                 return False
 
         return True
@@ -204,7 +210,7 @@ class WindowAggregationFeatureGroup(AggregationFeatureGroupBase):
             source_col = source_features[0]
             agg_type = cls._extract_aggregation_type(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)
-            order_by = feature.options.get(cls.ORDER_BY)
+            order_by = option_value(feature.options, cls.ORDER_BY, column_ref_value)
             mask_spec = parse_mask_spec(feature.options.get(MASK_KEY))
 
             table = cls._compute_window(table, feature_name, source_col, partition_by, agg_type, order_by, mask_spec)

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -266,6 +266,52 @@ class TestConfigBasedFeatures:
         assert result_col == expected
 
 
+class TestOrderByArity:
+    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+
+    def _options(self, order_by: Any) -> Options:
+        return Options(context={"partition_by": ["region"], "order_by": order_by})
+
+    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
+    def test_singleton_matches(self, order_by: Any) -> None:
+        result = WindowAggregationFeatureGroup.match_feature_group_criteria(
+            "value_int__first_window", self._options(order_by), None
+        )
+        assert result is True
+
+    @pytest.mark.parametrize("order_by", [["timestamp", "region"], ("timestamp", "region")])
+    def test_multi_element_rejected(self, order_by: Any) -> None:
+        result = WindowAggregationFeatureGroup.match_feature_group_criteria(
+            "value_int__first_window", self._options(order_by), None
+        )
+        assert result is False
+
+    def test_wrong_type_rejected(self) -> None:
+        result = WindowAggregationFeatureGroup.match_feature_group_criteria(
+            "value_int__first_window", self._options(123), None
+        )
+        assert result is False
+
+    def test_singleton_order_by_dispatches_like_bare(self) -> None:
+        """The singleton must reach the backend as the column name, not as its string form."""
+        import pandas as pd
+
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+        from mloda.testing.data_creator.base import DataOperationsTestDataCreator
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.pandas_window_aggregation import (
+            PandasWindowAggregation,
+        )
+        from mloda.user import Feature
+
+        def _compute(order_by: Any) -> list[Any]:
+            df = pd.DataFrame(DataOperationsTestDataCreator.get_raw_data())
+            fs = FeatureSet()
+            fs.add(Feature("value_int__first_window", options=self._options(order_by)))
+            return list(PandasWindowAggregation.calculate_feature(df, fs)["value_int__first_window"])
+
+        assert _compute(("timestamp",)) == _compute("timestamp")
+
+
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -7,6 +7,8 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
+from mloda.testing.feature_groups.data_operations.helpers import extract_column, feature_set_for
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
 
@@ -266,44 +268,6 @@ class TestConfigBasedFeatures:
         assert result_col == expected
 
 
-class TestOrderByArity:
-    """``order_by`` checks the shared harness cannot express.
-
-    The bare / single-element / multi-element verdicts live in
-    ``TestWindowAggregationMatchValidation.token_cases``; what stays here is the
-    wrong-type rejection and the dispatch check, since window aggregation reads
-    ``order_by`` inline in calculate_feature rather than through an extractor.
-    """
-
-    def _options(self, order_by: Any) -> Options:
-        return Options(context={"partition_by": ["region"], "order_by": order_by})
-
-    def test_wrong_type_rejected(self) -> None:
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria(
-            "value_int__first_window", self._options(123), None
-        )
-        assert result is False
-
-    def test_singleton_order_by_dispatches_like_bare(self) -> None:
-        """The singleton must reach the backend as the column name, not as its string form."""
-        import pandas as pd
-
-        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-        from mloda.testing.data_creator.base import DataOperationsTestDataCreator
-        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.pandas_window_aggregation import (
-            PandasWindowAggregation,
-        )
-        from mloda.user import Feature
-
-        def _compute(order_by: Any) -> list[Any]:
-            df = pd.DataFrame(DataOperationsTestDataCreator.get_raw_data())
-            fs = FeatureSet()
-            fs.add(Feature("value_int__first_window", options=self._options(order_by)))
-            return list(PandasWindowAggregation.calculate_feature(df, fs)["value_int__first_window"])
-
-        assert _compute(("timestamp",)) == _compute("timestamp")
-
-
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.
 
@@ -375,3 +339,16 @@ class TestWindowAggregationMatchValidation(MatchValidationTestBase):
             WindowAggregationFeatureGroup._extract_aggregation_type(feature),
             WindowAggregationFeatureGroup._resolve_agg_type("my_result", options),
         ]
+
+    @classmethod
+    def compute_values(cls, options: Options) -> list[Any] | None:
+        # Window aggregation reads order_by inline in calculate_feature rather than through an
+        # extractor, so only a run through the backend shows a container reaching it unwrapped.
+        from mloda.community.feature_groups.data_operations.row_preserving.window_aggregation.pyarrow_window_aggregation import (
+            PyArrowWindowAggregation,
+        )
+
+        result = PyArrowWindowAggregation.calculate_feature(
+            PyArrowDataOpsTestDataCreator.create(), feature_set_for("my_window_result", options)
+        )
+        return extract_column(result, "my_window_result")

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -267,24 +267,16 @@ class TestConfigBasedFeatures:
 
 
 class TestOrderByArity:
-    """``order_by`` is a scalar key: one column, bare or in a single-element container."""
+    """``order_by`` checks the shared harness cannot express.
+
+    The bare / single-element / multi-element verdicts live in
+    ``TestWindowAggregationMatchValidation.token_cases``; what stays here is the
+    wrong-type rejection and the dispatch check, since window aggregation reads
+    ``order_by`` inline in calculate_feature rather than through an extractor.
+    """
 
     def _options(self, order_by: Any) -> Options:
         return Options(context={"partition_by": ["region"], "order_by": order_by})
-
-    @pytest.mark.parametrize("order_by", ["timestamp", ("timestamp",), ["timestamp"]])
-    def test_singleton_matches(self, order_by: Any) -> None:
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria(
-            "value_int__first_window", self._options(order_by), None
-        )
-        assert result is True
-
-    @pytest.mark.parametrize("order_by", [["timestamp", "region"], ("timestamp", "region")])
-    def test_multi_element_rejected(self, order_by: Any) -> None:
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria(
-            "value_int__first_window", self._options(order_by), None
-        )
-        assert result is False
 
     def test_wrong_type_rejected(self) -> None:
         result = WindowAggregationFeatureGroup.match_feature_group_criteria(
@@ -372,6 +364,8 @@ class TestWindowAggregationMatchValidation(MatchValidationTestBase):
             *super().token_cases(),
             TokenCase(cls.config_key(), "first", without=("order_by",), matches=False),
             TokenCase(cls.config_key(), "first"),
+            # order_by names one column; declare it under the agg type that requires it.
+            TokenCase("order_by", "timestamp", "region", context={cls.config_key(): "first"}),
         ]
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/tests/test_scalar_guards.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_scalar_guards.py
@@ -1,0 +1,228 @@
+"""Arity contract of the shared scalar match_guards.
+
+Sibling of ``test_op_token_guard.py``: what that file pins for ``is_op_token``, this
+one pins for the remaining scalar ``PROPERTY_MAPPING`` keys. Core unwraps a singleton
+container when it reads a property value (``feature_chain_parser._unpack_property_value``),
+so ``("timestamp",)`` is valid caller syntax for one column reference and ``(5,)`` for one
+number. Every key that is read back as a SINGLE value must accept that form, dispatch it
+to the bare value, and reject multi-element containers, empty containers and wrong types
+at match time rather than inside ``calculate_feature``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.options import Options
+
+from mloda.community.feature_groups.data_operations.base import (
+    column_ref_value,
+    is_column_ref,
+    is_positive_int,
+    is_scalar_number,
+    positive_int_value,
+    scalar_number_value,
+)
+from mloda.community.feature_groups.data_operations.row_preserving.binning.base import BinningFeatureGroup
+from mloda.community.feature_groups.data_operations.row_preserving.ffill.pyarrow_ffill import PyArrowFfill
+from mloda.community.feature_groups.data_operations.row_preserving.rank.base import RankFeatureGroup
+
+
+class TestIsColumnRefAccepts:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "timestamp",
+            ("timestamp",),
+            ["timestamp"],
+            {"timestamp"},
+            frozenset({"timestamp"}),
+        ],
+    )
+    def test_plain_and_singleton_accepted(self, value: Any) -> None:
+        """A plain column name and any single-element container are valid caller syntax."""
+        assert is_column_ref(value) is True
+
+
+class TestIsColumnRefRejects:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            ["timestamp", "region"],
+            ("timestamp", "region"),
+            {"timestamp", "region"},
+            frozenset({"timestamp", "region"}),
+        ],
+    )
+    def test_multi_element_container_rejected(self, value: Any) -> None:
+        """More than one column is a composite value, not a single column reference."""
+        assert is_column_ref(value) is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            123,
+            True,
+            None,
+            "",
+            [],
+            (),
+            set(),
+            frozenset(),
+            [123],
+            (None,),
+        ],
+    )
+    def test_non_str_and_empty_rejected(self, value: Any) -> None:
+        """Non-string, empty-string and empty containers are never column references."""
+        assert is_column_ref(value) is False
+
+
+class TestColumnRefValue:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "timestamp",
+            ("timestamp",),
+            ["timestamp"],
+            {"timestamp"},
+            frozenset({"timestamp"}),
+        ],
+    )
+    def test_unwraps_to_bare_column_name(self, value: Any) -> None:
+        """The unwrapper must yield the column name itself, never the container's string form."""
+        assert column_ref_value(value) == "timestamp"
+
+
+class TestIsScalarNumberAccepts:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            5,
+            -5,
+            0,
+            0.75,
+            (5,),
+            [5],
+            {5},
+            frozenset({5}),
+            (0.75,),
+            [0.75],
+        ],
+    )
+    def test_plain_and_singleton_accepted(self, value: Any) -> None:
+        assert is_scalar_number(value) is True
+
+
+class TestIsScalarNumberRejects:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            [5, 10],
+            (5, 10),
+            {5, 10},
+            frozenset({5, 10}),
+        ],
+    )
+    def test_multi_element_container_rejected(self, value: Any) -> None:
+        assert is_scalar_number(value) is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "5",
+            None,
+            [],
+            (),
+            set(),
+            frozenset(),
+            ["5"],
+            (None,),
+        ],
+    )
+    def test_non_number_and_empty_rejected(self, value: Any) -> None:
+        assert is_scalar_number(value) is False
+
+    @pytest.mark.parametrize("value", [True, False, (True,), [False]])
+    def test_bool_rejected(self, value: Any) -> None:
+        """bool subclasses int but is not a number here, the same rule is_positive_int applies."""
+        assert is_scalar_number(value) is False
+
+
+class TestScalarNumberValue:
+    @pytest.mark.parametrize("value", [5, (5,), [5], {5}, frozenset({5})])
+    def test_unwraps_to_bare_int(self, value: Any) -> None:
+        assert scalar_number_value(value) == 5
+
+    @pytest.mark.parametrize("value", [0.75, (0.75,), [0.75]])
+    def test_unwraps_to_bare_float(self, value: Any) -> None:
+        assert scalar_number_value(value) == 0.75
+
+
+class TestIsPositiveIntSingleton:
+    """is_positive_int gains the same arity contract; its value space is unchanged."""
+
+    @pytest.mark.parametrize("value", [4, (4,), [4], {4}, frozenset({4})])
+    def test_plain_and_singleton_accepted(self, value: Any) -> None:
+        assert is_positive_int(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            0,
+            (0,),
+            [0],
+            -1,
+            (-1,),
+            (4, 5),
+            [4, 5],
+            (),
+            [],
+            True,
+            (True,),
+            "4",
+            ("4",),
+            (4.0,),
+        ],
+    )
+    def test_non_positive_multi_and_wrong_type_rejected(self, value: Any) -> None:
+        assert is_positive_int(value) is False
+
+
+class TestPositiveIntValue:
+    @pytest.mark.parametrize("value", [4, (4,), [4], {4}, frozenset({4})])
+    def test_unwraps_to_bare_int(self, value: Any) -> None:
+        assert positive_int_value(value) == 4
+
+
+class TestSingletonMatchesEndToEnd:
+    """The guards' arity contract must hold through ``match_feature_group_criteria``."""
+
+    def test_singleton_n_bins_matches(self) -> None:
+        options = Options(context={"binning_op": "bin", "n_bins": (5,), "in_features": "value_int"})
+        assert BinningFeatureGroup.match_feature_group_criteria("my_result", options, None) is True
+
+    def test_multi_element_n_bins_still_rejected(self) -> None:
+        options = Options(context={"binning_op": "bin", "n_bins": [5, 10], "in_features": "value_int"})
+        assert BinningFeatureGroup.match_feature_group_criteria("my_result", options, None) is False
+
+    def test_singleton_order_by_matches(self) -> None:
+        options = Options(
+            context={
+                "rank_type": "row_number",
+                "in_features": "value_int",
+                "partition_by": ["region"],
+                "order_by": ("value_int",),
+            }
+        )
+        assert RankFeatureGroup.match_feature_group_criteria("my_result", options, None) is True
+
+    def test_multi_element_order_by_rejected(self) -> None:
+        options = Options(context={"order_by": ["timestamp", "region"], "partition_by": ["region"]})
+        assert PyArrowFfill.match_feature_group_criteria("amount__ffill", options, None) is False
+
+    def test_non_string_order_by_rejected(self) -> None:
+        options = Options(context={"order_by": 123, "partition_by": ["region"]})
+        assert PyArrowFfill.match_feature_group_criteria("amount__ffill", options, None) is False

--- a/mloda/testing/feature_groups/data_operations/helpers.py
+++ b/mloda/testing/feature_groups/data_operations/helpers.py
@@ -3,6 +3,7 @@
 Provides:
 - ``extract_column``: Extract a column from any framework result as a Python list.
 - ``make_feature_set``: Build a FeatureSet with optional partition_by/order_by.
+- ``feature_set_for``: Build a FeatureSet around an Options that already exists.
 """
 
 from __future__ import annotations
@@ -59,4 +60,16 @@ def make_feature_set(
     feature = Feature(feature_name, options=Options(context=context))
     fs = FeatureSet()
     fs.add(feature)
+    return fs
+
+
+def feature_set_for(feature_name: str, options: Options) -> FeatureSet:
+    """Build a FeatureSet holding one feature that carries ``options`` verbatim.
+
+    ``make_feature_set`` assembles the Options from keyword arguments; this one takes an
+    Options that has already been assembled, which is the shape ``compute_values`` in the
+    scalar-arity harness hands to a family.
+    """
+    fs = FeatureSet()
+    fs.add(Feature(feature_name, options=options))
     return fs

--- a/mloda/testing/feature_groups/data_operations/match_validation.py
+++ b/mloda/testing/feature_groups/data_operations/match_validation.py
@@ -6,9 +6,10 @@ Provides ``MatchValidationTestBase`` with reusable test methods covering:
 - Invalid operation types (pattern-based and options-based)
 - Special characters in the operation portion of feature names
 - Type confusion via Options (None, int)
-- Single-element containers holding exactly one operation token, over every
-  token-valued key and option state a family declares (``token_cases``), and
-  the multi-element containers that must stay rejected
+- Single-element containers holding exactly one scalar value (an operation
+  token, a column reference or a number), over every scalar key and option
+  state a family declares (``token_cases``), and the multi-element containers
+  that must stay rejected
 - Case sensitivity enforcement (lowercase only)
 - Declaration/dispatch drift between the name path and the config path: the
   acceptance half is opt-out (``parity_operations``), the rejection half is
@@ -30,9 +31,14 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys
 
 
+def _is_container(value: Any) -> bool:
+    """True for the sequence containers core unpacks element-wise; a str is one scalar, not a sequence."""
+    return isinstance(value, (list, tuple, set, frozenset))
+
+
 @dataclass(frozen=True)
 class TokenCase:
-    """One state of one token-valued config key, declared for the single-token checks.
+    """One state of one scalar config key, declared for the single-element checks.
 
     ``context`` adds to and ``without`` drops from ``additional_match_options()``,
     which is how a state that turns a conditional requirement on or off is declared
@@ -40,8 +46,10 @@ class TokenCase:
     ``matches`` is the verdict that state must produce, bare and wrapped alike.
 
     ``other`` is a second valid value for the same key, used for the multi-element
-    rejection; ``None`` skips it. Only string tokens take part in the single-element
-    checks, since a container is caller syntax for one *token*.
+    rejection; ``None`` skips it. Any non-container token takes part in the
+    single-element checks: an operation token, a column reference and a number are
+    all read back as one value. A token that is already a container is skipped,
+    since wrapping it again would change its arity rather than its syntax.
     """
 
     key: str
@@ -120,14 +128,15 @@ class MatchValidationTestBase:
 
     @classmethod
     def token_cases(cls) -> list[TokenCase]:
-        """States whose token must behave the same bare and in a single-element container.
+        """States whose value must behave the same bare and in a single-element container.
 
         Core unwraps a one-element container when it reads a property value, so
-        ``("sum",)`` is valid caller syntax for one token: it must produce the same
-        verdict as ``"sum"`` and reach dispatch as ``"sum"``, not as ``"('sum',)"``.
+        ``("sum",)`` and ``(5,)`` are valid caller syntax for one value: each must produce
+        the same verdict as its bare form and reach dispatch as ``"sum"`` / ``5``, not as
+        ``"('sum',)"`` / ``(5,)``.
 
         Defaults to the primary operation key holding parity operations. Override to
-        append the other keys a family dispatches on, and the states where a token
+        append the other scalar keys a family dispatches on, and the states where a value
         turns a conditional requirement on or off.
         """
         operations = sorted(cls.parity_operations())
@@ -286,10 +295,10 @@ class MatchValidationTestBase:
             return None
 
     def test_single_element_container_matches(self) -> None:
-        """A bare token and its single-element containers must match alike and dispatch alike."""
-        cases = [case for case in self.token_cases() if isinstance(case.token, str)]
+        """A bare value and its single-element containers must match alike and dispatch alike."""
+        cases = [case for case in self.token_cases() if not _is_container(case.token)]
         if not cases:
-            pytest.skip("config vocabulary is not a single string token")
+            pytest.skip("no scalar value declared for the single-element checks")
         for case in cases:
             bare = self._case_options(case, case.token)
             assert self._match(bare) is case.matches, f"{case.key}={case.token!r} should match: {case.matches}"
@@ -302,16 +311,16 @@ class MatchValidationTestBase:
                 )
 
     def test_single_element_container_preserves_requirements(self) -> None:
-        """A wrapped token must switch the same conditional requirements on as a bare one.
+        """A wrapped value must switch the same conditional requirements on as a bare one.
 
         ``required_when`` predicates read the option raw, so this is where a container
         that never gets unwrapped drops a requirement and lets an under-specified
         feature match at discovery and fail at compute.
         """
         predicates = self._required_when_predicates()
-        cases = [case for case in self.token_cases() if isinstance(case.token, str)]
+        cases = [case for case in self.token_cases() if not _is_container(case.token)]
         if not predicates or not cases:
-            pytest.skip("no required_when predicate keyed off a string token")
+            pytest.skip("no required_when predicate keyed off a scalar value")
         for case in cases:
             bare = self._case_options(case, case.token)
             expected = {key: bool(predicate(bare)) for key, predicate in predicates.items()}

--- a/mloda/testing/feature_groups/data_operations/match_validation.py
+++ b/mloda/testing/feature_groups/data_operations/match_validation.py
@@ -1,15 +1,23 @@
-"""Shared match-validation test base for data-operations feature groups.
+"""Shared match-validation and scalar-arity test bases for data-operations feature groups.
 
-Provides ``MatchValidationTestBase`` with reusable test methods covering:
+``ScalarArityTestBase`` owns the arity contract of every scalar PROPERTY_MAPPING key a
+family declares. Core unwraps a one-element container when it reads a property value, so
+a single-element container is valid caller syntax for one value: it must produce the same
+match verdict, switch the same conditional requirements, reach dispatch as the same value
+and compute the same column as its bare form, while a multi-element container, a value of
+the wrong type and a value outside the key's value space must stay rejected at every
+arity. Families declare their keys as ``token_cases`` and the harness derives the checks;
+nothing here needs an operation config key, so families that carry the operation entirely
+in the feature name (ema's span, ffill's fixed suffix, sessionization's threshold) use
+this base on its own.
+
+``MatchValidationTestBase`` builds on it for families that do declare an operation config
+key, adding:
 - Feature names without a source column prefix
 - SQL injection in feature names
 - Invalid operation types (pattern-based and options-based)
 - Special characters in the operation portion of feature names
 - Type confusion via Options (None, int)
-- Single-element containers holding exactly one scalar value (an operation
-  token, a column reference or a number), over every scalar key and option
-  state a family declares (``token_cases``), and the multi-element containers
-  that must stay rejected
 - Case sensitivity enforcement (lowercase only)
 - Declaration/dispatch drift between the name path and the config path: the
   acceptance half is opt-out (``parity_operations``), the rejection half is
@@ -36,13 +44,17 @@ def _is_container(value: Any) -> bool:
     return isinstance(value, (list, tuple, set, frozenset))
 
 
+#: Sentinel for "derive the wrong-type value from the token"; ``None`` opts a case out.
+_DERIVED = object()
+
+
 @dataclass(frozen=True)
 class TokenCase:
     """One state of one scalar config key, declared for the single-element checks.
 
-    ``context`` adds to and ``without`` drops from ``additional_match_options()``,
-    which is how a state that turns a conditional requirement on or off is declared
-    (a sized frame type without its ``frame_size``, ``first`` without its ``order_by``).
+    ``context`` adds to and ``without`` drops from ``base_context()``, which is how a
+    state that turns a conditional requirement on or off is declared (a sized frame type
+    without its ``frame_size``, ``first`` without its ``order_by``).
     ``matches`` is the verdict that state must produce, bare and wrapped alike.
 
     ``other`` is a second valid value for the same key, used for the multi-element
@@ -50,6 +62,19 @@ class TokenCase:
     single-element checks: an operation token, a column reference and a number are
     all read back as one value. A token that is already a container is skipped,
     since wrapping it again would change its arity rather than its syntax.
+
+    The remaining fields declare, rather than hand-roll, the per-key checks:
+
+    ``wrong_type`` is a value of a type the key never accepts, rejected bare and wrapped
+    alike; it defaults to the opposite kind of the token (an int under a string key, a
+    string under a numeric one) and ``None`` opts the case out.
+    ``invalid`` holds values inside the key's type but outside its value space (``0``
+    bins, a percentile of ``1.5``, an unparsable op token); unwrapping is syntax, not
+    permission, so each must stay rejected bare and wrapped alike.
+    ``required`` marks a key whose absence the dispatch path must reject with a
+    ``ValueError`` naming the key, rather than silently substituting a default.
+    ``compute`` opts a state out of the end-to-end compute check for families that
+    declare ``compute_values``.
     """
 
     key: str
@@ -58,20 +83,240 @@ class TokenCase:
     context: dict[str, Any] = field(default_factory=dict)
     without: tuple[str, ...] = ()
     matches: bool = True
+    wrong_type: Any = _DERIVED
+    invalid: tuple[Any, ...] = ()
+    required: bool = False
+    compute: bool = True
+
+    def wrong_type_value(self) -> Any:
+        """A value of a type this key never accepts, or None when the case opted out."""
+        if self.wrong_type is not _DERIVED:
+            return self.wrong_type
+        return 123 if isinstance(self.token, str) else "five"
 
 
-class MatchValidationTestBase:
-    """Shared match-validation tests for data-operations feature groups.
+class ScalarArityTestBase:
+    """Shared arity tests for the scalar PROPERTY_MAPPING keys a data-operations family declares.
 
-    Subclasses implement abstract methods to provide operation-specific
-    constants (valid operations, config key, feature name pattern, etc.).
-    All concrete test methods are inherited automatically.
+    Subclasses declare their keys in ``token_cases`` and, where the family has them, the
+    extractors (``dispatch_values``) and the backend call (``compute_values``) a wrapped
+    value has to survive. Everything else is derived.
     """
 
     @classmethod
     @abstractmethod
     def feature_group_class(cls) -> Any:
         """Return the base FeatureGroup class under test."""
+
+    @classmethod
+    def match_class(cls) -> Any:
+        """The class whose matcher the arity checks call.
+
+        Defaults to the feature group itself. Families whose matcher only resolves on a
+        compute-framework subclass return that subclass instead.
+        """
+        return cls.feature_group_class()
+
+    @classmethod
+    def match_feature_name(cls) -> str:
+        """The feature name the arity checks match against.
+
+        ``"my_result"`` for families that carry the operation in the config; families
+        that carry it in the feature name return a name holding that operation.
+        """
+        return "my_result"
+
+    @classmethod
+    def base_context(cls) -> dict[str, Any]:
+        """The options context every arity case starts from, before the key under test."""
+        return {}
+
+    @classmethod
+    def token_cases(cls) -> list[TokenCase]:
+        """States whose value must behave the same bare and in a single-element container.
+
+        Core unwraps a one-element container when it reads a property value, so
+        ``("sum",)`` and ``(5,)`` are valid caller syntax for one value: each must produce
+        the same verdict as its bare form and reach dispatch as ``"sum"`` / ``5``, not as
+        ``"('sum',)"`` / ``(5,)``.
+
+        Empty by default. Declare one case per scalar key the family reads, plus the
+        states where a value turns a conditional requirement on or off.
+        """
+        return []
+
+    @classmethod
+    def dispatch_values(cls, options: Options) -> list[Any]:
+        """Values the dispatch path resolves from ``options``.
+
+        Empty by default, which checks the match verdict only. Override with the
+        family's extractors to also assert that a wrapped value reaches dispatch
+        unwrapped, rather than as the string form of its container.
+        """
+        return []
+
+    @classmethod
+    def compute_values(cls, options: Options) -> list[Any] | None:
+        """The column the backend computes for ``options``, or None to skip the compute check.
+
+        None by default. Override for families where a wrapped value used to survive
+        discovery and then fail (or silently mis-sort) inside ``calculate_feature``;
+        ``make_feature_set`` and ``extract_column`` in ``helpers`` build the call.
+        """
+        return None
+
+    # -- Case options ---------------------------------------------------------
+
+    def _case_context(self, case: TokenCase) -> dict[str, Any]:
+        """The context of ``case`` without the key under test."""
+        context: dict[str, Any] = dict(self.base_context())
+        context.update(case.context)
+        for key in case.without:
+            context.pop(key, None)
+        context.pop(case.key, None)
+        return context
+
+    def _case_options(self, case: TokenCase, value: Any) -> Options:
+        """Options for ``case`` with its key holding ``value``."""
+        return Options(context={**self._case_context(case), case.key: value})
+
+    def _match(self, options: Options) -> bool:
+        """Match verdict of the configuration-based path for the given options."""
+        matcher = self.match_class().match_feature_group_criteria
+        return bool(matcher(self.match_feature_name(), options, None))
+
+    def _scalar_cases(self) -> list[TokenCase]:
+        """The declared cases whose token is one scalar value rather than a container."""
+        return [case for case in self.token_cases() if not _is_container(case.token)]
+
+    @classmethod
+    def _required_when_predicates(cls) -> dict[str, Any]:
+        """The conditional-requirement predicates the feature group declares in PROPERTY_MAPPING."""
+        mapping = getattr(cls.feature_group_class(), "PROPERTY_MAPPING", None) or {}
+        predicates = {}
+        for key, entry in mapping.items():
+            predicate = entry.get(DefaultOptionKeys.required_when) if isinstance(entry, dict) else None
+            if callable(predicate):
+                predicates[key] = predicate
+        return predicates
+
+    def _dispatch_or_none(self, options: Options) -> list[Any] | None:
+        """Values the dispatch path resolves, or None for a state its extractors reject."""
+        try:
+            return self.dispatch_values(options)
+        except ValueError:
+            return None
+
+    # -- Single-element containers -------------------------------------------
+
+    def test_single_element_container_matches(self) -> None:
+        """A bare value and its single-element containers must match alike and dispatch alike."""
+        cases = self._scalar_cases()
+        if not cases:
+            pytest.skip("no scalar value declared for the single-element checks")
+        for case in cases:
+            bare = self._case_options(case, case.token)
+            assert self._match(bare) is case.matches, f"{case.key}={case.token!r} should match: {case.matches}"
+            expected = self._dispatch_or_none(bare)
+            for value in ((case.token,), [case.token]):
+                options = self._case_options(case, value)
+                assert self._match(options) is case.matches, f"{case.key}={value!r} should match: {case.matches}"
+                assert self._dispatch_or_none(options) == expected, (
+                    f"{case.key}={value!r} should dispatch as {case.token!r}"
+                )
+
+    def test_single_element_container_preserves_requirements(self) -> None:
+        """A wrapped value must switch the same conditional requirements on as a bare one.
+
+        ``required_when`` predicates read the option raw, so this is where a container
+        that never gets unwrapped drops a requirement and lets an under-specified
+        feature match at discovery and fail at compute.
+        """
+        predicates = self._required_when_predicates()
+        cases = self._scalar_cases()
+        if not predicates or not cases:
+            pytest.skip("no required_when predicate keyed off a scalar value")
+        for case in cases:
+            bare = self._case_options(case, case.token)
+            expected = {key: bool(predicate(bare)) for key, predicate in predicates.items()}
+            for value in ((case.token,), [case.token]):
+                options = self._case_options(case, value)
+                resolved = {key: bool(predicate(options)) for key, predicate in predicates.items()}
+                assert resolved == expected, f"{case.key}={value!r} should require what {case.token!r} requires"
+
+    def test_single_element_container_computes_like_bare(self) -> None:
+        """A wrapped value must reach the backend as the value, not as its container's string form.
+
+        The match verdict and the extractors can both be right while the backend still
+        receives the container, which is how ``constant=(5,)`` matched at discovery and
+        then raised ``must be int or float, got tuple`` inside calculate_feature (#339).
+        """
+        cases = [case for case in self._scalar_cases() if case.matches and case.compute]
+        if not cases:
+            pytest.skip("no computable scalar value declared")
+        for case in cases:
+            expected = self.compute_values(self._case_options(case, case.token))
+            if expected is None:
+                pytest.skip("family declares no compute check")
+            for value in ((case.token,), [case.token]):
+                assert self.compute_values(self._case_options(case, value)) == expected, (
+                    f"{case.key}={value!r} should compute like {case.token!r}"
+                )
+
+    def test_multi_element_container_rejected(self) -> None:
+        """Two operations in one container are not one operation, whatever the container type."""
+        cases = [case for case in self.token_cases() if case.other is not None and case.matches]
+        if not cases:
+            pytest.skip("no token key declares a second operation")
+        for case in cases:
+            for value in ([case.token, case.other], (case.token, case.other)):
+                assert self._match(self._case_options(case, value)) is False, (
+                    f"Config path should reject {case.key}={value!r}"
+                )
+
+    # -- Value space ----------------------------------------------------------
+
+    def test_wrong_type_rejected_at_every_arity(self) -> None:
+        """A value of the wrong type for a scalar key is a non-match, bare or wrapped."""
+        cases = [case for case in self._scalar_cases() if case.matches and case.wrong_type_value() is not None]
+        if not cases:
+            pytest.skip("no scalar key declares a wrong-type value")
+        for case in cases:
+            wrong = case.wrong_type_value()
+            for value in (wrong, (wrong,), [wrong]):
+                assert self._match(self._case_options(case, value)) is False, (
+                    f"{case.key}={value!r} is the wrong type and should not match"
+                )
+
+    def test_invalid_value_rejected_at_every_arity(self) -> None:
+        """Unwrapping is syntax, not permission: a value the key rejects stays rejected wrapped."""
+        cases = [case for case in self._scalar_cases() if case.invalid]
+        if not cases:
+            pytest.skip("no scalar key declares a value outside its value space")
+        for case in cases:
+            for invalid in case.invalid:
+                for value in (invalid, (invalid,), [invalid]):
+                    assert self._match(self._case_options(case, value)) is False, (
+                        f"{case.key}={value!r} is outside the key's value space and should not match"
+                    )
+
+    def test_missing_required_key_raises(self) -> None:
+        """A key the family requires must fail at dispatch naming itself, not fall back to a default."""
+        cases = [case for case in self.token_cases() if case.required]
+        if not cases:
+            pytest.skip("no scalar key is declared required")
+        for case in cases:
+            with pytest.raises(ValueError, match=case.key):
+                self.dispatch_values(Options(context=self._case_context(case)))
+
+
+class MatchValidationTestBase(ScalarArityTestBase):
+    """Shared match-validation tests for data-operations feature groups.
+
+    Subclasses implement abstract methods to provide operation-specific
+    constants (valid operations, config key, feature name pattern, etc.).
+    All concrete test methods are inherited automatically.
+    """
 
     @classmethod
     @abstractmethod
@@ -127,13 +372,13 @@ class MatchValidationTestBase:
         return operation
 
     @classmethod
+    def base_context(cls) -> dict[str, Any]:
+        """The operation key holding a valid value, plus whatever else matching requires."""
+        return {cls.config_key(): cls._primary_value(), **cls.additional_match_options()}
+
+    @classmethod
     def token_cases(cls) -> list[TokenCase]:
         """States whose value must behave the same bare and in a single-element container.
-
-        Core unwraps a one-element container when it reads a property value, so
-        ``("sum",)`` and ``(5,)`` are valid caller syntax for one value: each must produce
-        the same verdict as its bare form and reach dispatch as ``"sum"`` / ``5``, not as
-        ``"('sum',)"`` / ``(5,)``.
 
         Defaults to the primary operation key holding parity operations. Override to
         append the other scalar keys a family dispatches on, and the states where a value
@@ -144,16 +389,6 @@ class MatchValidationTestBase:
             return []
         values = [cls.config_value(operation) for operation in operations[:2]]
         return [TokenCase(cls.config_key(), values[0], values[1] if len(values) > 1 else None)]
-
-    @classmethod
-    def dispatch_values(cls, options: Options) -> list[Any]:
-        """Operation values the dispatch path resolves from ``options``.
-
-        Empty by default, which checks the match verdict only. Override with the
-        family's extractors to also assert that a wrapped token reaches dispatch
-        unwrapped, rather than as the string form of its container.
-        """
-        return []
 
     @classmethod
     def options_reject_invalid_types(cls) -> bool:
@@ -188,10 +423,6 @@ class MatchValidationTestBase:
     def _config_options(self, value: Any) -> Options:
         """Options carrying ``value`` as the operation on the configuration path."""
         return Options(context={self.config_key(): value, **self.additional_match_options()})
-
-    def _match(self, options: Options) -> bool:
-        """Match verdict of the configuration-based path for the given options."""
-        return bool(self.feature_group_class().match_feature_group_criteria("my_result", options, None))
 
     # -- No source column ------------------------------------------------------
 
@@ -264,81 +495,6 @@ class MatchValidationTestBase:
     def test_integer_type_rejected(self) -> None:
         """An integer as operation type in options must not match."""
         assert self._match(self._config_options(42)) is False
-
-    # -- Single-token containers ---------------------------------------------
-
-    def _case_options(self, case: TokenCase, value: Any) -> Options:
-        """Options for ``case`` with its key holding ``value``."""
-        context: dict[str, Any] = {self.config_key(): self._primary_value(), **self.additional_match_options()}
-        context.update(case.context)
-        for key in case.without:
-            context.pop(key, None)
-        context[case.key] = value
-        return Options(context=context)
-
-    @classmethod
-    def _required_when_predicates(cls) -> dict[str, Any]:
-        """The conditional-requirement predicates the feature group declares in PROPERTY_MAPPING."""
-        mapping = getattr(cls.feature_group_class(), "PROPERTY_MAPPING", None) or {}
-        predicates = {}
-        for key, entry in mapping.items():
-            predicate = entry.get(DefaultOptionKeys.required_when) if isinstance(entry, dict) else None
-            if callable(predicate):
-                predicates[key] = predicate
-        return predicates
-
-    def _dispatch_or_none(self, options: Options) -> list[Any] | None:
-        """Values the dispatch path resolves, or None for a state its extractors reject."""
-        try:
-            return self.dispatch_values(options)
-        except ValueError:
-            return None
-
-    def test_single_element_container_matches(self) -> None:
-        """A bare value and its single-element containers must match alike and dispatch alike."""
-        cases = [case for case in self.token_cases() if not _is_container(case.token)]
-        if not cases:
-            pytest.skip("no scalar value declared for the single-element checks")
-        for case in cases:
-            bare = self._case_options(case, case.token)
-            assert self._match(bare) is case.matches, f"{case.key}={case.token!r} should match: {case.matches}"
-            expected = self._dispatch_or_none(bare)
-            for value in ((case.token,), [case.token]):
-                options = self._case_options(case, value)
-                assert self._match(options) is case.matches, f"{case.key}={value!r} should match: {case.matches}"
-                assert self._dispatch_or_none(options) == expected, (
-                    f"{case.key}={value!r} should dispatch as {case.token!r}"
-                )
-
-    def test_single_element_container_preserves_requirements(self) -> None:
-        """A wrapped value must switch the same conditional requirements on as a bare one.
-
-        ``required_when`` predicates read the option raw, so this is where a container
-        that never gets unwrapped drops a requirement and lets an under-specified
-        feature match at discovery and fail at compute.
-        """
-        predicates = self._required_when_predicates()
-        cases = [case for case in self.token_cases() if not _is_container(case.token)]
-        if not predicates or not cases:
-            pytest.skip("no required_when predicate keyed off a scalar value")
-        for case in cases:
-            bare = self._case_options(case, case.token)
-            expected = {key: bool(predicate(bare)) for key, predicate in predicates.items()}
-            for value in ((case.token,), [case.token]):
-                options = self._case_options(case, value)
-                resolved = {key: bool(predicate(options)) for key, predicate in predicates.items()}
-                assert resolved == expected, f"{case.key}={value!r} should require what {case.token!r} requires"
-
-    def test_multi_element_container_rejected(self) -> None:
-        """Two operations in one container are not one operation, whatever the container type."""
-        cases = [case for case in self.token_cases() if case.other is not None and case.matches]
-        if not cases:
-            pytest.skip("no token key declares a second operation")
-        for case in cases:
-            for value in ([case.token, case.other], (case.token, case.other)):
-                assert self._match(self._case_options(case, value)) is False, (
-                    f"Config path should reject {case.key}={value!r}"
-                )
 
     # -- Case sensitivity ----------------------------------------------------
 


### PR DESCRIPTION
Closes #339.

## Problem

`scalar_arithmetic`'s `constant` declared no `match_guard`, so `constant=(5,)` matched at discovery and then raised `ValueError: ... must be int or float, got tuple` inside `calculate_feature`. The same shape existed on `time_column` and on `order_by` in the families that read it through `str(...)`, where `("ts",)` silently became the column name `"('ts',)"`.

The rule #332 settled on for operation tokens: core unwraps a one-element container when it reads a property value, so `(x,)` is valid caller syntax for a single value. Guard the arity at match time and reject there, never at compute. That rule was never applied to the non-operation scalar keys, so within one `PROPERTY_MAPPING` some keys accepted container syntax and others did not.

## Change

Every key read back as a single value now declares a `match_guard` covering its arity and unwraps at the read site: `constant`, `order_by` (window_aggregation, frame_aggregate, rank, offset, ema, ffill, sessionization), `time_column`, `resample_op`, `percentile`, `n_bins`, `frame_size`, `frame_unit`. One value bare or in a single-element container is accepted, empty and multi-element are rejected at discovery.

The singleton unwrap lives in one place, and the guards (`is_column_ref`, `is_scalar_number`, `is_positive_int`, `is_op_token`) all delegate to it. `partition_by`, `mask` and `in_features` are genuinely multi-valued and are untouched.

Three fixes came out of review:

- `frame_unit` was the last unguarded scalar key in `frame_aggregate`. Under a rolling frame the `SUPPORTED_TIME_UNITS` check never runs, so nothing else rejected a container there.
- `_extract_binning_params` unwraps and coerces again; unwrapping alone let a float out of a function annotated `int`.
- `percentile` range-checks before `float()`. `float(10**400)` raises `OverflowError`, which the match mixin does not catch, so a user-supplied option crashed discovery instead of not matching.

## Tests

The scalar arity checks run through the shared `MatchValidationTestBase` harness that #340 added, generalized from string tokens to any scalar, so every family declaring a scalar key gets them rather than each family hand-rolling its own. Per-family tests keep what the harness cannot express: the direct extractor calls, the wrong-type rejections, and the `calculate_feature`-does-not-raise checks. `resample` gains a harness subclass it never had.

`tox` passes: 4694 passed, 171 skipped, plus ruff format, ruff check, mypy --strict and bandit.