### PR TITLE
feat: guard top-level doc links in lint_docs #359

### DIFF
--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -1,4 +1,4 @@
-"""Lint documentation for broken relative links and internal imports in code snippets.
+"""Lint documentation (docs/ and top-level markdown) for broken relative links and internal imports.
 
 Run: python scripts/lint_docs.py
 Exit code: 1 if any issues found, 0 otherwise.
@@ -11,7 +11,8 @@ import sys
 from collections import deque
 from pathlib import Path
 
-DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
 
 # The orphan BFS is rooted at the guides index; docs-root files are linted but not part of that graph.
 GUIDES_DIR = DOCS_DIR / "guides"
@@ -98,7 +99,7 @@ def _slugify_heading(text: str) -> str:
 @functools.lru_cache(maxsize=None)
 def _heading_slugs(md_file: Path) -> frozenset[str]:
     slugs: set[str] = set()
-    content = _strip_code_blocks(md_file.read_text())
+    content = _strip_code_blocks(md_file.read_text(encoding="utf-8"))
     for match in HEADING_RE.finditer(content):
         slugs.add(_slugify_heading(match.group(2)))
     return frozenset(slugs)
@@ -170,7 +171,7 @@ def find_orphan_guides(docs_dir: Path, contents: dict[Path, str] | None = None) 
     def _read(path: Path) -> str:
         if contents is not None and path in contents:
             return contents[path]
-        return path.read_text()
+        return path.read_text(encoding="utf-8")
 
     root_resolved = root_index.resolve()
     reachable: set[Path] = {root_resolved}
@@ -352,7 +353,7 @@ def main() -> int:
     guides_root = GUIDES_DIR.resolve()
 
     for md_file in sorted(DOCS_DIR.rglob("*.md")):
-        content = md_file.read_text()
+        content = md_file.read_text(encoding="utf-8")
         resolved = md_file.resolve()
         contents[resolved] = content
         file_link_errors = check_relative_links_and_anchors(md_file, content)
@@ -362,6 +363,14 @@ def main() -> int:
         all_errors.extend(check_internal_imports(md_file, content))
         all_errors.extend(check_bare_fence_openers(md_file, content))
         all_errors.extend(check_retired_property_spec_spellings(md_file, content))
+
+    # Root markdown (README.md, CONTRIBUTING.md, ...) links into docs/ and at the
+    # other root files, so it needs the same guard. Orphan reachability stays a
+    # guides-only rule: root files need not be linked from docs/guides/index.md.
+    for md_file in sorted(REPO_ROOT.glob("*.md")):
+        content = md_file.read_text(encoding="utf-8")
+        link_errors.extend(check_relative_links_and_anchors(md_file, content))
+        all_errors.extend(check_bare_fence_openers(md_file, content))
 
     all_errors.extend(link_errors)
 

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -18,7 +18,7 @@ import lint_docs
 
 def _write(path: Path, body: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(body)
+    path.write_text(body, encoding="utf-8")
 
 
 def test_empty_tree_only_root_index(tmp_path: Path) -> None:
@@ -53,7 +53,7 @@ def test_unlinked_subdir_index_is_flagged(tmp_path: Path) -> None:
     _write(tmp_path / "sub" / "index.md", "# Sub\n\n[Leaf](leaf.md)\n")
     _write(tmp_path / "sub" / "leaf.md", "# Leaf\n")
     errors = lint_docs.find_orphan_guides(tmp_path)
-    flagged = {err.split(":")[0] for err in errors}
+    flagged = {Path(err.split(":")[0]).as_posix() for err in errors}
     assert "sub/index.md" in flagged
     assert "sub/leaf.md" in flagged
 
@@ -631,6 +631,84 @@ def test_main_reports_retired_property_spec_spellings(
     out = capsys.readouterr().out
     assert rc == 1
     assert "DefaultOptionKeys.allowed_values" in out
+
+
+def test_main_flags_broken_link_in_top_level_markdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A broken relative .md link in a repo-root file must fail the lint gate."""
+    docs = tmp_path / "docs"
+    guides = docs / "guides"
+    _write(guides / "index.md", "# Root\n")
+    _write(
+        tmp_path / "README.md",
+        "# README\n\n[Guide](docs/guides/index.md)\n\n[Missing](missing.md)\n",
+    )
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", guides)
+    monkeypatch.setattr(lint_docs, "REPO_ROOT", tmp_path)
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "broken link" in out
+    assert "missing.md" in out
+
+
+def test_main_flags_bare_fence_in_top_level_markdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A bare fenced-code opener in a repo-root file must fail the lint gate."""
+    docs = tmp_path / "docs"
+    guides = docs / "guides"
+    _write(guides / "index.md", "# Root\n")
+    _write(tmp_path / "README.md", "# README\n\n```\nplain\n```\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", guides)
+    monkeypatch.setattr(lint_docs, "REPO_ROOT", tmp_path)
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "bare fenced-code opener" in out
+
+
+def test_main_orphan_check_ignores_top_level_markdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Orphan reachability is guides-only; root files need no inbound links."""
+    docs = tmp_path / "docs"
+    guides = docs / "guides"
+    _write(guides / "index.md", "# Root\n")
+    _write(tmp_path / "notes.md", "# Notes\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", guides)
+    monkeypatch.setattr(lint_docs, "REPO_ROOT", tmp_path)
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "orphan" not in out
+
+
+def test_main_reads_markdown_as_utf8(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-ASCII UTF-8 in guides must not crash on Windows' GBK locale."""
+    docs = tmp_path / "docs"
+    guides = docs / "guides"
+    _write(guides / "index.md", "# Root\n\n[Guide](guide.md)\n")
+    _write(guides / "guide.md", "# Guide\n\n```text\n\u251c\u2500\u2500 plugin\n```\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", guides)
+    monkeypatch.setattr(lint_docs, "REPO_ROOT", tmp_path)
+    rc = lint_docs.main()
+    assert rc == 0
 
 
 def test_missing_root_index_uses_relative_path(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #359

Extends `scripts/lint_docs.py` so the doc gate also lints the repository's top-level `*.md` files (`README.md`, `CONTRIBUTING.md`, `SECURITY.md`, ...), not just `docs/guides/`. Root files now get:

- `check_relative_links_and_anchors`
- `check_bare_fence_openers`

`find_orphan_guides` stays scoped to `docs/guides/`, so top-level files are not required to be reachable from `docs/guides/index.md`.

Also made every markdown read explicit UTF-8, which fixes a crash on Windows where the script previously failed with `UnicodeDecodeError: 'gbk' codec ...` when guides contained box-drawing characters or arrows.

Testing:
- `python scripts/lint_docs.py` -> `All docs OK.`
- `pytest tests/test_end2end/test_lint_docs.py` -> 53 passed
- `ruff check` / `ruff format --check` on changed files -> clean
- Full `uv run tox` cannot run on this Windows machine: the `sh -c ...` command in `tox.ini` fails with `WinError 2` (`sh` is not available); the affected surface is covered by the focused checks above.

Note: this change was developed with AI assistance.