### PR TITLE
fix(scripts): lint every markdown file under docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,5 +54,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        # Pinned: uv reads the committed uv.lock, and a lockfile serialization change across minors invalidates it.
+        python -m pip install "uv>=0.12,<0.13"
+        uv tool install tox --with tox-uv
     - name: Lint docs
-      run: python scripts/lint_docs.py
+      run: tox -e lint-docs

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -1,4 +1,4 @@
-"""Lint documentation guides for broken relative links and internal imports in code snippets.
+"""Lint documentation for broken relative links and internal imports in code snippets.
 
 Run: python scripts/lint_docs.py
 Exit code: 1 if any issues found, 0 otherwise.
@@ -11,7 +11,10 @@ import sys
 from collections import deque
 from pathlib import Path
 
-DOCS_DIR = Path(__file__).resolve().parent.parent / "docs" / "guides"
+DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
+
+# Only guides are subject to the orphan check; docs-root files are entry points, not guides.
+GUIDES_DIR = DOCS_DIR / "guides"
 
 INTERNAL_IMPORT_RE = re.compile(r"from mloda\.core\.")
 
@@ -345,7 +348,7 @@ def main() -> int:
     all_errors.extend(link_errors)
 
     if not link_errors:
-        all_errors.extend(find_orphan_guides(DOCS_DIR, contents))
+        all_errors.extend(find_orphan_guides(GUIDES_DIR, contents))
 
     if all_errors:
         print(f"Found {len(all_errors)} doc issue(s):\n")

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
 
-# Only guides are subject to the orphan check; docs-root files are entry points, not guides.
+# The orphan BFS is rooted at the guides index; docs-root files are linted but not part of that graph.
 GUIDES_DIR = DOCS_DIR / "guides"
 
 INTERNAL_IMPORT_RE = re.compile(r"from mloda\.core\.")
@@ -153,7 +153,7 @@ def find_orphan_guides(docs_dir: Path, contents: dict[Path, str] | None = None) 
     docs_root = docs_dir.resolve()
     root_index = docs_dir / INDEX_FILENAME
     if not root_index.is_file():
-        return [f"{INDEX_FILENAME}: missing root index for orphan check"]
+        return [f"{docs_dir.name}/{INDEX_FILENAME}: missing root index for orphan check"]
 
     def _read(path: Path) -> str:
         if contents is not None and path in contents:
@@ -335,19 +335,26 @@ def main() -> int:
 
     all_errors: list[str] = []
     link_errors: list[str] = []
+    guides_link_errors: list[str] = []
     contents: dict[Path, str] = {}
+    guides_root = GUIDES_DIR.resolve()
 
     for md_file in sorted(DOCS_DIR.rglob("*.md")):
         content = md_file.read_text()
-        contents[md_file.resolve()] = content
-        link_errors.extend(check_relative_links_and_anchors(md_file, content))
+        resolved = md_file.resolve()
+        contents[resolved] = content
+        file_link_errors = check_relative_links_and_anchors(md_file, content)
+        link_errors.extend(file_link_errors)
+        if resolved.is_relative_to(guides_root):
+            guides_link_errors.extend(file_link_errors)
         all_errors.extend(check_internal_imports(md_file, content))
         all_errors.extend(check_bare_fence_openers(md_file, content))
         all_errors.extend(check_retired_property_spec_spellings(md_file, content))
 
     all_errors.extend(link_errors)
 
-    if not link_errors:
+    # Only link errors inside guides can corrupt the reachability BFS.
+    if not guides_link_errors:
         all_errors.extend(find_orphan_guides(GUIDES_DIR, contents))
 
     if all_errors:

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -103,6 +103,14 @@ def test_link_outside_docs_dir_does_not_crash(tmp_path: Path) -> None:
     assert lint_docs.find_orphan_guides(docs) == []
 
 
+def test_docs_dir_is_repo_docs_root() -> None:
+    """DOCS_DIR is the docs root and GUIDES_DIR its guides subdir; re-narrowing DOCS_DIR breaks this."""
+    assert lint_docs.DOCS_DIR == _REPO_ROOT / "docs"
+    assert lint_docs.GUIDES_DIR == _REPO_ROOT / "docs" / "guides"
+    assert lint_docs.GUIDES_DIR.is_dir()
+    assert list(lint_docs.DOCS_DIR.glob("*.md")), "docs-root markdown must exist and be in lint scope"
+
+
 def test_broken_link_suppresses_orphan_cascade(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -114,6 +122,7 @@ def test_broken_link_suppresses_orphan_cascade(
     _write(tmp_path / "plugins" / "index.md", "# Plugins\n\n[A](a.md)\n")
     _write(tmp_path / "plugins" / "a.md", "# A\n")
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -129,11 +138,64 @@ def test_clean_tree_runs_orphan_check(
     _write(tmp_path / "index.md", "# Root\n")
     _write(tmp_path / "orphan.md", "# Orphan\n")
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
     assert "orphan guide" in out
     assert "orphan.md" in out
+
+
+def test_main_flags_broken_link_outside_guides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Markdown at the docs root (packaging.md, releasing.md) is link-checked, not only docs/guides."""
+    _write(tmp_path / "guides" / "index.md", "# Guides\n")
+    _write(tmp_path / "packaging.md", "# Packaging\n\n[Missing](missing.md)\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "broken link" in out
+    assert "packaging.md" in out
+
+
+def test_main_flags_bare_fence_outside_guides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The fence check follows the widened walk: a bare ``` opener at the docs root is flagged."""
+    _write(tmp_path / "guides" / "index.md", "# Guides\n")
+    _write(tmp_path / "releasing.md", "# Releasing\n\n```\nuv build\n```\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "bare fenced-code opener" in out
+    assert "releasing.md" in out
+
+
+def test_orphan_check_stays_scoped_to_guides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Docs-root files are not guides, so they are never orphans; unlinked files under guides still are."""
+    _write(tmp_path / "guides" / "index.md", "# Guides\n")
+    _write(tmp_path / "guides" / "stray.md", "# Stray\n")
+    _write(tmp_path / "packaging.md", "# Packaging\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "stray.md: orphan guide" in out
+    assert "packaging.md" not in out
 
 
 def test_fenced_broken_link_is_ignored_by_link_check(tmp_path: Path) -> None:
@@ -507,6 +569,7 @@ def test_main_reports_retired_property_spec_spellings(
         "# Root\n\n```python\nkey = DefaultOptionKeys.allowed_values\n```\n",
     )
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -95,6 +95,16 @@ def test_missing_root_index_returns_sentinel(tmp_path: Path) -> None:
     assert "missing root index" in errors[0]
 
 
+def test_missing_root_index_names_scope_directory(tmp_path: Path) -> None:
+    """The sentinel names the orphan-scope dir, which is no longer the same dir the linter walks."""
+    guides = tmp_path / "guides"
+    guides.mkdir()
+    errors = lint_docs.find_orphan_guides(guides)
+    assert len(errors) == 1
+    assert errors[0] == "guides/index.md: missing root index for orphan check"
+    assert str(tmp_path) not in errors[0]
+
+
 def test_link_outside_docs_dir_does_not_crash(tmp_path: Path) -> None:
     outside = tmp_path.parent / "outside.md"
     outside.write_text("# Outside\n")
@@ -108,7 +118,8 @@ def test_docs_dir_is_repo_docs_root() -> None:
     assert lint_docs.DOCS_DIR == _REPO_ROOT / "docs"
     assert lint_docs.GUIDES_DIR == _REPO_ROOT / "docs" / "guides"
     assert lint_docs.GUIDES_DIR.is_dir()
-    assert list(lint_docs.DOCS_DIR.glob("*.md")), "docs-root markdown must exist and be in lint scope"
+    outside_guides = [p for p in lint_docs.DOCS_DIR.rglob("*.md") if not p.is_relative_to(lint_docs.GUIDES_DIR)]
+    assert outside_guides, "markdown outside docs/guides must exist and be in lint scope"
 
 
 def test_broken_link_suppresses_orphan_cascade(
@@ -116,18 +127,37 @@ def test_broken_link_suppresses_orphan_cascade(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Regression for fix 3: broken-link errors suppress the orphan check in main()."""
+    """A link error inside guides can corrupt the reachability BFS, so it still suppresses the orphan check."""
     # "plgins" is an intentional typo: it's what makes the link broken for this test.
-    _write(tmp_path / "index.md", "# Root\n\n[Plugins](plgins/index.md)\n")
-    _write(tmp_path / "plugins" / "index.md", "# Plugins\n\n[A](a.md)\n")
-    _write(tmp_path / "plugins" / "a.md", "# A\n")
+    _write(tmp_path / "guides" / "index.md", "# Guides\n\n[Plugins](plgins/index.md)\n")
+    _write(tmp_path / "guides" / "plugins" / "index.md", "# Plugins\n\n[A](a.md)\n")
+    _write(tmp_path / "guides" / "plugins" / "a.md", "# A\n")
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
-    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
     assert "broken link" in out
     assert "orphan guide" not in out
+
+
+def test_docs_root_link_error_does_not_suppress_guides_orphan_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A broken link outside guides cannot corrupt the guides BFS, so the orphan check must still run."""
+    _write(tmp_path / "guides" / "index.md", "# Guides\n")
+    _write(tmp_path / "guides" / "stray.md", "# Stray\n")
+    _write(tmp_path / "packaging.md", "# Packaging\n\n[Missing](missing.md)\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "broken link" in out
+    assert "packaging.md" in out
+    assert "stray.md: orphan guide" in out
 
 
 def test_clean_tree_runs_orphan_check(


### PR DESCRIPTION
Closes #361.

`scripts/lint_docs.py` hardcoded `DOCS_DIR` to `docs/guides`, so `docs/packaging.md` and `docs/releasing.md` got no link, anchor, fence, internal-import or retired-spelling checking. That is the drift mode the retired maintainer notes demonstrated: stale samples and an outdated package table with nothing to catch them.

## What changed

- `DOCS_DIR` now points at the `docs` root, so the walk covers every markdown file under `docs/` (72 files, up from 70).
- The orphan check keeps its guides-only scope through the new `GUIDES_DIR`: it is a BFS rooted at `docs/guides/index.md` and assumes that layout, so docs-root files are linted but are not part of that graph.
- The orphan check is suppressed only by link errors from files inside `docs/guides`. A broken link at the docs root cannot corrupt a BFS rooted in the guides index, so it must not hide unrelated orphans.
- The "missing root index" sentinel names its scope directory, which matters now that the walk scope and the orphan scope differ.
- The CI job runs `tox -e lint-docs` instead of calling the script against the runner's system Python. One entry point for the check, so the workflow and the tox env cannot drift.

## Verification

- `tox` green: 4689 passed, 210 skipped, ruff format, ruff check, mypy --strict and bandit clean.
- `tox -e lint-docs` reports "All docs OK." on the real tree; the two newly in-scope files needed no edits.
- 55 tests in `tests/test_end2end/test_lint_docs.py`, including new coverage for a docs-root broken link, a docs-root bare fence, the orphan scope boundary, and the cross-scope suppression fix.
