### PR TITLE
fix: report per-fence line numbers for internal imports #354

### DIFF
--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -60,12 +60,28 @@ def _fenced_ranges(content: str) -> list[tuple[int, int]]:
     return ranges
 
 
-def find_code_blocks(content: str) -> list[str]:
-    """Extract code block contents from markdown."""
-    blocks = []
-    parts = CODE_BLOCK_RE.split(content)
-    for i in range(1, len(parts), 2):
-        blocks.append(parts[i])
+def _fence_bodies(content: str) -> list[tuple[int, str]]:
+    """Return (opener line number, body) for every fenced code block.
+
+    The opener line number doubles as the offset: a body line ``n`` is file line
+    ``offset + n``.
+    """
+    blocks: list[tuple[int, str]] = []
+    opener_lineno = 0
+    body: list[str] = []
+    for lineno, line in enumerate(content.splitlines(), start=1):
+        if line.startswith("```"):
+            if opener_lineno:
+                blocks.append((opener_lineno, "\n".join(body)))
+                opener_lineno = 0
+                body = []
+            else:
+                opener_lineno = lineno
+            continue
+        if opener_lineno:
+            body.append(line)
+    if opener_lineno:
+        blocks.append((opener_lineno, "\n".join(body)))
     return blocks
 
 
@@ -109,15 +125,11 @@ def check_relative_links_and_anchors(md_file: Path, content: str) -> list[str]:
 
 def check_internal_imports(md_file: Path, content: str) -> list[str]:
     errors = []
-    code_blocks = find_code_blocks(content)
-    for block in code_blocks:
-        for line in block.splitlines():
+    for opener_lineno, body in _fence_bodies(content):
+        for lineno, line in enumerate(body.splitlines(), start=1):
             stripped = line.strip()
             if INTERNAL_IMPORT_RE.search(stripped):
-                line_num = content.find(stripped)
-                if line_num >= 0:
-                    line_num = content[:line_num].count("\n") + 1
-                errors.append(f"{md_file}:{line_num}: internal import in code snippet -> {stripped}")
+                errors.append(f"{md_file}:{opener_lineno + lineno}: internal import in code snippet -> {stripped}")
     return errors
 
 

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -200,6 +200,33 @@ def test_check_internal_imports_flags_mloda_core_import(tmp_path: Path) -> None:
     assert len(errors) == 1
     assert "internal import" in errors[0]
     assert "mloda.core" in errors[0]
+    assert errors[0].startswith(f"{md_file}:4:")
+
+
+def test_check_internal_imports_reports_own_line_for_repeated_import(tmp_path: Path) -> None:
+    """Identical imports in separate fences must report their own line numbers."""
+    md_file = tmp_path / "a.md"
+    content = (
+        "# Guide\n"
+        "\n"
+        "```python\n"
+        "from mloda.core.abstract_plugins.components.options import Options\n"
+        "```\n"
+        "\n"
+        "Some prose in between.\n"
+        "Padding line.\n"
+        "Padding line.\n"
+        "Padding line.\n"
+        "\n"
+        "```python\n"
+        "from mloda.core.abstract_plugins.components.options import Options\n"
+        "```\n"
+    )
+    _write(md_file, content)
+    errors = lint_docs.check_internal_imports(md_file, content)
+    assert len(errors) == 2
+    assert errors[0].startswith(f"{md_file}:4:")
+    assert errors[1].startswith(f"{md_file}:13:")
 
 
 def test_check_internal_imports_ignores_prose_match(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #354

Reworks `check_internal_imports` to walk fenced code blocks with a per-fence opener line offset, instead of locating each error with `content.find(stripped)`. Repeated identical imports now report their own line numbers, and the `-1` fallback path is gone so no error message can render a negative line number.

The new `_fence_bodies` helper follows the same `(opener_line, body)` pattern as `_python_fences`, so reported lines are inside the fence, not the fence opener.

Testing:
- `pytest tests/test_end2end/test_lint_docs.py` -> 49 passed (1 pre-existing Windows-only path-separator assertion in `test_unlinked_subdir_index_is_flagged` deselected locally; it passes on Linux CI)
- `python scripts/lint_docs.py` -> `All docs OK.`
- `ruff check` / `ruff format --check` and `mypy --strict` on changed files -> clean
- Full `uv run tox` cannot run on this Windows machine: the `sh -c ...` command in `tox.ini` fails with `WinError 2` (`sh` is not available)

Note: this change was developed with AI assistance.