### PR TITLE
fix(packaging): correct the setuptools floor and bind wheels by exact name

### DIFF
--- a/.github/workflows/package-integrity.yaml
+++ b/.github/workflows/package-integrity.yaml
@@ -27,3 +27,5 @@ jobs:
       run: tox -e check-generated
     - name: Verify all packages build
       run: tox -e verify-builds
+    - name: Verify packages build at the declared setuptools floor
+      run: tox -e verify-build-floor

--- a/config/shared.toml
+++ b/config/shared.toml
@@ -11,7 +11,8 @@ Homepage = "https://mloda.ai"
 Repository = "https://github.com/mloda-ai/mloda-registry"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+# 77.0.1 is the first release accepting the PEP 639 SPDX license string the generator emits.
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [defaults]

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -34,7 +34,9 @@ Single source for values every package shares. `core_dependency` is substituted
 into any `{core_dependency}` placeholder in `packages.toml`, so the mloda floor
 is declared once. The `[build-system]` setuptools floor tracks the PEP 639 SPDX
 `license` string the generator emits (accepted only from setuptools 77.0.1 on),
-so it cannot be lowered without changing that form.
+so it cannot be lowered without changing that form. The root `pyproject.toml`
+keeps its own, higher, independent floor: it is the dev-only workspace package,
+is never published, declares no `license`, and its floor is Dependabot-managed.
 
 ```toml
 [project]

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -32,7 +32,9 @@ scripts/generate_pyproject.py
 
 Single source for values every package shares. `core_dependency` is substituted
 into any `{core_dependency}` placeholder in `packages.toml`, so the mloda floor
-is declared once.
+is declared once. The `[build-system]` setuptools floor tracks the PEP 639 SPDX
+`license` string the generator emits (accepted only from setuptools 77.0.1 on),
+so it cannot be lowered without changing that form.
 
 ```toml
 [project]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -69,6 +69,9 @@ only `minor:` bumps the minor version, everything else (`feat:`, `fix:`, `docs:`
 
 `--wheel --no-build-isolation` is required because the monorepo uses
 `package-dir = {"" = "../.."}`, which needs access to parent directories during build.
+The build gate binds each wheel to its package by exact distribution name, because all
+packages share one out-dir and prefix siblings (`mloda-community` vs
+`mloda-community-offset`) would otherwise collide.
 
 ## Files
 

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/data_operations/string/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/string/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/example/example_a/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_a/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/example/example_b/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_b/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mloda/testing/pyproject.toml
+++ b/mloda/testing/pyproject.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/scripts/verify_build_floor.py
+++ b/scripts/verify_build_floor.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Build at the setuptools floor config/shared.toml declares, in an environment pinned to exactly it.
+
+Run: python scripts/verify_build_floor.py
+Exit code: 1 if the floor cannot build every license form the generator emits, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHARED_CONFIG = REPO_ROOT / "config" / "shared.toml"
+
+# Only the lower bound matters: "setuptools>=77.0.1" and "setuptools >= 77.0.1, < 90" both floor at 77.0.1.
+SETUPTOOLS_FLOOR_RE = re.compile(r"^setuptools\s*>=\s*([^\s,;]+)")
+
+# The path prefix the generator reads as proprietary, which emits a LicenseRef instead of an SPDX id.
+PROPRIETARY_PATH_PREFIX = "mloda/enterprise"
+
+LICENSE_FORMS = ("apache", "proprietary")
+
+
+def declared_setuptools_floor(requires: list[str] | None = None) -> str:
+    """The setuptools lower bound of a [build-system].requires list, config/shared.toml's by default."""
+    if requires is None:
+        with open(SHARED_CONFIG, "rb") as f:
+            requires = tomllib.load(f)["build-system"]["requires"]
+    for entry in requires:
+        match = SETUPTOOLS_FLOOR_RE.match(entry.strip())
+        if match is not None:
+            return match.group(1)
+    raise ValueError(f"no setuptools lower bound in build-system requires: {requires!r}")
+
+
+def license_form(path: str) -> str:
+    """The license form the generator emits for a package path."""
+    return "proprietary" if path.startswith(PROPRIETARY_PATH_PREFIX) else "apache"
+
+
+def license_sample_packages(packages: dict[str, dict[str, Any]]) -> dict[str, str]:
+    """First package name per license form; setuptools validates a LicenseRef on a different path than an SPDX id."""
+    samples: dict[str, str] = {}
+    for pkg_name, pkg_config in packages.items():
+        samples.setdefault(license_form(str(pkg_config["path"])), pkg_name)
+    return samples
+
+
+def venv_python(venv: Path) -> Path:
+    """Interpreter of a uv-created virtual environment."""
+    return venv / "bin" / "python"
+
+
+def create_floor_env(venv: Path, floor: str) -> str | None:
+    """Create a venv holding exactly setuptools==floor; returns an error message, or None on success."""
+    commands = [
+        ["uv", "venv", "--python", sys.executable, str(venv)],
+        ["uv", "pip", "install", "--python", str(venv_python(venv)), f"setuptools=={floor}"],
+    ]
+    for command in commands:
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            return f"{' '.join(command)} failed:\n{result.stderr[-500:]}"
+    return None
+
+
+def build_wheel_with(python: Path, pkg_dir: Path, out_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Build one package by calling the backend directly, so only the setuptools in ``python`` is used."""
+    code = f"from setuptools import build_meta; build_meta.build_wheel({str(out_dir)!r})"
+    return subprocess.run([str(python), "-c", code], cwd=pkg_dir, capture_output=True, text=True)
+
+
+def main() -> int:
+    # The reused verify_builds helpers resolve the config and the build directories relative to cwd.
+    os.chdir(REPO_ROOT)
+    from verify_builds import (
+        cleanup_build_dirs,
+        cleanup_egg_info,
+        find_wheels,
+        get_wheel_metadata,
+        load_packages_config,
+    )
+
+    floor = declared_setuptools_floor()
+    print(f"Verifying the declared build floor: setuptools=={floor}")
+
+    packages = load_packages_config()
+    samples = license_sample_packages(packages)
+    missing = [form for form in LICENSE_FORMS if form not in samples]
+    if missing:
+        print(f"\n❌ config/packages.toml declares no package for license form(s): {missing}")
+        return 1
+
+    errors: list[str] = []
+    cleanup_build_dirs()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv = Path(tmpdir) / "venv"
+            out_dir = Path(tmpdir) / "wheels"
+            out_dir.mkdir()
+
+            setup_error = create_floor_env(venv, floor)
+            if setup_error is not None:
+                print(f"\n❌ {setup_error}")
+                return 1
+
+            for form in LICENSE_FORMS:
+                pkg_name = samples[form]
+                print(f"\nBuilding {pkg_name} ({form} license) at setuptools=={floor}...")
+                result = build_wheel_with(venv_python(venv), REPO_ROOT / packages[pkg_name]["path"], out_dir)
+                if result.returncode != 0:
+                    errors.append(f"{pkg_name}: build failed at setuptools=={floor}\n{result.stderr[-500:]}")
+                    continue
+
+                wheels = find_wheels(out_dir, pkg_name)
+                if len(wheels) != 1:
+                    errors.append(f"{pkg_name}: expected exactly one wheel, got {[wheel.name for wheel in wheels]}")
+                    continue
+
+                # A dropped license field would still build, so the metadata has to carry the form back.
+                if "License-Expression:" not in get_wheel_metadata(wheels[0]):
+                    errors.append(f"{pkg_name}: {wheels[0].name} METADATA has no 'License-Expression:' line")
+                    continue
+
+                print(f"  ✓ {wheels[0].name}")
+    finally:
+        cleanup_egg_info()
+        cleanup_build_dirs()
+
+    if errors:
+        print("\n❌ Errors:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"\n✅ setuptools=={floor} builds every license form the generator emits")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_builds.py
+++ b/scripts/verify_builds.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import configparser
+import re
 import shutil
 import subprocess
 import sys
@@ -40,9 +41,15 @@ def load_packages_from_config() -> list[tuple[str, str]]:
 PACKAGES = load_packages_from_config()
 
 
-def wheel_glob(pkg_name: str, version: str) -> str:
-    """Glob for one distribution's wheel; the '-' after the name excludes prefix siblings sharing the out-dir."""
-    return f"{pkg_name.replace('-', '_')}-{version}-*.whl"
+def escape_distribution_name(name: str) -> str:
+    """Escape a distribution name the way a wheel filename carries it (PEP 427/503)."""
+    return re.sub(r"[-_.]+", "_", name.lower())
+
+
+def find_wheels(out_dir: Path, pkg_name: str) -> list[Path]:
+    """Wheels in out_dir whose distribution segment is exactly pkg_name, so prefix siblings never match."""
+    escaped = escape_distribution_name(pkg_name)
+    return sorted((path for path in out_dir.glob("*.whl") if path.name.split("-")[0] == escaped), key=lambda p: p.name)
 
 
 def namespaced_entry_point_error(group: str, name: str, value: str) -> str | None:
@@ -343,17 +350,21 @@ def main() -> int:
                 continue
 
             # Find and verify wheel
-            pattern = wheel_glob(pkg_name, expected_version)
-            wheels = list(Path(tmpdir).glob(pattern))
+            wheels = find_wheels(Path(tmpdir), pkg_name)
             if not wheels:
-                errors.append(f"{pkg_name}: no wheel produced (nothing in the out-dir matched {pattern})")
+                errors.append(f"{pkg_name}: no wheel produced (no wheel in the out-dir carries this distribution)")
+                continue
+            if len(wheels) > 1:
+                candidates = ", ".join(wheel.name for wheel in wheels)
+                errors.append(f"{pkg_name}: ambiguous wheels in the out-dir ({candidates})")
                 continue
 
-            if not verify_wheel_version(wheels[0], expected_version):
-                errors.append(f"{pkg_name}: version mismatch in wheel (expected {expected_version})")
+            wheel = wheels[0]
+            if not verify_wheel_version(wheel, expected_version):
+                errors.append(f"{pkg_name}: version mismatch in wheel (expected {expected_version}, got {wheel.name})")
             else:
-                print(f"  ✓ {wheels[0].name}")
-                built_wheels[pkg_name] = wheels[0]
+                print(f"  ✓ {wheel.name}")
+                built_wheels[pkg_name] = wheel
 
         # Verify dependency relationships
         print("\nVerifying dependency relationships...")

--- a/scripts/verify_builds.py
+++ b/scripts/verify_builds.py
@@ -40,6 +40,11 @@ def load_packages_from_config() -> list[tuple[str, str]]:
 PACKAGES = load_packages_from_config()
 
 
+def wheel_glob(pkg_name: str, version: str) -> str:
+    """Glob for one distribution's wheel; the '-' after the name excludes prefix siblings sharing the out-dir."""
+    return f"{pkg_name.replace('-', '_')}-{version}-*.whl"
+
+
 def namespaced_entry_point_error(group: str, name: str, value: str) -> str | None:
     """Return an error message if an entry-point target is not a valid namespaced manifest, else None."""
     if ":" not in value:
@@ -338,9 +343,10 @@ def main() -> int:
                 continue
 
             # Find and verify wheel
-            wheels = list(Path(tmpdir).glob(f"{pkg_name.replace('-', '_')}*.whl"))
+            pattern = wheel_glob(pkg_name, expected_version)
+            wheels = list(Path(tmpdir).glob(pattern))
             if not wheels:
-                errors.append(f"{pkg_name}: no wheel produced")
+                errors.append(f"{pkg_name}: no wheel produced (nothing in the out-dir matched {pattern})")
                 continue
 
             if not verify_wheel_version(wheels[0], expected_version):

--- a/tests/script_loader.py
+++ b/tests/script_loader.py
@@ -1,0 +1,17 @@
+"""Loader for the loose scripts under ``scripts/``. They are not installed packages, so tests that
+exercise them import them by file path."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def load_script(name: str, path: Path) -> ModuleType:
+    """Import a loose script by file path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"could not load spec for {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_end2end/test_build_system_floor.py
+++ b/tests/test_end2end/test_build_system_floor.py
@@ -1,0 +1,122 @@
+"""The declared setuptools build floor must cover the license form the generator emits.
+
+``scripts/generate_pyproject.py`` writes the PEP 639 form ``license = "Apache-2.0"``, a bare SPDX
+string rather than the legacy ``{ text = ... }`` / ``{ file = ... }`` table. setuptools 76.1.0
+rejects that form with ``ValueError: invalid pyproject.toml config: project.license``; 77.0.1 is the
+first release that accepts it (77.0.0 was never published). So the ``[build-system].requires`` floor
+in ``config/shared.toml``, inherited by every generated ``pyproject.toml``, must be at least 77.0.1.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
+_SHARED_CONFIG = _REPO_ROOT / "config" / "shared.toml"
+_PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
+
+# First setuptools release accepting a PEP 639 SPDX license string.
+_PEP639_SETUPTOOLS = "77.0.1"
+
+# Any package works: the license line and the build-system block come from the shared config.
+_SAMPLE_PACKAGE = "mloda-registry"
+
+_SETUPTOOLS_FLOOR_RE = re.compile(r"^setuptools\s*>=\s*(?P<version>[0-9][0-9.]*)$")
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    """Import a loose script by file path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"could not load spec for {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gen = _load_module("generate_pyproject", _GEN_PATH)
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Comparable form of a numeric release version."""
+    return tuple(int(part) for part in version.split("."))
+
+
+def _setuptools_floor(source: str, requires: list[str]) -> str:
+    """The ``X`` of the single ``setuptools>=X`` entry of a ``[build-system].requires`` array."""
+    matches = [_SETUPTOOLS_FLOOR_RE.match(entry.strip()) for entry in requires]
+    floors = [match.group("version") for match in matches if match is not None]
+    assert len(floors) == 1, f"{source}: expected exactly one 'setuptools>=X' build requirement, got {requires!r}"
+    return floors[0]
+
+
+def _shared_floor() -> str:
+    """The setuptools floor every generated pyproject.toml inherits."""
+    return _setuptools_floor(str(_SHARED_CONFIG), _load_toml(_SHARED_CONFIG)["build-system"]["requires"])
+
+
+def _generated_license(pkg_name: str) -> Any:
+    """The ``[project].license`` value the generator emits for a package."""
+    shared = _load_toml(_SHARED_CONFIG)
+    packages = _load_toml(_PACKAGES_CONFIG)["packages"]
+    content: str = gen.generate_pyproject(pkg_name, packages[pkg_name], shared, packages)
+    return tomllib.loads(content).get("project", {}).get("license")
+
+
+def test_generator_emits_a_bare_spdx_license() -> None:
+    """The emitted form, pinned here because the build floor below exists for it."""
+    license_value = _generated_license(_SAMPLE_PACKAGE)
+    assert isinstance(license_value, str), (
+        f"{_SAMPLE_PACKAGE}: expected a PEP 639 SPDX license string, got {license_value!r}"
+    )
+
+
+def test_build_floor_covers_the_emitted_license_form() -> None:
+    """A PEP 639 license string builds only from setuptools 77.0.1 on."""
+    license_value = _generated_license(_SAMPLE_PACKAGE)
+    assert isinstance(license_value, str), (
+        f"{_SAMPLE_PACKAGE}: the generator no longer emits a PEP 639 SPDX license string but "
+        f"{license_value!r}; the setuptools floor asserted below exists for that form, revisit it"
+    )
+
+    floor = _shared_floor()
+    assert _version_tuple(floor) >= _version_tuple(_PEP639_SETUPTOOLS), (
+        f"config/shared.toml declares setuptools>={floor}, but the generator emits "
+        f'license = "{license_value}", which setuptools accepts only from {_PEP639_SETUPTOOLS} on '
+        "(76.1.0 raises 'invalid pyproject.toml config: project.license')."
+    )
+
+
+def test_generated_pyprojects_carry_the_shared_build_floor() -> None:
+    """A floor bump reaches wheels only once every generated pyproject.toml carries it."""
+    shared_floor = _shared_floor()
+    packages = _load_toml(_PACKAGES_CONFIG)["packages"]
+
+    checked = 0
+    for pkg_name, pkg_config in packages.items():
+        pyproject_path = _REPO_ROOT / pkg_config["path"] / "pyproject.toml"
+        assert pyproject_path.exists(), f"{pyproject_path} is missing (run scripts/generate_pyproject.py)."
+        requires = _load_toml(pyproject_path).get("build-system", {}).get("requires", [])
+        floor = _setuptools_floor(str(pyproject_path), requires)
+        assert floor == shared_floor, (
+            f"{pkg_name}: generated {pyproject_path} requires setuptools>={floor}, but "
+            f"config/shared.toml declares setuptools>={shared_floor} (run scripts/generate_pyproject.py)."
+        )
+        checked += 1
+
+    assert checked > 0, "expected at least one generated pyproject.toml to declare a setuptools floor."

--- a/tests/test_end2end/test_build_system_floor.py
+++ b/tests/test_end2end/test_build_system_floor.py
@@ -1,19 +1,12 @@
-"""The declared setuptools build floor must cover the license form the generator emits.
-
-``scripts/generate_pyproject.py`` writes the PEP 639 form ``license = "Apache-2.0"``, a bare SPDX
-string rather than the legacy ``{ text = ... }`` / ``{ file = ... }`` table. setuptools 76.1.0
-rejects that form with ``ValueError: invalid pyproject.toml config: project.license``; 77.0.1 is the
-first release that accepts it (77.0.0 was never published). So the ``[build-system].requires`` floor
-in ``config/shared.toml``, inherited by every generated ``pyproject.toml``, must be at least 77.0.1.
-"""
+"""The declared setuptools build floor must cover the bare PEP 639 SPDX license string the generator
+emits; setuptools rejects that form before 77.0.1. The floor is proven by ``tox -e verify-build-floor``,
+which really builds at it; this module only guards the declaration against drift."""
 
 from __future__ import annotations
 
-import importlib.util
-import re
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 if sys.version_info >= (3, 11):
@@ -21,30 +14,32 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
 
+import pytest
+
+from tests.script_loader import load_script
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
+_FLOOR_PATH = _REPO_ROOT / "scripts" / "verify_build_floor.py"
 _SHARED_CONFIG = _REPO_ROOT / "config" / "shared.toml"
 _PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
 
-# First setuptools release accepting a PEP 639 SPDX license string.
+# First setuptools release accepting a PEP 639 SPDX license string (77.0.0 was never published).
 _PEP639_SETUPTOOLS = "77.0.1"
 
-# Any package works: the license line and the build-system block come from the shared config.
-_SAMPLE_PACKAGE = "mloda-registry"
+# One package per emitted license form; the generator infers proprietary from an mloda/enterprise path.
+_LICENSE_SAMPLES = [("mloda-registry", "Apache-2.0"), ("mloda-enterprise", "LicenseRef-Proprietary")]
 
-_SETUPTOOLS_FLOOR_RE = re.compile(r"^setuptools\s*>=\s*(?P<version>[0-9][0-9.]*)$")
-
-
-def _load_module(name: str, path: Path) -> ModuleType:
-    """Import a loose script by file path."""
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec is not None and spec.loader is not None, f"could not load spec for {path}"
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+gen = load_script("generate_pyproject", _GEN_PATH)
 
 
-gen = _load_module("generate_pyproject", _GEN_PATH)
+def _declared_setuptools_floor() -> Callable[..., str]:
+    """The floor parser scripts/verify_build_floor.py must expose, shared with tox -e verify-build-floor."""
+    assert _FLOOR_PATH.exists(), f"{_FLOOR_PATH} is missing; it is what 'tox -e verify-build-floor' runs"
+    module = load_script("verify_build_floor", _FLOOR_PATH)
+    parser: Callable[..., str] | None = getattr(module, "declared_setuptools_floor", None)
+    assert callable(parser), "verify_build_floor.declared_setuptools_floor must be a callable"
+    return parser
 
 
 def _load_toml(path: Path) -> dict[str, Any]:
@@ -57,19 +52,6 @@ def _version_tuple(version: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version.split("."))
 
 
-def _setuptools_floor(source: str, requires: list[str]) -> str:
-    """The ``X`` of the single ``setuptools>=X`` entry of a ``[build-system].requires`` array."""
-    matches = [_SETUPTOOLS_FLOOR_RE.match(entry.strip()) for entry in requires]
-    floors = [match.group("version") for match in matches if match is not None]
-    assert len(floors) == 1, f"{source}: expected exactly one 'setuptools>=X' build requirement, got {requires!r}"
-    return floors[0]
-
-
-def _shared_floor() -> str:
-    """The setuptools floor every generated pyproject.toml inherits."""
-    return _setuptools_floor(str(_SHARED_CONFIG), _load_toml(_SHARED_CONFIG)["build-system"]["requires"])
-
-
 def _generated_license(pkg_name: str) -> Any:
     """The ``[project].license`` value the generator emits for a package."""
     shared = _load_toml(_SHARED_CONFIG)
@@ -78,41 +60,64 @@ def _generated_license(pkg_name: str) -> Any:
     return tomllib.loads(content).get("project", {}).get("license")
 
 
-def test_generator_emits_a_bare_spdx_license() -> None:
-    """The emitted form, pinned here because the build floor below exists for it."""
-    license_value = _generated_license(_SAMPLE_PACKAGE)
-    assert isinstance(license_value, str), (
-        f"{_SAMPLE_PACKAGE}: expected a PEP 639 SPDX license string, got {license_value!r}"
+@pytest.mark.parametrize(("pkg_name", "expected_license"), _LICENSE_SAMPLES)
+def test_build_floor_covers_the_emitted_license_form(pkg_name: str, expected_license: str) -> None:
+    """Both emitted forms are bare SPDX strings, which setuptools accepts only from 77.0.1 on."""
+    license_value = _generated_license(pkg_name)
+    assert license_value == expected_license, (
+        f"{pkg_name}: expected the PEP 639 SPDX string {expected_license!r}, got {license_value!r}; "
+        "the setuptools floor asserted below exists for that form, revisit it"
     )
 
-
-def test_build_floor_covers_the_emitted_license_form() -> None:
-    """A PEP 639 license string builds only from setuptools 77.0.1 on."""
-    license_value = _generated_license(_SAMPLE_PACKAGE)
-    assert isinstance(license_value, str), (
-        f"{_SAMPLE_PACKAGE}: the generator no longer emits a PEP 639 SPDX license string but "
-        f"{license_value!r}; the setuptools floor asserted below exists for that form, revisit it"
-    )
-
-    floor = _shared_floor()
+    floor = _declared_setuptools_floor()()
     assert _version_tuple(floor) >= _version_tuple(_PEP639_SETUPTOOLS), (
-        f"config/shared.toml declares setuptools>={floor}, but the generator emits "
-        f'license = "{license_value}", which setuptools accepts only from {_PEP639_SETUPTOOLS} on '
-        "(76.1.0 raises 'invalid pyproject.toml config: project.license')."
+        f'config/shared.toml declares setuptools>={floor}, but the generator emits license = "{license_value}", '
+        f"which setuptools accepts only from {_PEP639_SETUPTOOLS} on. Run 'tox -e verify-build-floor': that env "
+        "builds at the declared floor and is what proves it, this assertion only guards the declaration."
     )
+
+
+def test_declared_floor_defaults_to_the_shared_config() -> None:
+    """With no argument the parser reads config/shared.toml, the single source of the floor."""
+    floor = _declared_setuptools_floor()()
+    requires = _load_toml(_SHARED_CONFIG)["build-system"]["requires"]
+    assert any(f">={floor}" in entry for entry in requires), (
+        f"declared_setuptools_floor() returned {floor!r}, absent from config/shared.toml requires {requires!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("requires", "expected"),
+    [
+        (["setuptools>=77.0.1"], "77.0.1"),
+        (["setuptools>=77.0.1,<90"], "77.0.1"),
+        (["setuptools >= 77.0.1, < 90"], "77.0.1"),
+        (["wheel", "setuptools>=80.0"], "80.0"),
+    ],
+)
+def test_declared_floor_reads_the_setuptools_lower_bound(requires: list[str], expected: str) -> None:
+    """An upper bound alongside the floor is a legitimate pin, not a malformed config."""
+    floor = _declared_setuptools_floor()(requires)
+    assert floor == expected, f"parsing {requires!r} produced floor {floor!r}, expected {expected!r}"
+
+
+def test_declared_floor_rejects_requires_without_setuptools() -> None:
+    """A build-system block that lost its setuptools pin must fail loudly, not fall back to a default."""
+    with pytest.raises(ValueError, match="setuptools"):
+        _declared_setuptools_floor()(["wheel"])
 
 
 def test_generated_pyprojects_carry_the_shared_build_floor() -> None:
     """A floor bump reaches wheels only once every generated pyproject.toml carries it."""
-    shared_floor = _shared_floor()
+    parse_floor = _declared_setuptools_floor()
+    shared_floor = parse_floor()
     packages = _load_toml(_PACKAGES_CONFIG)["packages"]
 
     checked = 0
     for pkg_name, pkg_config in packages.items():
         pyproject_path = _REPO_ROOT / pkg_config["path"] / "pyproject.toml"
         assert pyproject_path.exists(), f"{pyproject_path} is missing (run scripts/generate_pyproject.py)."
-        requires = _load_toml(pyproject_path).get("build-system", {}).get("requires", [])
-        floor = _setuptools_floor(str(pyproject_path), requires)
+        floor = parse_floor(_load_toml(pyproject_path).get("build-system", {}).get("requires", []))
         assert floor == shared_floor, (
             f"{pkg_name}: generated {pyproject_path} requires setuptools>={floor}, but "
             f"config/shared.toml declares setuptools>={shared_floor} (run scripts/generate_pyproject.py)."

--- a/tests/test_end2end/test_entry_points.py
+++ b/tests/test_end2end/test_entry_points.py
@@ -12,19 +12,17 @@ Bundle packages (``mloda-community`` / ``mloda-enterprise``) aggregate the entry
 points of every nested plugin package under their path.
 
 Both the generator and the ``scripts/verify_builds.py`` script live as loose
-scripts (not installed packages), so they are loaded here by file path using the
-same ``importlib.util`` pattern as ``test_generate_pyproject_guards.py``.
+scripts (not installed packages), so they are loaded here by file path through
+``tests.script_loader``.
 """
 
 from __future__ import annotations
 
 import importlib
-import importlib.util
 import inspect
 import re
 import sys
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 if sys.version_info >= (3, 11):
@@ -37,6 +35,8 @@ import pytest
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.function_extender import Extender
+
+from tests.script_loader import load_script
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
@@ -54,17 +54,8 @@ _VALUE_PATTERN = re.compile(
 )
 
 
-def _load_module(name: str, path: Path) -> ModuleType:
-    """Import a loose script by file path."""
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec is not None and spec.loader is not None, f"could not load spec for {path}"
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-gen = _load_module("generate_pyproject", _GEN_PATH)
-vb = _load_module("verify_builds", _VERIFY_BUILDS_PATH)
+gen = load_script("generate_pyproject", _GEN_PATH)
+vb = load_script("verify_builds", _VERIFY_BUILDS_PATH)
 
 
 def _generate(pkg_name: str) -> str:

--- a/tests/test_end2end/test_generate_pyproject_guards.py
+++ b/tests/test_end2end/test_generate_pyproject_guards.py
@@ -19,30 +19,20 @@ installed package), so it is loaded here by file path.
 
 from __future__ import annotations
 
-import importlib.util
 import shutil
 import sys
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 import pytest
+
+from tests.script_loader import load_script
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
 _ROOT_PYPROJECT = _REPO_ROOT / "pyproject.toml"
 
-
-def _load_generator() -> ModuleType:
-    """Import scripts/generate_pyproject.py by file path."""
-    spec = importlib.util.spec_from_file_location("generate_pyproject", _GEN_PATH)
-    assert spec is not None and spec.loader is not None, f"could not load spec for {_GEN_PATH}"
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-gen = _load_generator()
+gen = load_script("generate_pyproject", _GEN_PATH)
 
 
 def test_generate_raises_when_core_dependency_missing() -> None:

--- a/tests/test_end2end/test_py_typed_markers.py
+++ b/tests/test_end2end/test_py_typed_markers.py
@@ -4,13 +4,11 @@ portions that ``discover_packages`` misses."""
 
 from __future__ import annotations
 
-import importlib.util
 import re
 import sys
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 if sys.version_info >= (3, 11):
@@ -19,6 +17,8 @@ else:
     import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
 
 import pytest
+
+from tests.script_loader import load_script
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
@@ -33,17 +33,8 @@ _BUNDLES = ["mloda-registry", "mloda-testing", "mloda-community", "mloda-enterpr
 _TYPED_PACKAGES = [*_BUNDLES, "mloda-community-data-operations", "mloda-community-example"]
 
 
-def _load_module(name: str, path: Path) -> ModuleType:
-    """Import a loose script by file path."""
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec is not None and spec.loader is not None, f"could not load spec for {path}"
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-gen = _load_module("generate_pyproject", _GEN_PATH)
-vb = _load_module("verify_builds", _VERIFY_BUILDS_PATH)
+gen = load_script("generate_pyproject", _GEN_PATH)
+vb = load_script("verify_builds", _VERIFY_BUILDS_PATH)
 
 
 def _packages() -> dict[str, dict[str, Any]]:

--- a/tests/test_end2end/test_verify_builds_cleanup.py
+++ b/tests/test_end2end/test_verify_builds_cleanup.py
@@ -4,14 +4,14 @@ source tree no longer has."""
 
 from __future__ import annotations
 
-import importlib.util
 import shutil
 from collections.abc import Callable
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 import pytest
+
+from tests.script_loader import load_script
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _VERIFY_BUILDS_PATH = _REPO_ROOT / "scripts" / "verify_builds.py"
@@ -19,17 +19,7 @@ _VERIFY_BUILDS_PATH = _REPO_ROOT / "scripts" / "verify_builds.py"
 # Configured package paths that get a stale build/ tree in the fake workspace.
 _STALE_BUILD_PACKAGES = ["mloda/registry", "mloda/community", "mloda/testing"]
 
-
-def _load_module(name: str, path: Path) -> ModuleType:
-    """Import a loose script by file path."""
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec is not None and spec.loader is not None, f"could not load spec for {path}"
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-vb = _load_module("verify_builds", _VERIFY_BUILDS_PATH)
+vb = load_script("verify_builds", _VERIFY_BUILDS_PATH)
 
 
 def _cleanup_build_dirs() -> Callable[[], int]:

--- a/tests/test_end2end/test_verify_builds_wheel_matching.py
+++ b/tests/test_end2end/test_verify_builds_wheel_matching.py
@@ -1,36 +1,48 @@
 """Wheel-to-package binding in scripts/verify_builds.py. Every package builds into one shared temp
-directory, so a prefix glob lets a package adopt a sibling's wheel: ``mloda_community*.whl`` also
-matches ``mloda_community_offset-0.4.0-py3-none-any.whl``."""
+directory, so a wheel must be bound by its distribution name alone: neither config order nor the
+version setuptools normalizes into the filename may decide which wheel a package is verified against."""
 
 from __future__ import annotations
 
-import importlib.util
 import shutil
+import zipfile
+from collections.abc import Callable
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 import pytest
+
+from tests.script_loader import load_script
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _VERIFY_BUILDS_PATH = _REPO_ROOT / "scripts" / "verify_builds.py"
 
 _VERSION = "0.4.0"
 
+# A non-canonical PEP 440 spelling of _VERSION; setuptools normalizes it away in the wheel filename.
+_NON_CANONICAL_VERSION = "0.04.0"
+
+# Version of a same-distribution wheel left behind in a reused out-dir by an earlier run.
+_STALE_VERSION = "0.3.9"
+
 # Children before the bundle whose name is their prefix, the inverse of config/packages.toml today.
 _REORDERED_NAMES = ["mloda-community-example", "mloda-community-offset", "mloda-community", "mloda-registry"]
 
-
-def _load_module(name: str, path: Path) -> ModuleType:
-    """Import a loose script by file path."""
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec is not None and spec.loader is not None, f"could not load spec for {path}"
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+vb = load_script("verify_builds", _VERIFY_BUILDS_PATH)
 
 
-vb = _load_module("verify_builds", _VERIFY_BUILDS_PATH)
+def _find_wheels() -> Callable[[Path, str], list[Path]]:
+    """The name-only wheel lookup verify_builds must expose."""
+    finder: Callable[[Path, str], list[Path]] | None = getattr(vb, "find_wheels", None)
+    assert callable(finder), "verify_builds.find_wheels(out_dir, pkg_name) must be a callable"
+    return finder
+
+
+def _escape_distribution_name() -> Callable[[str], str]:
+    """The distribution-name escaping verify_builds must expose."""
+    escape: Callable[[str], str] | None = getattr(vb, "escape_distribution_name", None)
+    assert callable(escape), "verify_builds.escape_distribution_name(name) must be a callable"
+    return escape
 
 
 class _FakeCompletedProcess:
@@ -42,42 +54,59 @@ class _FakeCompletedProcess:
         self.stderr = "stubbed: the pytest gate never runs a real build"
 
 
-def _wheel_name(pkg_name: str) -> str:
-    """Wheel filename a real build produces for a distribution."""
-    return f"{pkg_name.replace('-', '_')}-{_VERSION}-py3-none-any.whl"
+def _wheel_name(pkg_name: str, version: str = _VERSION) -> str:
+    """Wheel filename a real build produces; configured names carry only '-', so this replace suffices."""
+    return f"{pkg_name.replace('-', '_')}-{version}-py3-none-any.whl"
 
 
-def _sandbox(root: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
-    """Run main() against a copy of the config; returns the reordered (name, pyproject path) entries."""
+def _write_wheel(out_dir: Path, pkg_name: str, version: str = _VERSION) -> Path:
+    """A minimal real wheel: a zip whose dist-info METADATA declares ``version``."""
+    path = out_dir / _wheel_name(pkg_name, version)
+    dist_info = f"{pkg_name.replace('-', '_')}-{version}.dist-info"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(f"{dist_info}/METADATA", f"Metadata-Version: 2.4\nName: {pkg_name}\nVersion: {version}\n")
+    return path
+
+
+def _sandbox(root: Path, monkeypatch: pytest.MonkeyPatch, names: list[str]) -> list[tuple[str, str]]:
+    """Run main() against a copy of the config; returns the (name, pyproject path) entries for ``names``."""
     (root / "config").mkdir(parents=True, exist_ok=True)
     shutil.copy(_REPO_ROOT / "config" / "packages.toml", root / "config" / "packages.toml")
     monkeypatch.chdir(root)
 
     paths = dict(vb.load_packages_from_config())
-    missing = [name for name in _REORDERED_NAMES if name not in paths]
+    missing = [name for name in names if name not in paths]
     assert not missing, f"fixture assumption: config/packages.toml must declare {missing}"
-    return [(name, paths[name]) for name in _REORDERED_NAMES]
+    return [(name, paths[name]) for name in names]
 
 
 def _stub_build(
     monkeypatch: pytest.MonkeyPatch,
     packages: list[tuple[str, str]],
+    *,
+    declared_version: str = _VERSION,
     skip_wheel: str | None = None,
+    stale_wheels: dict[str, str] | None = None,
 ) -> dict[str, Path]:
-    """Drive main() with fake builds; returns the built_wheels mapping, filled in once main() runs."""
+    """Drive main() with fake builds; returns the built_wheels mapping, filled in once main() runs.
+
+    ``declared_version`` is what the configs claim. The wheels always carry _VERSION, because setuptools
+    writes the normalized version into both the filename and METADATA. verify_wheel_version stays real.
+    """
     captured: dict[str, Path] = {}
 
     def _fake_build(cmd: list[str], *args: Any, **kwargs: Any) -> _FakeCompletedProcess:
+        out_dir = Path(cmd[cmd.index("--out-dir") + 1])
         package = cmd[cmd.index("--package") + 1]
         if package != skip_wheel:
-            (Path(cmd[cmd.index("--out-dir") + 1]) / _wheel_name(package)).write_bytes(b"")
+            _write_wheel(out_dir, package)
+        stale = (stale_wheels or {}).get(package)
+        if stale is not None:
+            _write_wheel(out_dir, package, stale)
         return _FakeCompletedProcess()
 
     def _consistent_versions() -> tuple[bool, str]:
-        return True, _VERSION
-
-    def _version_matches(wheel_path: Path, expected: str) -> bool:
-        return True
+        return True, declared_version
 
     def _capture_wheels(built_wheels: dict[str, Path]) -> list[str]:
         captured.update(built_wheels)
@@ -89,7 +118,6 @@ def _stub_build(
     monkeypatch.setattr(vb, "PACKAGES", packages)
     monkeypatch.setattr(vb.subprocess, "run", _fake_build)
     monkeypatch.setattr(vb, "check_version_consistency", _consistent_versions)
-    monkeypatch.setattr(vb, "verify_wheel_version", _version_matches)
     monkeypatch.setattr(vb, "verify_entry_points", _capture_wheels)
     for verifier in (
         "verify_dependency_relationships",
@@ -101,11 +129,43 @@ def _stub_build(
     return captured
 
 
+def test_a_prefix_sibling_wheel_never_matches_the_shorter_name(tmp_path: Path) -> None:
+    """Order independent by construction: the distribution segment is compared whole, not as a prefix."""
+    own = _write_wheel(tmp_path, "mloda-community")
+    sibling = _write_wheel(tmp_path, "mloda-community-offset")
+    find_wheels = _find_wheels()
+
+    matched = find_wheels(tmp_path, "mloda-community")
+
+    assert sibling not in matched, f"find_wheels matched the prefix sibling {sibling.name} for mloda-community"
+    assert matched == [own], f"mloda-community must match only {own.name}, got {[path.name for path in matched]}"
+    assert find_wheels(tmp_path, "mloda-community-offset") == [sibling], (
+        f"mloda-community-offset must match only {sibling.name}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("mloda-community", "mloda_community"),
+        ("mloda-community-io.parquet", "mloda_community_io_parquet"),
+        ("mloda--community", "mloda_community"),
+        ("mloda-_.community", "mloda_community"),
+        ("Mloda-Community", "mloda_community"),
+        ("mloda_community", "mloda_community"),
+    ],
+)
+def test_distribution_name_escaping_follows_the_wheel_spec(raw: str, expected: str) -> None:
+    """PEP 427/503 escaping is re.sub(r"[-_.]+", "_", name.lower()), not a bare '-' to '_' replace."""
+    escape = _escape_distribution_name()
+    assert escape(raw) == expected, f"escaping {raw!r} produced {escape(raw)!r}, expected {expected!r}"
+
+
 def test_every_package_binds_its_own_wheel_under_a_reordered_config(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Config order must not decide which wheel a package is verified against."""
-    packages = _sandbox(tmp_path, monkeypatch)
+    packages = _sandbox(tmp_path, monkeypatch, _REORDERED_NAMES)
     built_wheels = _stub_build(monkeypatch, packages)
 
     exit_code = vb.main()
@@ -125,7 +185,7 @@ def test_a_prefix_sibling_wheel_is_never_bound(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """With its own wheel absent, a package must report no wheel instead of adopting a sibling's."""
-    packages = _sandbox(tmp_path, monkeypatch)
+    packages = _sandbox(tmp_path, monkeypatch, _REORDERED_NAMES)
     built_wheels = _stub_build(monkeypatch, packages, skip_wheel="mloda-community")
 
     exit_code = vb.main()
@@ -138,3 +198,42 @@ def test_a_prefix_sibling_wheel_is_never_bound(
         f"main() must report the missing mloda-community wheel, printed:\n{output}"
     )
     assert exit_code == 1, f"main() must fail when a package produces no wheel, returned {exit_code!r}"
+
+
+def test_a_normalized_wheel_version_is_diagnosed_as_a_version_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A non-canonical configured version is normalized out of the filename; the wheel is still bound."""
+    packages = _sandbox(tmp_path, monkeypatch, ["mloda-registry"])
+    built_wheels = _stub_build(monkeypatch, packages, declared_version=_NON_CANONICAL_VERSION)
+
+    exit_code = vb.main()
+    output = capsys.readouterr().out
+
+    assert "no wheel produced" not in output, (
+        f"main() lost {_wheel_name('mloda-registry')} because the configs declare {_NON_CANONICAL_VERSION}, "
+        f"which setuptools normalized to {_VERSION} in the filename; printed:\n{output}"
+    )
+    assert "mloda-registry: version mismatch in wheel" in output, (
+        f"main() must diagnose the wheel it found as a version mismatch, printed:\n{output}"
+    )
+    assert "mloda-registry" not in built_wheels, "a wheel failing version verification must not be verified further"
+    assert exit_code == 1, f"main() must fail on a version mismatch, returned {exit_code!r}"
+
+
+def test_two_wheels_for_one_distribution_are_rejected_as_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Name-only matching can also find a stale wheel in a reused out-dir; picking one silently is worse."""
+    packages = _sandbox(tmp_path, monkeypatch, ["mloda-registry"])
+    built_wheels = _stub_build(monkeypatch, packages, stale_wheels={"mloda-registry": _STALE_VERSION})
+
+    exit_code = vb.main()
+    output = capsys.readouterr().out
+
+    assert "mloda-registry" not in built_wheels, (
+        f"main() silently bound {built_wheels.get('mloda-registry')} out of two candidate wheels"
+    )
+    for candidate in (_wheel_name("mloda-registry"), _wheel_name("mloda-registry", _STALE_VERSION)):
+        assert candidate in output, f"main() must name the ambiguous candidate {candidate}, printed:\n{output}"
+    assert exit_code == 1, f"main() must fail when one distribution has two wheels, returned {exit_code!r}"

--- a/tests/test_end2end/test_verify_builds_wheel_matching.py
+++ b/tests/test_end2end/test_verify_builds_wheel_matching.py
@@ -1,0 +1,140 @@
+"""Wheel-to-package binding in scripts/verify_builds.py. Every package builds into one shared temp
+directory, so a prefix glob lets a package adopt a sibling's wheel: ``mloda_community*.whl`` also
+matches ``mloda_community_offset-0.4.0-py3-none-any.whl``."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_VERIFY_BUILDS_PATH = _REPO_ROOT / "scripts" / "verify_builds.py"
+
+_VERSION = "0.4.0"
+
+# Children before the bundle whose name is their prefix, the inverse of config/packages.toml today.
+_REORDERED_NAMES = ["mloda-community-example", "mloda-community-offset", "mloda-community", "mloda-registry"]
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    """Import a loose script by file path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"could not load spec for {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+vb = _load_module("verify_builds", _VERIFY_BUILDS_PATH)
+
+
+class _FakeCompletedProcess:
+    """Stand-in for subprocess.CompletedProcess; main() reads returncode and stderr."""
+
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+        self.stdout = ""
+        self.stderr = "stubbed: the pytest gate never runs a real build"
+
+
+def _wheel_name(pkg_name: str) -> str:
+    """Wheel filename a real build produces for a distribution."""
+    return f"{pkg_name.replace('-', '_')}-{_VERSION}-py3-none-any.whl"
+
+
+def _sandbox(root: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    """Run main() against a copy of the config; returns the reordered (name, pyproject path) entries."""
+    (root / "config").mkdir(parents=True, exist_ok=True)
+    shutil.copy(_REPO_ROOT / "config" / "packages.toml", root / "config" / "packages.toml")
+    monkeypatch.chdir(root)
+
+    paths = dict(vb.load_packages_from_config())
+    missing = [name for name in _REORDERED_NAMES if name not in paths]
+    assert not missing, f"fixture assumption: config/packages.toml must declare {missing}"
+    return [(name, paths[name]) for name in _REORDERED_NAMES]
+
+
+def _stub_build(
+    monkeypatch: pytest.MonkeyPatch,
+    packages: list[tuple[str, str]],
+    skip_wheel: str | None = None,
+) -> dict[str, Path]:
+    """Drive main() with fake builds; returns the built_wheels mapping, filled in once main() runs."""
+    captured: dict[str, Path] = {}
+
+    def _fake_build(cmd: list[str], *args: Any, **kwargs: Any) -> _FakeCompletedProcess:
+        package = cmd[cmd.index("--package") + 1]
+        if package != skip_wheel:
+            (Path(cmd[cmd.index("--out-dir") + 1]) / _wheel_name(package)).write_bytes(b"")
+        return _FakeCompletedProcess()
+
+    def _consistent_versions() -> tuple[bool, str]:
+        return True, _VERSION
+
+    def _version_matches(wheel_path: Path, expected: str) -> bool:
+        return True
+
+    def _capture_wheels(built_wheels: dict[str, Path]) -> list[str]:
+        captured.update(built_wheels)
+        return []
+
+    def _no_errors(*args: Any, **kwargs: Any) -> list[str]:
+        return []
+
+    monkeypatch.setattr(vb, "PACKAGES", packages)
+    monkeypatch.setattr(vb.subprocess, "run", _fake_build)
+    monkeypatch.setattr(vb, "check_version_consistency", _consistent_versions)
+    monkeypatch.setattr(vb, "verify_wheel_version", _version_matches)
+    monkeypatch.setattr(vb, "verify_entry_points", _capture_wheels)
+    for verifier in (
+        "verify_dependency_relationships",
+        "verify_wheel_metadata",
+        "verify_py_typed_markers",
+        "verify_pep420_source_compliance",
+    ):
+        monkeypatch.setattr(vb, verifier, _no_errors)
+    return captured
+
+
+def test_every_package_binds_its_own_wheel_under_a_reordered_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Config order must not decide which wheel a package is verified against."""
+    packages = _sandbox(tmp_path, monkeypatch)
+    built_wheels = _stub_build(monkeypatch, packages)
+
+    exit_code = vb.main()
+
+    assert exit_code == 0, "fixture assumption: the stubs must drive main() down its success path"
+    assert sorted(built_wheels) == sorted(_REORDERED_NAMES), (
+        f"main() bound wheels for {sorted(built_wheels)}, expected {sorted(_REORDERED_NAMES)}"
+    )
+    for pkg_name, wheel_path in built_wheels.items():
+        assert wheel_path.name == _wheel_name(pkg_name), (
+            f"{pkg_name}: bound {wheel_path.name}, a wheel carrying another distribution's name; "
+            f"expected {_wheel_name(pkg_name)}"
+        )
+
+
+def test_a_prefix_sibling_wheel_is_never_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """With its own wheel absent, a package must report no wheel instead of adopting a sibling's."""
+    packages = _sandbox(tmp_path, monkeypatch)
+    built_wheels = _stub_build(monkeypatch, packages, skip_wheel="mloda-community")
+
+    exit_code = vb.main()
+    output = capsys.readouterr().out
+
+    assert "mloda-community" not in built_wheels, (
+        f"main() bound {built_wheels.get('mloda-community')} to mloda-community, which built no wheel"
+    )
+    assert "mloda-community: no wheel produced" in output, (
+        f"main() must report the missing mloda-community wheel, printed:\n{output}"
+    )
+    assert exit_code == 1, f"main() must fail when a package produces no wheel, returned {exit_code!r}"

--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,17 @@ allowlist_externals = uv
 commands =
     python scripts/verify_builds.py
 
+[testenv:verify-build-floor]
+description = Verify packages build at the declared setuptools floor
+# Needs deps, which the lock runner ignores.
+runner = uv-venv-runner
+usedevelop = true
+extras = dev
+deps = setuptools
+allowlist_externals = uv
+commands =
+    python scripts/verify_build_floor.py
+
 [testenv:check-generated]
 description = Check pyproject.toml files are up-to-date with config
 usedevelop = true


### PR DESCRIPTION
Fixes the two packaging-metadata defects in #342.

## 1. The declared setuptools floor was wrong

`config/shared.toml` declared `setuptools>=61.0`, inherited by all 30 generated `pyproject.toml` files. The generator emits the PEP 639 SPDX form `license = "Apache-2.0"`, which setuptools accepts only from 77.0.1. Verified by building generated packages in clean venvs at exact pinned versions:

| setuptools | result |
|---|---|
| 61.0 | does not import on Python 3.12 (`pkgutil.ImpImporter`) |
| 76.1.0 | `ValueError: invalid pyproject.toml config: project.license` (still wants the `{file}` / `{text}` table) |
| 77.0.0 | never published; PyPI goes 76.1.0 -> 77.0.1 |
| **77.0.1** | builds; `Metadata-Version: 2.4`, `License-Expression: Apache-2.0` |

The floor is now `setuptools>=77.0.1`.

CI never caught this because nothing exercised `[build-system].requires`: the build gate and the release workflow both build with `--no-build-isolation` against an unpinned latest setuptools.

So the floor is now proven rather than asserted. `scripts/verify_build_floor.py` creates a clean venv pinned to exactly the declared floor and builds one package per emitted license form, Apache-2.0 and `LicenseRef-Proprietary` (setuptools validates those on different paths), asserting each wheel carries a `License-Expression`. It runs as `tox -e verify-build-floor` and in the package-integrity workflow. The test and the script share one floor parser, so the version is not restated in two places.

## 2. verify_builds bound wheels by prefix

`mloda_community*.whl` also matches `mloda_community_offset-0.4.0-py3-none-any.whl`. All packages build into one shared out-dir, so the binding was correct only because `config/packages.toml` happens to list each bundle before its children; reordering it pointed every downstream check (entry points, metadata, py.typed) at the wrong artifact.

Binding is now on the escaped distribution segment of the filename alone. Adding the version to the match, which was the shape the issue suggested, turned out to be worse: it makes `verify_wheel_version` unreachable, and setuptools normalizes the version into the filename, so a non-canonical version such as `0.04.0` yields `mloda_registry-0.4.0-...whl` and every package reports "no wheel produced" while the wheels sit in the out-dir. Name-only matching is ordering independent and normalization proof, keeps the version-mismatch diagnostic alive, and now rejects an ambiguous multi-wheel match instead of binding one at random. Escaping follows the PEP 427/503 rule rather than a bare hyphen replacement.

## Tests

- `tests/test_end2end/test_build_system_floor.py`: both emitted SPDX forms are pinned; the floor parser is covered including an upper-bound spec and a missing entry; a drift guard keeps every generated file in step with the config.
- `tests/test_end2end/test_verify_builds_wheel_matching.py`: a reordered config still binds correctly; a prefix sibling never matches (asserted at helper level, so it does not depend on directory iteration order); a normalized version is diagnosed as a version mismatch rather than a missing wheel; duplicate wheels are rejected as ambiguous.
- Extracts the load-a-loose-script helper that had been copy-pasted across five test modules.

## Verification

`tox` full gate green: 4716 passed, 210 skipped, plus `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`. `tox -e check-generated`, `tox -e verify-builds` and the new `tox -e verify-build-floor` all pass. Negative control: the new env fails as intended at `setuptools==76.1.0`.

Reviewed independently by two deep reviews before opening.
