### PR TITLE
chore: gitignore security reports from tox -e security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ coverage.xml
 .pytest_cache/
 cover/
 
+# Security reports produced by `tox -e security`
+security-reports/
+
 # Translations
 *.mo
 *.pot


### PR DESCRIPTION
Closes #355

## What

Adds `security-reports/` to `.gitignore` next to the other generated output entries, with a comment naming `tox -e security` as the producer.

## Verification

- `git check-ignore -v security-reports/` reports the new `.gitignore:security-reports/` rule
- `git status` stays clean when the report directory exists

## Note

This contribution was drafted with the assistance of an AI coding agent and reviewed by the author before opening.
