### PR TITLE
fix(packaging): publish every configured plugin distribution from one source

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,15 +107,22 @@ jobs:
         run: |
           # The released set is whatever config/packages.toml flags published = true.
           # A package without the flag ships only inside the bundle wheels.
-          # An empty array is checked explicitly: set -e does not catch a failing
-          # process substitution.
+          # Capture first, check the status, then split: a process substitution hides the
+          # producer's exit status, so a script that prints two lines and then fails would
+          # build a partial release. `packages` holds the raw output until the last line
+          # splits it into the build array, because `mapfile <<< ""` yields one empty
+          # element and the emptiness check has to run on the string.
           # `--wheel --no-build-isolation` is required by the monorepo layout
           # (build needs access to parent directories).
-          mapfile -t packages < <(python scripts/published_packages.py)
-          if [ ${#packages[@]} -eq 0 ]; then
+          if ! packages=$(python scripts/published_packages.py); then
+            echo "::error ::scripts/published_packages.py failed"
+            exit 1
+          fi
+          if [ -z "$packages" ]; then
             echo "::error ::scripts/published_packages.py returned no packages to build"
             exit 1
           fi
+          mapfile -t packages <<<"$packages"
 
           mkdir -p dist
           for pkg in "${packages[@]}"; do
@@ -130,4 +137,5 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
+        # --skip-existing keeps a rerun after a partial upload from failing on files already on PyPI.
+        run: twine upload --non-interactive --skip-existing dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,43 +101,21 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install uv twine setuptools
+          python -m pip install uv twine setuptools tomli
 
       - name: Build packages
         run: |
-          # Released set: 4 bundles + 13 community data-operations packages +
-          # 2 examples kept for end-to-end PyPI dependency-resolution coverage
-          # (mloda-community-example, mloda-community-example-a).
-          #
-          # Other example/demo packages declared in config/packages.toml are
-          # intentionally NOT published standalone; their code ships inside
-          # the mloda-community / mloda-enterprise bundle wheels. See the
-          # header comment in config/packages.toml for the full policy and
-          # the checklist for adding a new released package.
-          #
+          # The released set is whatever config/packages.toml flags published = true.
+          # A package without the flag ships only inside the bundle wheels.
+          # An empty array is checked explicitly: set -e does not catch a failing
+          # process substitution.
           # `--wheel --no-build-isolation` is required by the monorepo layout
           # (build needs access to parent directories).
-          packages=(
-            "mloda-registry"
-            "mloda-testing"
-            "mloda-community"
-            "mloda-enterprise"
-            "mloda-community-example"
-            "mloda-community-example-a"
-            "mloda-community-data-operations"
-            "mloda-community-aggregation"
-            "mloda-community-rank"
-            "mloda-community-offset"
-            "mloda-community-window-aggregation"
-            "mloda-community-frame-aggregate"
-            "mloda-community-scalar-aggregate"
-            "mloda-community-scalar-arithmetic"
-            "mloda-community-point-arithmetic"
-            "mloda-community-datetime"
-            "mloda-community-string"
-            "mloda-community-binning"
-            "mloda-community-percentile"
-          )
+          mapfile -t packages < <(python scripts/published_packages.py)
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "::error ::scripts/published_packages.py returned no packages to build"
+            exit 1
+          fi
 
           mkdir -p dist
           for pkg in "${packages[@]}"; do

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,13 +105,9 @@ jobs:
 
       - name: Build packages
         run: |
-          # The released set is whatever config/packages.toml flags published = true.
-          # A package without the flag ships only inside the bundle wheels.
-          # Capture first, check the status, then split: a process substitution hides the
-          # producer's exit status, so a script that prints two lines and then fails would
-          # build a partial release. `packages` holds the raw output until the last line
-          # splits it into the build array, because `mapfile <<< ""` yields one empty
-          # element and the emptiness check has to run on the string.
+          # Released set: whatever config/packages.toml flags published = true.
+          # Capture before splitting: a process substitution hides the producer's exit status,
+          # and the emptiness check needs the string, since `mapfile <<< ""` yields one element.
           # `--wheel --no-build-isolation` is required by the monorepo layout
           # (build needs access to parent directories).
           if ! packages=$(python scripts/published_packages.py); then

--- a/config/packages.toml
+++ b/config/packages.toml
@@ -1,11 +1,9 @@
 # Package-specific configuration for mloda-registry packages
 # Edit this file and run: python scripts/generate_pyproject.py
 #
-# published = true marks the distributions that ship standalone on PyPI. It is the
-# single source of the released set: the release workflow, the tox envs that install
-# from PyPI, the generated extras and the tests all read it, through
-# scripts/published_packages.py. A package without the flag reaches users only
-# inside the mloda-community / mloda-enterprise bundle wheels.
+# published = true is the single source of the released set, read through
+# scripts/published_packages.py. Without it a package ships only inside the
+# mloda-community / mloda-enterprise bundle wheels.
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"

--- a/config/packages.toml
+++ b/config/packages.toml
@@ -1,23 +1,24 @@
 # Package-specific configuration for mloda-registry packages
 # Edit this file and run: python scripts/generate_pyproject.py
 #
-# Some packages declared here are example/demo only and intentionally NOT
-# released as standalone PyPI artifacts; they reach users via the
-# mloda-community / mloda-enterprise bundle wheels. Do not add them to the
-# build/upload list in .github/workflows/release.yaml:
-#   mloda-community-example-b, mloda-enterprise-example,
-#   mloda-{community,enterprise}-{compute-frameworks,extenders}-example
+# published = true marks the distributions that ship standalone on PyPI. It is the
+# single source of the released set: the release workflow, the tox envs that install
+# from PyPI, the generated extras and the tests all read it, through
+# scripts/published_packages.py. A package without the flag reaches users only
+# inside the mloda-community / mloda-enterprise bundle wheels.
 
 [packages.mloda-registry]
 description = "Plugin discovery and search for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/registry"
+published = true
 py_typed = true
 
 [packages.mloda-testing]
 description = "Test utilities for mloda plugin development"
 dependencies = ["{core_dependency}", "pytest>=9.0.3"]
 path = "mloda/testing"
+published = true
 optional_dependencies = { dev = ["pytest>=9.0.3"] }
 py_typed = true
 
@@ -25,6 +26,7 @@ py_typed = true
 description = "All community plugins for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/community"
+published = true
 entry_point_bundle = true
 py_typed = true
 
@@ -32,6 +34,7 @@ py_typed = true
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 dependencies = ["{core_dependency}"]
 path = "mloda/enterprise"
+published = true
 entry_point_bundle = true
 py_typed = true
 
@@ -39,6 +42,7 @@ py_typed = true
 description = "Example community FeatureGroup plugin for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/community/feature_groups/example"
+published = true
 optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-example-b"] }
 entry_point_groups = ["mloda.feature_groups"]
 py_typed = true
@@ -53,6 +57,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Example A FeatureGroup extending community example base"
 dependencies = ["mloda-community-example>=0.2.0"]
 path = "mloda/community/feature_groups/example/example_a"
+published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-example-b]
@@ -91,13 +96,15 @@ entry_point_groups = ["mloda.extenders"]
 description = "Shared base classes for data operation feature groups"
 dependencies = ["{core_dependency}"]
 path = "mloda/community/feature_groups/data_operations"
-optional_dependencies = { all = ["mloda-community-window-aggregation", "mloda-community-aggregation", "mloda-community-rank", "mloda-community-offset", "mloda-community-frame-aggregate", "mloda-community-scalar-aggregate", "mloda-community-scalar-arithmetic", "mloda-community-point-arithmetic", "mloda-community-datetime", "mloda-community-string", "mloda-community-binning", "mloda-community-percentile", "mloda-community-time-bucketization", "mloda-community-ffill", "mloda-community-ema", "mloda-community-sessionization", "mloda-community-resample"] }
+published = true
+optional_dependencies = { all = ["{published_children}"] }
 py_typed = true
 
 [packages.mloda-community-aggregation]
 description = "Aggregation feature group (reduce, partition_by, one row per group)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/aggregation"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -105,6 +112,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Rank feature group (row_number, rank, dense_rank, percent_rank, ntile, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/rank"
+published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -112,6 +120,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Offset feature group (lag, lead, diff, pct_change, first_value, last_value, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/offset"
+published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -119,6 +128,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Window aggregation feature group (broadcast, partition_by, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -126,6 +136,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Frame aggregate feature group (rolling, cumulative, expanding, time window, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate"
+published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas>=2.2"], all = ["polars", "pandas>=2.2", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -133,6 +144,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Scalar aggregate feature group (single-column global aggregate broadcast)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -141,6 +153,7 @@ description = "Scalar arithmetic feature group (element-wise column op constant:
 # Floor 0.3.3: first data-operations release shipping the data_operations.row_preserving.arithmetic package.
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -149,6 +162,7 @@ description = "Point arithmetic feature group (element-wise two-column op: add, 
 # Floor 0.3.3: first data-operations release shipping the data_operations.row_preserving.arithmetic package.
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -156,18 +170,21 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Datetime extraction feature group (element-wise, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/datetime"
+published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-string]
 description = "String operation feature group (element-wise, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/string"
+published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-binning]
 description = "Binning feature group (equal-width, quantile, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/binning"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -175,6 +192,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Percentile feature group (PERCENTILE_CONT, partition_by, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/percentile"
+published = true
 optional_dependencies = { duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -182,6 +200,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Time bucketization feature group (floor, ceil, round a timestamp to a bucket interval, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/time_bucketization"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -189,6 +208,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Forward-fill feature group (ffill a value column across time gaps, per partition, ordered by time, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ffill"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -196,6 +216,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "EMA feature group (exponential moving average, adjust=False, null-skipping recurrence, per partition, row-preserving; pandas/polars native, pyarrow/duckdb/sqlite reject)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ema"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -203,6 +224,7 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Sessionization feature group (gap-threshold session id on an ordered timestamp, per partition, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/sessionization"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -210,5 +232,6 @@ entry_point_groups = ["mloda.feature_groups"]
 description = "Resample feature group (collapse events onto a regular time grid: floor to bucket, group, aggregate; one row per non-empty bucket, row-changing)"
 dependencies = ["mloda-community-data-operations>=0.3.3"]
 path = "mloda/community/feature_groups/data_operations/row_changing/resample"
+published = true
 optional_dependencies = { pyarrow = ["pyarrow"], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]

--- a/docs/guides/06-publish-to-community.md
+++ b/docs/guides/06-publish-to-community.md
@@ -16,7 +16,7 @@ Submit your plugin to mloda-registry for others to use.
    mloda/community/feature_groups/your_plugin/
    ```
 
-3. **Add to package config** in `config/packages.toml`. For a typed plugin, set `py_typed = true` and commit an empty `<path>/py.typed`. A plugin nested under an already-typed path (anything under `data_operations/`) inherits the ancestor marker and needs neither the flag nor its own file. Such a plugin must floor its dependency on the marker-shipping base at the release that first shipped the marker, otherwise an older base resolves and the plugin installs untyped.
+3. **Add to package config** in `config/packages.toml`. A plugin that should also ship as its own PyPI distribution, not only inside the `mloda-community` bundle wheel, needs `published = true`. For a typed plugin, set `py_typed = true` and commit an empty `<path>/py.typed`. A plugin nested under an already-typed path (anything under `data_operations/`) inherits the ancestor marker and needs neither the flag nor its own file. Such a plugin must floor its dependency on the marker-shipping base at the release that first shipped the marker, otherwise an older base resolves and the plugin installs untyped.
 
 4. **Run tests** to ensure everything works:
    ```bash

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -56,7 +56,7 @@ optional_dependencies = { dev = ["mloda-testing", "pytest>=9.0.3"] }
 |-------|----------|-------------|
 | `description` | Yes | PyPI description |
 | `path` | Yes | Package directory |
-| `published` | No | `true` marks a distribution that ships standalone on PyPI. Single source of the released set: `scripts/published_packages.py` prints it, and the release workflow, the `verify-published` and `security` tox envs and the `{published_children}` extras all read it from there. Without it a package reaches users only inside the bundle wheels. Must be a boolean; it governs the released set only, never wheel contents |
+| `published` | No | `true` ships the distribution standalone on PyPI. Single source of the released set, read through `scripts/published_packages.py`. Must be a boolean, and governs the released set only, never wheel contents |
 | `dependencies` | By convention | Runtime deps; use `"{core_dependency}"` for the mloda floor. The generator defaults it to empty rather than failing, but every package declares it |
 | `optional_dependencies` | No | Merged with defaults. The entry `"{published_children}"` expands to every published package nested under this package's path, in config order |
 | `has_readme` | No | `true` points the package at its own `README.md` |
@@ -71,9 +71,8 @@ A marker declares its whole subtree typed, including third-party distributions i
 
 - `license` from path (`mloda/enterprise/*` → proprietary, else default)
 - `packages` from filesystem (scans for `__init__.py`, excludes `tests/`, `build/`, etc.)
-- wheel boundaries from the configured layout: every configured package nested under a
-  package's path stays out of that package's wheel, published or not; `entry_point_bundle`
-  packages are the exception and ship all nested code
+- wheel boundaries from the layout: a nested package stays out of its parent's wheel,
+  published or not; `entry_point_bundle` packages ship all nested code
 
 **Default dev deps skipped for:** `mloda-testing`, `mloda-community`, `mloda-enterprise`
 
@@ -171,15 +170,12 @@ python scripts/generate_pyproject.py    # Regenerate
 1. Add to `config/packages.toml` (description, dependencies, path; for a plugin
    package also `entry_point_groups = ["mloda.feature_groups" | ...]`).
 2. For a plugin package, create `<path>/manifest.py` listing the concrete classes.
-3. If it should ship standalone on PyPI, set `published = true`. The release
-   workflow, the `verify-published` and `security` tox envs and the
-   `{published_children}` extras all derive from that flag. Two more edits are
-   required, the way `py_typed` also requires its committed marker file: the gate
-   test `tests/test_end2end/test_published_set_single_source.py` pins the expected
-   set in `_EXPECTED_PUBLISHED` (a bundle-only package goes into `_BUNDLE_ONLY`
-   instead), and every published distribution needs a smoke import line in the
-   `verify-published` tox env. The flag only takes effect at the next release, so
-   `tox -e verify-published` fails for the new package until that release is on PyPI.
+3. If it should ship standalone on PyPI, set `published = true`. Two edits follow it,
+   the way `py_typed` also needs its committed marker: the gate test
+   `tests/test_end2end/test_published_set_single_source.py` pins the expected set in
+   `_EXPECTED_PUBLISHED` (bundle-only packages go into `_BUNDLE_ONLY`), and every
+   published distribution needs a smoke import line in the `verify-published` tox env.
+   The flag takes effect at the next release, so that env fails for it until then.
 4. Regenerate and sync:
 
 ```bash

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -56,7 +56,7 @@ optional_dependencies = { dev = ["mloda-testing", "pytest>=9.0.3"] }
 |-------|----------|-------------|
 | `description` | Yes | PyPI description |
 | `path` | Yes | Package directory |
-| `published` | No | `true` marks a distribution that ships standalone on PyPI. Single source of the released set: `scripts/published_packages.py` prints it, and the release workflow, the `verify-published` and `security` tox envs and the `{published_children}` extras all read it from there. Without it a package reaches users only inside the bundle wheels |
+| `published` | No | `true` marks a distribution that ships standalone on PyPI. Single source of the released set: `scripts/published_packages.py` prints it, and the release workflow, the `verify-published` and `security` tox envs and the `{published_children}` extras all read it from there. Without it a package reaches users only inside the bundle wheels. Must be a boolean; it governs the released set only, never wheel contents |
 | `dependencies` | By convention | Runtime deps; use `"{core_dependency}"` for the mloda floor. The generator defaults it to empty rather than failing, but every package declares it |
 | `optional_dependencies` | No | Merged with defaults. The entry `"{published_children}"` expands to every published package nested under this package's path, in config order |
 | `has_readme` | No | `true` points the package at its own `README.md` |
@@ -71,6 +71,9 @@ A marker declares its whole subtree typed, including third-party distributions i
 
 - `license` from path (`mloda/enterprise/*` → proprietary, else default)
 - `packages` from filesystem (scans for `__init__.py`, excludes `tests/`, `build/`, etc.)
+- wheel boundaries from the configured layout: every configured package nested under a
+  package's path stays out of that package's wheel, published or not; `entry_point_bundle`
+  packages are the exception and ship all nested code
 
 **Default dev deps skipped for:** `mloda-testing`, `mloda-community`, `mloda-enterprise`
 
@@ -101,6 +104,7 @@ does not require its children, the children require the base.
 description = "Example community FeatureGroup plugin for mloda"
 dependencies = ["{core_dependency}"]
 path = "mloda/community/feature_groups/example"
+published = true
 optional_dependencies = { all = ["mloda-community-example-a", "mloda-community-example-b"] }
 entry_point_groups = ["mloda.feature_groups"]
 py_typed = true
@@ -169,7 +173,13 @@ python scripts/generate_pyproject.py    # Regenerate
 2. For a plugin package, create `<path>/manifest.py` listing the concrete classes.
 3. If it should ship standalone on PyPI, set `published = true`. The release
    workflow, the `verify-published` and `security` tox envs and the
-   `{published_children}` extras all derive from that flag; nothing else to edit.
+   `{published_children}` extras all derive from that flag. Two more edits are
+   required, the way `py_typed` also requires its committed marker file: the gate
+   test `tests/test_end2end/test_published_set_single_source.py` pins the expected
+   set in `_EXPECTED_PUBLISHED` (a bundle-only package goes into `_BUNDLE_ONLY`
+   instead), and every published distribution needs a smoke import line in the
+   `verify-published` tox env. The flag only takes effect at the next release, so
+   `tox -e verify-published` fails for the new package until that release is on PyPI.
 4. Regenerate and sync:
 
 ```bash
@@ -180,3 +190,5 @@ uv sync --all-extras
 ### Add a variant to an existing plugin
 
 Same as above, plus add the variant to the parent's `optional_dependencies.all`.
+If that extra is `["{published_children}"]`, do not edit it: set `published = true`
+on the variant instead, and the placeholder picks it up.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -56,8 +56,9 @@ optional_dependencies = { dev = ["mloda-testing", "pytest>=9.0.3"] }
 |-------|----------|-------------|
 | `description` | Yes | PyPI description |
 | `path` | Yes | Package directory |
+| `published` | No | `true` marks a distribution that ships standalone on PyPI. Single source of the released set: `scripts/published_packages.py` prints it, and the release workflow, the `verify-published` and `security` tox envs and the `{published_children}` extras all read it from there. Without it a package reaches users only inside the bundle wheels |
 | `dependencies` | By convention | Runtime deps; use `"{core_dependency}"` for the mloda floor. The generator defaults it to empty rather than failing, but every package declares it |
-| `optional_dependencies` | No | Merged with defaults |
+| `optional_dependencies` | No | Merged with defaults. The entry `"{published_children}"` expands to every published package nested under this package's path, in config order |
 | `has_readme` | No | `true` points the package at its own `README.md` |
 | `workspace_deps` | No | Marks a meta-package whose deps are workspace siblings. Mutually exclusive with `py_typed`; unused today |
 | `entry_point_groups` | No | List of mloda entry-point groups the package's `manifest.py` populates (`mloda.feature_groups`, `mloda.compute_frameworks`, `mloda.extenders`) |
@@ -115,8 +116,8 @@ py_typed = true
 Entries in `optional_dependencies.all` are emitted unpinned, so a variant only has
 to exist on PyPI at some version for the extra to resolve. A variant that is
 dropped from the release list therefore keeps resolving at its last published
-version, which is why `mloda-community-example-b` can be absent from
-`.github/workflows/release.yaml` without breaking `[all]`. A variant that was
+version, which is why `mloda-community-example-b` can lack `published = true`
+without breaking `[all]`. A variant that was
 never published at all is different: it cannot satisfy the extra at any version,
 so `[all]` fails outright.
 
@@ -166,11 +167,9 @@ python scripts/generate_pyproject.py    # Regenerate
 1. Add to `config/packages.toml` (description, dependencies, path; for a plugin
    package also `entry_point_groups = ["mloda.feature_groups" | ...]`).
 2. For a plugin package, create `<path>/manifest.py` listing the concrete classes.
-3. If it should ship standalone on PyPI, add it to all three hardcoded lists:
-   the build array in `.github/workflows/release.yaml`, and the install lines of
-   the `verify-published` and `security` envs in `tox.ini`. Nothing cross-checks
-   them, so a package added to one and not the others either goes unverified or
-   is verified at a version that was never published.
+3. If it should ship standalone on PyPI, set `published = true`. The release
+   workflow, the `verify-published` and `security` tox envs and the
+   `{published_children}` extras all derive from that flag; nothing else to edit.
 4. Regenerate and sync:
 
 ```bash

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,7 +16,8 @@ workflow_dispatch → semantic-release → PyPI publish
 2. **Regenerate**: `scripts/generate_pyproject.py` updates all `pyproject.toml` files.
 3. **Commit**: version changes committed to `main`.
 4. **GitHub release**: tag created (e.g. `0.4.0`).
-5. **PyPI publish**: wheels built and uploaded.
+5. **PyPI publish**: wheels built and uploaded with `twine --skip-existing`, so a rerun
+   after a partial upload does not fail on the files that already made it.
 
 The `prepareCmd` in `.releaserc.yaml` also seds a `MLODA_REGISTRY_VERSION:<version>}`
 default into `tox.ini`. No such default remains there, so that half of the command is
@@ -39,10 +40,15 @@ It sets `MLODA_REGISTRY_VERSION` and runs three tox envs:
 
 ## Published packages
 
-The released set is the `published = true` flag in `config/packages.toml`, and nothing
-else. `scripts/published_packages.py` prints it, plain or pinned to a version; the build
-array in `.github/workflows/release.yaml` and the install lists of the `verify-published`
-and `security` tox envs are all filled from that one command, so they cannot drift apart.
+The released set is the `published = true` flag in `config/packages.toml`.
+`scripts/published_packages.py` prints it, plain or pinned to a version; the build array
+in `.github/workflows/release.yaml` and the install lists of the `verify-published` and
+`security` tox envs are all filled from that one command, so they cannot drift apart.
+`verify-published-independent` and `verify-extras` still name packages by hand, but only
+the four bundles and `mloda-community-example`, not the set as a whole.
+
+Flagging a package does not publish it: it ships with the next release run, and
+`tox -e verify-published` fails for it until that release is on PyPI.
 
 Not every package in `config/packages.toml` ships standalone: most demo and example
 packages reach users inside the `mloda-community` / `mloda-enterprise` bundle wheels
@@ -63,7 +69,7 @@ only `minor:` bumps the minor version, everything else (`feat:`, `fix:`, `docs:`
 | Secret | Purpose |
 |--------|---------|
 | `SEMANTIC_RELEASE_TOKEN` | GitHub PAT with `repo` scope |
-| `PYPI_API_TOKEN` | PyPI token (account-wide or project-scoped) |
+| `PYPI_API_TOKEN` | PyPI token (account-wide or project-scoped). A release that introduces a new distribution name needs a token that can create projects, so a project-scoped token has to be replaced or widened first |
 
 ## Build flags
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -41,21 +41,19 @@ It sets `MLODA_REGISTRY_VERSION` and runs three tox envs:
 ## Published packages
 
 The released set is the `published = true` flag in `config/packages.toml`.
-`scripts/published_packages.py` prints it, plain or pinned to a version; the build array
-in `.github/workflows/release.yaml` and the install lists of the `verify-published` and
+`scripts/published_packages.py` prints it, plain or pinned; the build array in
+`.github/workflows/release.yaml` and the install lists of the `verify-published` and
 `security` tox envs are all filled from that one command, so they cannot drift apart.
 `verify-published-independent` and `verify-extras` still name packages by hand, but only
 the four bundles and `mloda-community-example`, not the set as a whole.
 
 Flagging a package does not publish it: it ships with the next release run, and
-`tox -e verify-published` fails for it until that release is on PyPI.
+`tox -e verify-published` fails for it until then.
 
-Not every package in `config/packages.toml` ships standalone: most demo and example
-packages reach users inside the `mloda-community` / `mloda-enterprise` bundle wheels
-instead. `mloda-community-example` and `mloda-community-example-a` are the exceptions,
-published to keep end-to-end PyPI dependency resolution covered.
-`tests/test_end2end/test_published_set_single_source.py` asserts that the flag stays the
-only copy of the set. When adding a package to it, see
+Not every package ships standalone. Most demo and example packages reach users inside the
+`mloda-community` / `mloda-enterprise` bundle wheels instead; `mloda-community-example`
+and `mloda-community-example-a` are the exceptions, published to keep end-to-end PyPI
+dependency resolution covered. When adding a package to the set, see
 [Add a new package](packaging.md#add-a-new-package).
 
 ## Commit messages
@@ -69,7 +67,7 @@ only `minor:` bumps the minor version, everything else (`feat:`, `fix:`, `docs:`
 | Secret | Purpose |
 |--------|---------|
 | `SEMANTIC_RELEASE_TOKEN` | GitHub PAT with `repo` scope |
-| `PYPI_API_TOKEN` | PyPI token (account-wide or project-scoped). A release that introduces a new distribution name needs a token that can create projects, so a project-scoped token has to be replaced or widened first |
+| `PYPI_API_TOKEN` | PyPI token (account-wide or project-scoped) |
 
 ## Build flags
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -39,18 +39,18 @@ It sets `MLODA_REGISTRY_VERSION` and runs three tox envs:
 
 ## Published packages
 
-The build list lives in `.github/workflows/release.yaml`; that workflow is the source
-of truth, not this page. Not every package in `config/packages.toml` ships standalone:
-most demo and example packages reach users inside the `mloda-community` /
-`mloda-enterprise` bundle wheels instead. `mloda-community-example` and
-`mloda-community-example-a` are the exceptions, published to keep end-to-end PyPI
-dependency resolution covered. The header comment in `config/packages.toml` states
-the policy, and `tests/test_end2end/test_py_typed_markers.py` asserts that every
-package built by the workflow is declared in the config.
+The released set is the `published = true` flag in `config/packages.toml`, and nothing
+else. `scripts/published_packages.py` prints it, plain or pinned to a version; the build
+array in `.github/workflows/release.yaml` and the install lists of the `verify-published`
+and `security` tox envs are all filled from that one command, so they cannot drift apart.
 
-The released set is also hardcoded in the `verify-published` and `security` envs of
-`tox.ini`, and nothing cross-checks those against the workflow. When adding a package
-to the release list, see [Add a new package](packaging.md#add-a-new-package).
+Not every package in `config/packages.toml` ships standalone: most demo and example
+packages reach users inside the `mloda-community` / `mloda-enterprise` bundle wheels
+instead. `mloda-community-example` and `mloda-community-example-a` are the exceptions,
+published to keep end-to-end PyPI dependency resolution covered.
+`tests/test_end2end/test_published_set_single_source.py` asserts that the flag stays the
+only copy of the set. When adding a package to it, see
+[Add a new package](packaging.md#add-a-new-package).
 
 ## Commit messages
 
@@ -76,5 +76,7 @@ packages share one out-dir and prefix siblings (`mloda-community` vs
 ## Files
 
 - `.releaserc.yaml` - semantic-release config
+- `config/packages.toml` - the `published` flag, single source of the released set
+- `scripts/published_packages.py` - prints that set for the workflow and the tox envs
 - `.github/workflows/release.yaml` - release workflow
 - `.github/workflows/verify-published.yaml` - weekly post-release verification

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]
-all = ["mloda-community-window-aggregation", "mloda-community-aggregation", "mloda-community-rank", "mloda-community-offset", "mloda-community-frame-aggregate", "mloda-community-scalar-aggregate", "mloda-community-scalar-arithmetic", "mloda-community-point-arithmetic", "mloda-community-datetime", "mloda-community-string", "mloda-community-binning", "mloda-community-percentile", "mloda-community-time-bucketization", "mloda-community-ffill", "mloda-community-ema", "mloda-community-sessionization", "mloda-community-resample"]
+all = ["mloda-community-aggregation", "mloda-community-rank", "mloda-community-offset", "mloda-community-window-aggregation", "mloda-community-frame-aggregate", "mloda-community-scalar-aggregate", "mloda-community-scalar-arithmetic", "mloda-community-point-arithmetic", "mloda-community-datetime", "mloda-community-string", "mloda-community-binning", "mloda-community-percentile", "mloda-community-time-bucketization", "mloda-community-ffill", "mloda-community-ema", "mloda-community-sessionization", "mloda-community-resample"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -29,8 +29,7 @@ HEADER = """\
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 """
 
-# Placeholder for the published packages nested under a package's path, expanded from the
-# ``published = true`` flags in config/packages.toml (issue #345).
+# Expands to the published packages nested under a package's path. See issue #345.
 PUBLISHED_CHILDREN = "{published_children}"
 
 # Entry-point group -> manifest attribute exposing the concrete plugin classes.
@@ -90,12 +89,7 @@ def expand_published_children(
     pkg_config: dict[str, Any],
     all_packages: dict[str, dict[str, Any]],
 ) -> dict[str, list[str]]:
-    """Substitute the ``{published_children}`` placeholder in a package's optional dependencies.
-
-    The placeholder stands for every package flagged ``published = true`` whose path is nested
-    under this package's path, in config order, so an extra listing the released children is
-    derived from that flag instead of re-typed.
-    """
+    """Substitute ``{published_children}`` in a package's optional dependencies, in config order."""
     opt_deps: dict[str, list[str]] = pkg_config.get("optional_dependencies", {})
     if not any(PUBLISHED_CHILDREN in deps for deps in opt_deps.values()):
         return opt_deps
@@ -221,9 +215,7 @@ def generate_pyproject(
     lines.append(f'requires-python = "{shared["project"]["requires-python"]}"')
     lines.append("")
 
-    # Optional dependencies - merge defaults with package-specific.
-    # The {published_children} placeholder is expanded here, so the emitted extra names real
-    # distributions and the exclude_paths below never see the placeholder itself.
+    # Optional dependencies - merge defaults with package-specific
     # Skip defaults for specific packages
     skip_defaults = pkg_name in ("mloda-testing", "mloda-community", "mloda-enterprise")
     default_opt_deps = {} if skip_defaults else defaults.get("optional_dependencies", {})
@@ -264,20 +256,13 @@ def generate_pyproject(
         depth = len(pkg_path.parts)
         rel_path = "/".join([".."] * depth)
 
-        # Wheel boundaries come from the configured layout, not from the released set: every
-        # configured package nested under this path belongs to its own wheel, published or not.
-        # Sub-packages named in optional_dependencies are excluded as well, since an extra may
-        # point at a package that is not nested. Bundle packages (entry_point_bundle = true, like
-        # mloda-community) are the deliberate exception and ship all nested code.
-        optional_pkg_names = set()
-        for deps in pkg_opt_deps.values():
-            optional_pkg_names.update(deps)
-
-        excluded_pkg_names = set(optional_pkg_names)
+        # Wheel boundaries come from the configured layout, not the released set: a nested
+        # package belongs to its own wheel, published or not. Optional deps are excluded too,
+        # since an extra may name a package that is not nested. Bundles ship all nested code.
+        excluded_pkg_names = {dep for deps in pkg_opt_deps.values() for dep in deps}
         if not pkg_config.get("entry_point_bundle"):
             excluded_pkg_names |= set(nested_package_names(pkg_config["path"], all_packages))
 
-        # Map excluded package names to their paths
         exclude_paths = sorted(
             all_packages[dep_name]["path"] for dep_name in excluded_pkg_names if dep_name in all_packages
         )

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -44,6 +44,12 @@ ENTRY_POINT_ATTRS = {
 }
 
 
+def nested_package_names(pkg_path: str, all_packages: dict[str, dict[str, Any]]) -> list[str]:
+    """Return the configured packages whose path is nested under ``pkg_path``, in config order."""
+    prefix = pkg_path.rstrip("/") + "/"
+    return [name for name, cfg in all_packages.items() if cfg["path"].startswith(prefix)]
+
+
 def compute_entry_points(
     pkg_name: str,
     pkg_config: dict[str, Any],
@@ -64,12 +70,10 @@ def compute_entry_points(
     result: dict[str, list[tuple[str, str]]] = {}
 
     if pkg_config.get("entry_point_bundle"):
-        bundle_prefix = pkg_config["path"].rstrip("/") + "/"
-        for name, cfg in all_packages.items():
+        for name in nested_package_names(pkg_config["path"], all_packages):
+            cfg = all_packages[name]
             groups = cfg.get("entry_point_groups")
             if not groups:
-                continue
-            if not cfg["path"].startswith(bundle_prefix):
                 continue
             for group in groups:
                 value = f"{cfg['path'].replace('/', '.')}.manifest:{ENTRY_POINT_ATTRS[group]}"
@@ -96,11 +100,8 @@ def expand_published_children(
     if not any(PUBLISHED_CHILDREN in deps for deps in opt_deps.values()):
         return opt_deps
 
-    prefix = pkg_config["path"].rstrip("/") + "/"
     children = [
-        name
-        for name, child_config in all_packages.items()
-        if child_config.get("published") and child_config["path"].startswith(prefix)
+        name for name in nested_package_names(pkg_config["path"], all_packages) if all_packages[name].get("published")
     ]
 
     expanded: dict[str, list[str]] = {}
@@ -221,9 +222,8 @@ def generate_pyproject(
     lines.append("")
 
     # Optional dependencies - merge defaults with package-specific.
-    # The {published_children} placeholder is expanded here, before the exclude_paths below
-    # are derived from these names: an unexpanded placeholder would ship every child package
-    # inside the base wheel.
+    # The {published_children} placeholder is expanded here, so the emitted extra names real
+    # distributions and the exclude_paths below never see the placeholder itself.
     # Skip defaults for specific packages
     skip_defaults = pkg_name in ("mloda-testing", "mloda-community", "mloda-enterprise")
     default_opt_deps = {} if skip_defaults else defaults.get("optional_dependencies", {})
@@ -264,14 +264,23 @@ def generate_pyproject(
         depth = len(pkg_path.parts)
         rel_path = "/".join([".."] * depth)
 
-        # Only exclude sub-packages that are listed in optional_dependencies
-        # Bundle packages (like mloda-community) don't have optional deps, so they include everything
+        # Wheel boundaries come from the configured layout, not from the released set: every
+        # configured package nested under this path belongs to its own wheel, published or not.
+        # Sub-packages named in optional_dependencies are excluded as well, since an extra may
+        # point at a package that is not nested. Bundle packages (entry_point_bundle = true, like
+        # mloda-community) are the deliberate exception and ship all nested code.
         optional_pkg_names = set()
         for deps in pkg_opt_deps.values():
             optional_pkg_names.update(deps)
 
-        # Map optional dependency names to their paths
-        exclude_paths = [all_packages[dep_name]["path"] for dep_name in optional_pkg_names if dep_name in all_packages]
+        excluded_pkg_names = set(optional_pkg_names)
+        if not pkg_config.get("entry_point_bundle"):
+            excluded_pkg_names |= set(nested_package_names(pkg_config["path"], all_packages))
+
+        # Map excluded package names to their paths
+        exclude_paths = sorted(
+            all_packages[dep_name]["path"] for dep_name in excluded_pkg_names if dep_name in all_packages
+        )
 
         # Discover packages from filesystem, excluding optional sub-packages
         packages = discover_packages(pkg_config["path"], exclude_paths)

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -29,6 +29,10 @@ HEADER = """\
 # Do not edit directly - modify config/shared.toml or config/packages.toml instead
 """
 
+# Placeholder for the published packages nested under a package's path, expanded from the
+# ``published = true`` flags in config/packages.toml (issue #345).
+PUBLISHED_CHILDREN = "{published_children}"
+
 # Entry-point group -> manifest attribute exposing the concrete plugin classes.
 # mloda 0.9.0 discovers installed plugins through these entry-point groups; each
 # plugin package ships a ``manifest.py`` listing its concrete plugin classes
@@ -76,6 +80,39 @@ def compute_entry_points(
             result.setdefault(group, []).append((pkg_name, value))
 
     return {group: sorted(pairs, key=lambda pair: pair[0]) for group, pairs in result.items() if pairs}
+
+
+def expand_published_children(
+    pkg_config: dict[str, Any],
+    all_packages: dict[str, dict[str, Any]],
+) -> dict[str, list[str]]:
+    """Substitute the ``{published_children}`` placeholder in a package's optional dependencies.
+
+    The placeholder stands for every package flagged ``published = true`` whose path is nested
+    under this package's path, in config order, so an extra listing the released children is
+    derived from that flag instead of re-typed.
+    """
+    opt_deps: dict[str, list[str]] = pkg_config.get("optional_dependencies", {})
+    if not any(PUBLISHED_CHILDREN in deps for deps in opt_deps.values()):
+        return opt_deps
+
+    prefix = pkg_config["path"].rstrip("/") + "/"
+    children = [
+        name
+        for name, child_config in all_packages.items()
+        if child_config.get("published") and child_config["path"].startswith(prefix)
+    ]
+
+    expanded: dict[str, list[str]] = {}
+    for group, deps in opt_deps.items():
+        resolved: list[str] = []
+        for dep in deps:
+            if dep == PUBLISHED_CHILDREN:
+                resolved.extend(children)
+            else:
+                resolved.append(dep)
+        expanded[group] = resolved
+    return expanded
 
 
 def to_toml_list(items: list[str]) -> str:
@@ -183,11 +220,14 @@ def generate_pyproject(
     lines.append(f'requires-python = "{shared["project"]["requires-python"]}"')
     lines.append("")
 
-    # Optional dependencies - merge defaults with package-specific
+    # Optional dependencies - merge defaults with package-specific.
+    # The {published_children} placeholder is expanded here, before the exclude_paths below
+    # are derived from these names: an unexpanded placeholder would ship every child package
+    # inside the base wheel.
     # Skip defaults for specific packages
     skip_defaults = pkg_name in ("mloda-testing", "mloda-community", "mloda-enterprise")
     default_opt_deps = {} if skip_defaults else defaults.get("optional_dependencies", {})
-    pkg_opt_deps = pkg_config.get("optional_dependencies", {})
+    pkg_opt_deps = expand_published_children(pkg_config, all_packages)
     merged_opt_deps = {**default_opt_deps, **pkg_opt_deps}
     if merged_opt_deps:
         lines.append("[project.optional-dependencies]")
@@ -226,9 +266,8 @@ def generate_pyproject(
 
         # Only exclude sub-packages that are listed in optional_dependencies
         # Bundle packages (like mloda-community) don't have optional deps, so they include everything
-        opt_deps = pkg_config.get("optional_dependencies", {})
         optional_pkg_names = set()
-        for deps in opt_deps.values():
+        for deps in pkg_opt_deps.values():
             optional_pkg_names.update(deps)
 
         # Map optional dependency names to their paths

--- a/scripts/published_packages.py
+++ b/scripts/published_packages.py
@@ -35,14 +35,32 @@ def load_packages_config() -> dict[str, dict[str, Any]]:
 
 
 def published_packages(packages: dict[str, dict[str, Any]]) -> list[str]:
-    """Return the distributions flagged ``published = true``, in config order."""
-    return [name for name, pkg_config in packages.items() if pkg_config.get("published")]
+    """Return the distributions flagged ``published = true``, in config order.
+
+    Only the boolean ``true`` counts. A truthiness test would publish on any non-empty
+    value, so ``published = "false"`` is rejected instead of released.
+    """
+    names: list[str] = []
+    for name, pkg_config in packages.items():
+        flag = pkg_config.get("published")
+        if flag is None:
+            continue
+        if not isinstance(flag, bool):
+            raise ValueError(f"{name}: 'published' must be a boolean in {PACKAGES_CONFIG}, got {flag!r}")
+        if flag is True:
+            names.append(name)
+    return names
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Print the distributions published to PyPI")
     parser.add_argument("--pin", metavar="VERSION", help="Append '==VERSION' to every distribution name")
     args = parser.parse_args()
+
+    # tox renders '--pin ' when MLODA_REGISTRY_VERSION is unset; a bare 'name==' specifier
+    # reaches uv as an opaque parse error instead of naming the missing version.
+    if args.pin is not None and not args.pin.strip():
+        parser.error("--pin needs a version, got an empty value (is MLODA_REGISTRY_VERSION set?)")
 
     names = published_packages(load_packages_config())
 

--- a/scripts/published_packages.py
+++ b/scripts/published_packages.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Print the distributions published to PyPI, read from config/packages.toml.
+
+The ``published = true`` flag in config/packages.toml is the single source of the
+released set. This script is how the release workflow and the tox envs that install
+from PyPI read it, so none of them re-types the set.
+
+Usage:
+    python scripts/published_packages.py                # one distribution name per line
+    python scripts/published_packages.py --pin 0.4.0    # each name pinned to a version
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+CONFIG_DIR = Path("config")
+PACKAGES_CONFIG = CONFIG_DIR / "packages.toml"
+
+
+def load_packages_config() -> dict[str, dict[str, Any]]:
+    """Return the raw [packages] table of config/packages.toml, in config order."""
+    with open(PACKAGES_CONFIG, "rb") as f:
+        data = tomllib.load(f)
+    packages: dict[str, dict[str, Any]] = data.get("packages", {})
+    return packages
+
+
+def published_packages(packages: dict[str, dict[str, Any]]) -> list[str]:
+    """Return the distributions flagged ``published = true``, in config order."""
+    return [name for name, pkg_config in packages.items() if pkg_config.get("published")]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Print the distributions published to PyPI")
+    parser.add_argument("--pin", metavar="VERSION", help="Append '==VERSION' to every distribution name")
+    args = parser.parse_args()
+
+    names = published_packages(load_packages_config())
+
+    # An empty set would silently publish, verify or scan nothing at all.
+    if not names:
+        print(f"{PACKAGES_CONFIG}: no package is flagged 'published = true'", file=sys.stderr)
+        return 1
+
+    for name in names:
+        print(f"{name}=={args.pin}" if args.pin else name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/published_packages.py
+++ b/scripts/published_packages.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""Print the distributions published to PyPI, read from config/packages.toml.
-
-The ``published = true`` flag in config/packages.toml is the single source of the
-released set. This script is how the release workflow and the tox envs that install
-from PyPI read it, so none of them re-types the set.
+"""Print the distributions published to PyPI, read from the ``published`` flag in config/packages.toml.
 
 Usage:
     python scripts/published_packages.py                # one distribution name per line
@@ -35,11 +31,7 @@ def load_packages_config() -> dict[str, dict[str, Any]]:
 
 
 def published_packages(packages: dict[str, dict[str, Any]]) -> list[str]:
-    """Return the distributions flagged ``published = true``, in config order.
-
-    Only the boolean ``true`` counts. A truthiness test would publish on any non-empty
-    value, so ``published = "false"`` is rejected instead of released.
-    """
+    """Return the distributions flagged ``published = true``, in config order."""
     names: list[str] = []
     for name, pkg_config in packages.items():
         flag = pkg_config.get("published")
@@ -57,14 +49,13 @@ def main() -> int:
     parser.add_argument("--pin", metavar="VERSION", help="Append '==VERSION' to every distribution name")
     args = parser.parse_args()
 
-    # tox renders '--pin ' when MLODA_REGISTRY_VERSION is unset; a bare 'name==' specifier
-    # reaches uv as an opaque parse error instead of naming the missing version.
+    # tox renders '--pin ' when MLODA_REGISTRY_VERSION is unset.
     if args.pin is not None and not args.pin.strip():
         parser.error("--pin needs a version, got an empty value (is MLODA_REGISTRY_VERSION set?)")
 
     names = published_packages(load_packages_config())
 
-    # An empty set would silently publish, verify or scan nothing at all.
+    # An empty set would silently publish, verify or scan nothing.
     if not names:
         print(f"{PACKAGES_CONFIG}: no package is flagged 'published = true'", file=sys.stderr)
         return 1

--- a/tests/test_end2end/test_published_set_single_source.py
+++ b/tests/test_end2end/test_published_set_single_source.py
@@ -1,0 +1,356 @@
+"""Tests that the set of distributions published to PyPI is declared in a single source of truth.
+
+The released set must live in exactly ONE place: a ``published = true`` flag per
+package in ``config/packages.toml``. Everywhere else it must be derived, never
+re-typed:
+
+* ``scripts/published_packages.py`` reads the flag and prints the set, plain or
+  pinned to a version.
+* ``.github/workflows/release.yaml`` fills its ``packages=( ... )`` build array
+  from that script instead of a hand-written list.
+* ``tox.ini`` builds the ``verify-published`` and ``security`` install lists from
+  the same script.
+* ``config/packages.toml`` declares the data-operations ``all`` extra as the
+  ``"{published_children}"`` placeholder, which ``scripts/generate_pyproject.py``
+  expands to the published packages nested under that path.
+
+These tests encode that contract. They must fail while the released set is still
+copied across release.yaml, tox.ini and the data-operations extra: that drift is
+how five distributions reached three of the copies but never the build array, so
+``pip install mloda-community-data-operations[all]`` cannot resolve.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+import pytest
+
+from tests.script_loader import load_script
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SHARED_CONFIG = _REPO_ROOT / "config" / "shared.toml"
+_PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
+_GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
+_PUBLISHED_SCRIPT = _REPO_ROOT / "scripts" / "published_packages.py"
+_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yaml"
+_TOX_INI = _REPO_ROOT / "tox.ini"
+
+# The bundle distributions, always part of the released set.
+_BUNDLES = ["mloda-registry", "mloda-testing", "mloda-community", "mloda-enterprise"]
+
+# The released set, in config declaration order: the 4 bundles, the 2 examples kept for end-to-end
+# PyPI dependency-resolution coverage, and the data-operations base plus its 17 plugin packages.
+_EXPECTED_PUBLISHED = [
+    *_BUNDLES,
+    "mloda-community-example",
+    "mloda-community-example-a",
+    "mloda-community-data-operations",
+    "mloda-community-aggregation",
+    "mloda-community-rank",
+    "mloda-community-offset",
+    "mloda-community-window-aggregation",
+    "mloda-community-frame-aggregate",
+    "mloda-community-scalar-aggregate",
+    "mloda-community-scalar-arithmetic",
+    "mloda-community-point-arithmetic",
+    "mloda-community-datetime",
+    "mloda-community-string",
+    "mloda-community-binning",
+    "mloda-community-percentile",
+    "mloda-community-time-bucketization",
+    "mloda-community-ffill",
+    "mloda-community-ema",
+    "mloda-community-sessionization",
+    "mloda-community-resample",
+]
+
+# Example/demo packages that reach users only inside the community and enterprise bundle wheels.
+_BUNDLE_ONLY = [
+    "mloda-enterprise-example",
+    "mloda-community-example-b",
+    "mloda-community-compute-frameworks-example",
+    "mloda-community-extenders-example",
+    "mloda-enterprise-compute-frameworks-example",
+    "mloda-enterprise-extenders-example",
+]
+
+_DATA_OPERATIONS = "mloda-community-data-operations"
+
+# The placeholder config/packages.toml uses instead of listing the nested published packages.
+_PUBLISHED_CHILDREN = "{published_children}"
+
+# The tox envs that install the released set from PyPI.
+_TOX_PUBLISHED_ENVS = ["verify-published", "security"]
+
+_SCRIPT_INVOCATION = "scripts/published_packages.py"
+
+# A distribution name written out in a workflow build array, e.g. ``"mloda-community-ffill"``.
+_QUOTED_DISTRIBUTION_RE = re.compile(r'"(mloda-[A-Za-z0-9._-]+)"')
+
+# A hand-pinned distribution specifier, e.g. ``mloda-community-ffill==``.
+_PINNED_DISTRIBUTION_RE = re.compile(r"mloda-[A-Za-z0-9._-]*==")
+
+gen = load_script("generate_pyproject", _GEN_PATH)
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _packages() -> dict[str, dict[str, Any]]:
+    """Config-declared packages, in config order."""
+    packages: dict[str, dict[str, Any]] = _load_toml(_PACKAGES_CONFIG)["packages"]
+    return packages
+
+
+def _config_published() -> list[str]:
+    """Distribution names flagged ``published = true``, in config order."""
+    return [name for name, cfg in _packages().items() if cfg.get("published")]
+
+
+def _published_children() -> list[str]:
+    """Published packages nested under the data-operations path, in config order."""
+    packages = _packages()
+    prefix = packages[_DATA_OPERATIONS]["path"] + "/"
+    return [name for name in _EXPECTED_PUBLISHED if packages[name]["path"].startswith(prefix)]
+
+
+def _published_script() -> ModuleType:
+    """The single-source reader the release workflow, tox and the tests all share."""
+    assert _PUBLISHED_SCRIPT.exists(), (
+        f"{_PUBLISHED_SCRIPT} is missing; it must expose the released set read from config/packages.toml"
+    )
+    return load_script("published_packages", _PUBLISHED_SCRIPT)
+
+
+def _published_packages_fn() -> Callable[[dict[str, dict[str, Any]]], list[str]]:
+    """The set reader that published_packages must expose."""
+    reader: Callable[[dict[str, dict[str, Any]]], list[str]] | None = getattr(
+        _published_script(), "published_packages", None
+    )
+    assert callable(reader), "published_packages.published_packages must be a callable"
+    return reader
+
+
+def _cli(monkeypatch: pytest.MonkeyPatch, cwd: Path, argv: list[str]) -> Callable[[], int]:
+    """The CLI entry point, wired to run from ``cwd`` with ``argv``."""
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(sys, "argv", ["published_packages.py", *argv])
+    main: Callable[[], int] | None = getattr(_published_script(), "main", None)
+    assert callable(main), "published_packages.main must be a callable returning an exit code"
+    return main
+
+
+def _cli_lines(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], argv: list[str]) -> list[str]:
+    """Run the CLI in-process from the repo root and return its non-empty output lines."""
+    exit_code = _cli(monkeypatch, _REPO_ROOT, argv)()
+    assert exit_code == 0, f"published_packages.py {' '.join(argv)} exited {exit_code!r}, expected 0"
+    return [line.strip() for line in capsys.readouterr().out.splitlines() if line.strip()]
+
+
+def _tox_block(env_name: str) -> str:
+    """Body of a tox.ini ``[testenv:<name>]`` section."""
+    match = re.search(
+        rf"^\[testenv:{re.escape(env_name)}\]\n(.*?)(?=\n\[|\Z)",
+        _TOX_INI.read_text(),
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"tox.ini has no [testenv:{env_name}] section"
+    return match.group(1)
+
+
+def _generated_data_operations() -> dict[str, Any]:
+    """Parsed pyproject document the generator emits for the data-operations base package."""
+    shared = _load_toml(_SHARED_CONFIG)
+    packages = _packages()
+    content: str = gen.generate_pyproject(_DATA_OPERATIONS, packages[_DATA_OPERATIONS], shared, packages)
+    return tomllib.loads(content)
+
+
+def _committed_data_operations() -> dict[str, Any]:
+    """Parsed committed pyproject.toml of the data-operations base package."""
+    pyproject_path = _REPO_ROOT / _packages()[_DATA_OPERATIONS]["path"] / "pyproject.toml"
+    assert pyproject_path.exists(), f"{pyproject_path} is missing (run scripts/generate_pyproject.py)"
+    return _load_toml(pyproject_path)
+
+
+def _leaked_child_packages(listed: list[str]) -> list[str]:
+    """Entries of a ``[tool.setuptools] packages`` list that belong to a published child package."""
+    packages = _packages()
+    children = [packages[name]["path"].replace("/", ".") for name in _published_children()]
+    return [entry for entry in listed if any(entry == child or entry.startswith(child + ".") for child in children)]
+
+
+def test_config_declares_a_published_set() -> None:
+    """config/packages.toml carries the released set as a per-package 'published' flag."""
+    assert _config_published(), (
+        "config/packages.toml declares no package with 'published = true'; that flag is the single "
+        "source of truth for the distributions that ship to PyPI."
+    )
+
+
+def test_published_set_contains_the_bundles() -> None:
+    """The four bundle wheels are always released."""
+    flagged = _config_published()
+    assert set(_BUNDLES) <= set(flagged), (
+        f"config/packages.toml does not flag bundles {sorted(set(_BUNDLES) - set(flagged))} as 'published = true'"
+    )
+
+
+def test_published_flag_marks_exactly_the_released_distributions() -> None:
+    """The flagged set is the release workflow array plus the five distributions it had drifted from."""
+    flagged = _config_published()
+    assert sorted(flagged) == sorted(_EXPECTED_PUBLISHED), (
+        "config/packages.toml must flag exactly the released set with 'published = true': missing "
+        f"{sorted(set(_EXPECTED_PUBLISHED) - set(flagged))}, unexpected {sorted(set(flagged) - set(_EXPECTED_PUBLISHED))}"
+    )
+
+
+def test_bundle_only_packages_are_not_published() -> None:
+    """Example and demo packages ship inside the bundle wheels, never as standalone distributions."""
+    packages = _packages()
+    flagged = [name for name in _BUNDLE_ONLY if packages[name].get("published")]
+    assert flagged == [], (
+        f"config/packages.toml flags bundle-only packages {flagged} as 'published = true'; their code "
+        "reaches users through the mloda-community / mloda-enterprise wheels."
+    )
+
+
+def test_published_packages_returns_the_flagged_names_in_config_order() -> None:
+    """published_packages() is the one reader of the flag; order follows config declaration order."""
+    names = _published_packages_fn()(_packages())
+    assert names == _EXPECTED_PUBLISHED, (
+        f"published_packages() returned {names!r}, expected the flagged distributions in config "
+        f"declaration order {_EXPECTED_PUBLISHED!r}"
+    )
+
+
+def test_cli_prints_one_distribution_per_line(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The bare CLI feeds the release workflow build array."""
+    lines = _cli_lines(monkeypatch, capsys, [])
+    assert lines == _EXPECTED_PUBLISHED, (
+        f"'python scripts/published_packages.py' printed {lines!r}, expected one distribution name per "
+        f"line in config order {_EXPECTED_PUBLISHED!r}"
+    )
+
+
+def test_cli_pin_appends_the_version_to_every_name(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--pin`` feeds the tox install lines, which need ``name==version`` specifiers."""
+    lines = _cli_lines(monkeypatch, capsys, ["--pin", "9.9.9"])
+    expected = [f"{name}==9.9.9" for name in _EXPECTED_PUBLISHED]
+    assert lines == expected, (
+        f"'python scripts/published_packages.py --pin 9.9.9' printed {lines!r}, expected {expected!r}"
+    )
+
+
+def test_cli_exits_non_zero_when_nothing_is_published(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty set would silently publish nothing, so it must fail loudly instead."""
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "packages.toml").write_text(
+        '[packages.mloda-registry]\ndescription = "sandbox"\npath = "mloda/registry"\n'
+    )
+
+    exit_code = _cli(monkeypatch, tmp_path, [])()
+
+    assert exit_code != 0, "published_packages.main() must exit non-zero when no package carries 'published = true'"
+
+
+def test_release_workflow_has_no_hardcoded_distribution_list() -> None:
+    """The build array must be generated, not typed out; the typed-out copy is what drifted."""
+    names = sorted(set(_QUOTED_DISTRIBUTION_RE.findall(_RELEASE_WORKFLOW.read_text())))
+    assert names == [], (
+        f".github/workflows/release.yaml still names {len(names)} distribution(s) itself, starting with "
+        f"{names[:3]}; fill 'packages=( ... )' from 'python {_SCRIPT_INVOCATION}' instead."
+    )
+
+
+def test_release_workflow_builds_from_the_published_script() -> None:
+    """The workflow reads the released set from the single source."""
+    assert _SCRIPT_INVOCATION in _RELEASE_WORKFLOW.read_text(), (
+        f".github/workflows/release.yaml does not invoke {_SCRIPT_INVOCATION}, so its build array is a "
+        "second copy of the released set."
+    )
+
+
+@pytest.mark.parametrize("env_name", _TOX_PUBLISHED_ENVS)
+def test_tox_env_holds_no_pinned_distribution_list(env_name: str) -> None:
+    """tox must not re-type the released set to install it."""
+    pins = sorted(set(_PINNED_DISTRIBUTION_RE.findall(_tox_block(env_name))))
+    assert pins == [], (
+        f"tox.ini [testenv:{env_name}] still pins {len(pins)} distribution(s) by hand, starting with "
+        f"{pins[:3]}; build the list from 'python {_SCRIPT_INVOCATION} --pin ...' instead."
+    )
+
+
+@pytest.mark.parametrize("env_name", _TOX_PUBLISHED_ENVS)
+def test_tox_env_installs_from_the_published_script(env_name: str) -> None:
+    """Both PyPI-installing envs read the released set from the single source."""
+    assert _SCRIPT_INVOCATION in _tox_block(env_name), (
+        f"tox.ini [testenv:{env_name}] does not invoke {_SCRIPT_INVOCATION}, so its package list is a "
+        "second copy of the released set."
+    )
+
+
+def test_data_operations_extra_uses_the_published_children_placeholder() -> None:
+    """The 'all' extra is derived from the flag, so an unpublished package can never enter it."""
+    extra = _packages()[_DATA_OPERATIONS].get("optional_dependencies", {}).get("all")
+    assert extra == [_PUBLISHED_CHILDREN], (
+        f"config/packages.toml must declare the {_DATA_OPERATIONS} 'all' extra as "
+        f'["{_PUBLISHED_CHILDREN}"], got {extra!r}'
+    )
+
+
+def test_generator_expands_published_children() -> None:
+    """The placeholder expands to the published packages under the package path, in config order."""
+    expected = _published_children()
+    extra: list[str] = _generated_data_operations()["project"]["optional-dependencies"]["all"]
+    assert extra == expected, (
+        f"the generator emitted 'all' = {extra!r} for {_DATA_OPERATIONS}, expected the published "
+        f"packages nested under its path in config order {expected!r}"
+    )
+
+
+def test_generator_keeps_published_children_out_of_the_base_wheel() -> None:
+    """The placeholder must expand before exclude_paths, or every child leaks into the base wheel."""
+    listed: list[str] = _generated_data_operations()["tool"]["setuptools"]["packages"]
+    leaked = _leaked_child_packages(listed)
+    assert leaked == [], (
+        f"the generated {_DATA_OPERATIONS} wheel would ship child packages {leaked}; expand "
+        f'"{_PUBLISHED_CHILDREN}" before the exclude_paths are computed from the extras.'
+    )
+
+
+def test_committed_data_operations_extra_lists_the_published_children() -> None:
+    """``tox -e check-generated`` runs only in the package-integrity workflow, not in this gate."""
+    expected = _published_children()
+    extra: list[str] = _committed_data_operations()["project"]["optional-dependencies"]["all"]
+    assert extra == expected, (
+        f"the committed {_DATA_OPERATIONS} pyproject.toml declares 'all' = {extra!r}, expected "
+        f"{expected!r} (run scripts/generate_pyproject.py)"
+    )
+
+
+def test_committed_base_wheel_excludes_the_published_children() -> None:
+    """The committed base wheel must not carry the code of its child distributions."""
+    listed: list[str] = _committed_data_operations()["tool"]["setuptools"]["packages"]
+    leaked = _leaked_child_packages(listed)
+    assert leaked == [], (
+        f"the committed {_DATA_OPERATIONS} pyproject.toml lists child packages {leaked} in "
+        "[tool.setuptools] packages (run scripts/generate_pyproject.py)"
+    )

--- a/tests/test_end2end/test_published_set_single_source.py
+++ b/tests/test_end2end/test_published_set_single_source.py
@@ -14,10 +14,22 @@ re-typed:
   ``"{published_children}"`` placeholder, which ``scripts/generate_pyproject.py``
   expands to the published packages nested under that path.
 
-These tests encode that contract. They must fail while the released set is still
-copied across release.yaml, tox.ini and the data-operations extra: that drift is
-how five distributions reached three of the copies but never the build array, so
-``pip install mloda-community-data-operations[all]`` cannot resolve.
+These tests encode that contract. Re-typed copies are how five distributions
+reached three of the copies but never the build array, so
+``pip install mloda-community-data-operations[all]`` could not resolve.
+
+The flag governs the RELEASE SET only. Wheel boundaries come from the configured
+package layout: every configured package nested under another package's path stays
+out of that package's wheel, published or not. The ``entry_point_bundle`` packages
+are the deliberate exception and ship all nested code. Deriving the wheel exclusions
+from the expanded extra instead couples the two, so dropping ``published`` from a
+plugin silently absorbs its modules into the base wheel and ships them twice.
+
+The remaining tests keep the derivation honest: the "no hand-written copy" guards
+must catch bare and single-quoted names as well as pinned ones and must look at the
+build array itself rather than at a comment naming the script, and every published
+distribution must be imported by ``tox -e verify-published``, or a newly released
+plugin installs from PyPI without anyone ever importing it.
 """
 
 from __future__ import annotations
@@ -25,6 +37,7 @@ from __future__ import annotations
 import re
 import sys
 from collections.abc import Callable
+from copy import deepcopy
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -87,19 +100,39 @@ _BUNDLE_ONLY = [
 
 _DATA_OPERATIONS = "mloda-community-data-operations"
 
+_COMMUNITY_EXAMPLE = "mloda-community-example"
+
+_EXAMPLE_B = "mloda-community-example-b"
+
+# The published child whose flag the wheel-boundary tests drop to prove 'published' does not
+# control wheel contents.
+_UNPUBLISH_PROBE = "mloda-community-ema"
+
+# The packages flagged ``entry_point_bundle = true``: the only wheels that ship nested code.
+_ENTRY_POINT_BUNDLES = ["mloda-community", "mloda-enterprise"]
+
 # The placeholder config/packages.toml uses instead of listing the nested published packages.
 _PUBLISHED_CHILDREN = "{published_children}"
 
 # The tox envs that install the released set from PyPI.
 _TOX_PUBLISHED_ENVS = ["verify-published", "security"]
 
+# The tox env that import-checks every installed distribution.
+_VERIFY_PUBLISHED_ENV = "verify-published"
+
 _SCRIPT_INVOCATION = "scripts/published_packages.py"
 
-# A distribution name written out in a workflow build array, e.g. ``"mloda-community-ffill"``.
-_QUOTED_DISTRIBUTION_RE = re.compile(r'"(mloda-[A-Za-z0-9._-]+)"')
+# The release workflow step that builds the wheels.
+_BUILD_STEP = "Build packages"
 
-# A hand-pinned distribution specifier, e.g. ``mloda-community-ffill==``.
-_PINNED_DISTRIBUTION_RE = re.compile(r"mloda-[A-Za-z0-9._-]*==")
+# A distribution name written out by hand, quoted or bare, e.g. ``"mloda-community-ffill"``. The
+# leading boundary keeps the ``/tmp/mloda-verify*`` venv paths and the dotted ``mloda.community....``
+# import paths of the same tox blocks out.
+_DISTRIBUTION_NAME_RE = re.compile(r"(?<![\w/-])mloda-(?:registry|testing|community|enterprise)[a-z0-9-]*")
+
+# The build array filled from the script on one line, e.g.
+# ``mapfile -t packages < <(python scripts/published_packages.py)``. A comment cannot match.
+_ARRAY_FROM_SCRIPT_RE = re.compile(rf"^[^\n#]*\bpackages\b[^\n#]*{re.escape(_SCRIPT_INVOCATION)}", re.MULTILINE)
 
 gen = load_script("generate_pyproject", _GEN_PATH)
 
@@ -118,6 +151,12 @@ def _packages() -> dict[str, dict[str, Any]]:
 def _config_published() -> list[str]:
     """Distribution names flagged ``published = true``, in config order."""
     return [name for name, cfg in _packages().items() if cfg.get("published")]
+
+
+def _dotted_path(pkg_name: str) -> str:
+    """Dotted import path of a configured package."""
+    path: str = _packages()[pkg_name]["path"]
+    return path.replace("/", ".")
 
 
 def _published_children() -> list[str]:
@@ -153,6 +192,14 @@ def _cli(monkeypatch: pytest.MonkeyPatch, cwd: Path, argv: list[str]) -> Callabl
     return main
 
 
+def _cli_exit_code(monkeypatch: pytest.MonkeyPatch, cwd: Path, argv: list[str]) -> int:
+    """Run the CLI and return its exit code, treating an argparse ``SystemExit`` as that code."""
+    try:
+        return _cli(monkeypatch, cwd, argv)()
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 1
+
+
 def _cli_lines(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], argv: list[str]) -> list[str]:
     """Run the CLI in-process from the repo root and return its non-empty output lines."""
     exit_code = _cli(monkeypatch, _REPO_ROOT, argv)()
@@ -171,12 +218,39 @@ def _tox_block(env_name: str) -> str:
     return match.group(1)
 
 
+def _workflow_build_step() -> str:
+    """Body of the ``run:`` block of the release workflow's build step."""
+    match = re.search(
+        rf"^(?P<indent>\s*)- name: {re.escape(_BUILD_STEP)}\n(?P<body>.*?)(?=^(?P=indent)- name:|\Z)",
+        _RELEASE_WORKFLOW.read_text(),
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f".github/workflows/release.yaml has no '- name: {_BUILD_STEP}' step"
+    _, separator, run_block = match.group("body").partition("run: |\n")
+    assert separator, f".github/workflows/release.yaml step '{_BUILD_STEP}' has no 'run: |' block"
+    return run_block
+
+
+def _generated(pkg_name: str, packages: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Parsed pyproject document the generator emits for a package under the given config."""
+    shared = _load_toml(_SHARED_CONFIG)
+    content: str = gen.generate_pyproject(pkg_name, packages[pkg_name], shared, packages)
+    return tomllib.loads(content)
+
+
+def _wheel_packages(pkg_name: str, packages: dict[str, dict[str, Any]]) -> list[str]:
+    """``[tool.setuptools] packages`` the generator emits for a package under the given config."""
+    listed: list[str] = _generated(pkg_name, packages)["tool"]["setuptools"]["packages"]
+    assert listed, (
+        f"the generator discovered no modules for {pkg_name}; its paths are relative to the working "
+        "directory, so run pytest from the repository root"
+    )
+    return listed
+
+
 def _generated_data_operations() -> dict[str, Any]:
     """Parsed pyproject document the generator emits for the data-operations base package."""
-    shared = _load_toml(_SHARED_CONFIG)
-    packages = _packages()
-    content: str = gen.generate_pyproject(_DATA_OPERATIONS, packages[_DATA_OPERATIONS], shared, packages)
-    return tomllib.loads(content)
+    return _generated(_DATA_OPERATIONS, _packages())
 
 
 def _committed_data_operations() -> dict[str, Any]:
@@ -186,11 +260,15 @@ def _committed_data_operations() -> dict[str, Any]:
     return _load_toml(pyproject_path)
 
 
+def _entries_under(listed: list[str], dotted: str) -> list[str]:
+    """Entries of a ``[tool.setuptools] packages`` list that sit at or below a dotted path."""
+    return [entry for entry in listed if entry == dotted or entry.startswith(dotted + ".")]
+
+
 def _leaked_child_packages(listed: list[str]) -> list[str]:
     """Entries of a ``[tool.setuptools] packages`` list that belong to a published child package."""
-    packages = _packages()
-    children = [packages[name]["path"].replace("/", ".") for name in _published_children()]
-    return [entry for entry in listed if any(entry == child or entry.startswith(child + ".") for child in children)]
+    children = [_dotted_path(name) for name in _published_children()]
+    return sorted({entry for child in children for entry in _entries_under(listed, child)})
 
 
 def test_config_declares_a_published_set() -> None:
@@ -221,6 +299,8 @@ def test_published_flag_marks_exactly_the_released_distributions() -> None:
 def test_bundle_only_packages_are_not_published() -> None:
     """Example and demo packages ship inside the bundle wheels, never as standalone distributions."""
     packages = _packages()
+    missing = [name for name in _BUNDLE_ONLY if name not in packages]
+    assert missing == [], f"config/packages.toml no longer declares bundle-only packages {missing}"
     flagged = [name for name in _BUNDLE_ONLY if packages[name].get("published")]
     assert flagged == [], (
         f"config/packages.toml flags bundle-only packages {flagged} as 'published = true'; their code "
@@ -235,6 +315,29 @@ def test_published_packages_returns_the_flagged_names_in_config_order() -> None:
         f"published_packages() returned {names!r}, expected the flagged distributions in config "
         f"declaration order {_EXPECTED_PUBLISHED!r}"
     )
+
+
+def test_published_packages_rejects_a_non_boolean_flag() -> None:
+    """A truthiness test publishes on 'published = "false"', so a non-boolean flag must be rejected."""
+    packages: dict[str, dict[str, Any]] = {
+        "mloda-registry": {"description": "sandbox", "path": "mloda/registry", "published": "false"},
+    }
+
+    with pytest.raises(ValueError, match="published"):
+        _published_packages_fn()(packages)
+
+
+def test_published_packages_counts_only_a_true_flag() -> None:
+    """'published = false' and a missing flag both keep a package out of the released set."""
+    packages: dict[str, dict[str, Any]] = {
+        "mloda-registry": {"description": "sandbox", "path": "mloda/registry", "published": True},
+        "mloda-testing": {"description": "sandbox", "path": "mloda/testing", "published": False},
+        "mloda-community": {"description": "sandbox", "path": "mloda/community"},
+    }
+
+    names = _published_packages_fn()(packages)
+
+    assert names == ["mloda-registry"], f"published_packages() returned {names!r}, expected ['mloda-registry']"
 
 
 def test_cli_prints_one_distribution_per_line(
@@ -266,35 +369,64 @@ def test_cli_exits_non_zero_when_nothing_is_published(tmp_path: Path, monkeypatc
         '[packages.mloda-registry]\ndescription = "sandbox"\npath = "mloda/registry"\n'
     )
 
-    exit_code = _cli(monkeypatch, tmp_path, [])()
+    exit_code = _cli_exit_code(monkeypatch, tmp_path, [])
 
     assert exit_code != 0, "published_packages.main() must exit non-zero when no package carries 'published = true'"
 
 
+def test_cli_rejects_an_empty_pin(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """tox renders '--pin ' when MLODA_REGISTRY_VERSION is unset; bare 'name==' specifiers must not reach uv."""
+    exit_code = _cli_exit_code(monkeypatch, _REPO_ROOT, ["--pin", ""])
+    captured = capsys.readouterr()
+
+    assert exit_code != 0, (
+        f"'python {_SCRIPT_INVOCATION} --pin ' exited {exit_code!r}; an empty version must be rejected "
+        "instead of printing unusable 'name==' specifiers"
+    )
+    assert "==" not in captured.out, (
+        f"'python {_SCRIPT_INVOCATION} --pin ' printed {captured.out.splitlines()[:3]}; an empty version "
+        "must produce no specifiers at all"
+    )
+    assert "--pin" in captured.err, (
+        f"'python {_SCRIPT_INVOCATION} --pin ' failed without naming --pin on stderr, got {captured.err!r}; "
+        "the message must say which argument is empty"
+    )
+
+
 def test_release_workflow_has_no_hardcoded_distribution_list() -> None:
-    """The build array must be generated, not typed out; the typed-out copy is what drifted."""
-    names = sorted(set(_QUOTED_DISTRIBUTION_RE.findall(_RELEASE_WORKFLOW.read_text())))
+    """The build array must be generated, not typed out in any quoting style; the copy is what drifted."""
+    names = sorted(set(_DISTRIBUTION_NAME_RE.findall(_workflow_build_step())))
     assert names == [], (
-        f".github/workflows/release.yaml still names {len(names)} distribution(s) itself, starting with "
-        f"{names[:3]}; fill 'packages=( ... )' from 'python {_SCRIPT_INVOCATION}' instead."
+        f".github/workflows/release.yaml step '{_BUILD_STEP}' names {len(names)} distribution(s) itself, "
+        f"starting with {names[:3]}; fill 'packages=( ... )' from 'python {_SCRIPT_INVOCATION}' instead."
     )
 
 
 def test_release_workflow_builds_from_the_published_script() -> None:
-    """The workflow reads the released set from the single source."""
-    assert _SCRIPT_INVOCATION in _RELEASE_WORKFLOW.read_text(), (
-        f".github/workflows/release.yaml does not invoke {_SCRIPT_INVOCATION}, so its build array is a "
-        "second copy of the released set."
+    """Naming the script in a comment proves nothing: the build array itself must be filled from it."""
+    assert _ARRAY_FROM_SCRIPT_RE.search(_workflow_build_step()) is not None, (
+        f".github/workflows/release.yaml step '{_BUILD_STEP}' does not fill its 'packages' array from "
+        f"'python {_SCRIPT_INVOCATION}', so the set it builds is a second copy of the released set."
     )
 
 
 @pytest.mark.parametrize("env_name", _TOX_PUBLISHED_ENVS)
-def test_tox_env_holds_no_pinned_distribution_list(env_name: str) -> None:
-    """tox must not re-type the released set to install it."""
-    pins = sorted(set(_PINNED_DISTRIBUTION_RE.findall(_tox_block(env_name))))
-    assert pins == [], (
-        f"tox.ini [testenv:{env_name}] still pins {len(pins)} distribution(s) by hand, starting with "
-        f"{pins[:3]}; build the list from 'python {_SCRIPT_INVOCATION} --pin ...' instead."
+def test_tox_env_names_no_distribution_itself(env_name: str) -> None:
+    """tox must not re-type the released set to install it, pinned or unpinned."""
+    names = sorted(set(_DISTRIBUTION_NAME_RE.findall(_tox_block(env_name))))
+    assert names == [], (
+        f"tox.ini [testenv:{env_name}] names {len(names)} distribution(s) by hand, starting with "
+        f"{names[:3]}; build the list from 'python {_SCRIPT_INVOCATION} --pin ...' instead."
+    )
+
+
+@pytest.mark.parametrize("pkg_name", _EXPECTED_PUBLISHED)
+def test_verify_published_imports_every_published_distribution(pkg_name: str) -> None:
+    """Installing the released set proves nothing about importing it, so every distribution needs a smoke import."""
+    dotted = _dotted_path(pkg_name)
+    assert dotted in _tox_block(_VERIFY_PUBLISHED_ENV), (
+        f"tox.ini [testenv:{_VERIFY_PUBLISHED_ENV}] never imports {dotted}, so {pkg_name} is installed "
+        "from PyPI and never import-checked; add a smoke import line for it."
     )
 
 
@@ -316,6 +448,20 @@ def test_data_operations_extra_uses_the_published_children_placeholder() -> None
     )
 
 
+def test_community_example_extra_keeps_the_unpublished_example_b() -> None:
+    """example-b is unpublished but still resolvable at its last version, and tox -e verify-extras installs it."""
+    packages = _packages()
+    extra = packages[_COMMUNITY_EXAMPLE].get("optional_dependencies", {}).get("all", [])
+    assert _EXAMPLE_B in extra, (
+        f"config/packages.toml dropped {_EXAMPLE_B} from the {_COMMUNITY_EXAMPLE} 'all' extra, got "
+        f"{extra!r}; tox -e verify-extras installs that extra and imports example_b from it."
+    )
+    assert not packages[_EXAMPLE_B].get("published"), (
+        f"{_EXAMPLE_B} is flagged published; this test pins that an unpublished package may stay in a "
+        "hand-written extra, so the extra must not be converted to the published-children placeholder."
+    )
+
+
 def test_generator_expands_published_children() -> None:
     """The placeholder expands to the published packages under the package path, in config order."""
     expected = _published_children()
@@ -333,6 +479,55 @@ def test_generator_keeps_published_children_out_of_the_base_wheel() -> None:
     assert leaked == [], (
         f"the generated {_DATA_OPERATIONS} wheel would ship child packages {leaked}; expand "
         f'"{_PUBLISHED_CHILDREN}" before the exclude_paths are computed from the extras.'
+    )
+
+
+def test_unpublishing_a_child_keeps_it_out_of_the_base_wheel() -> None:
+    """'published' governs the released set, never wheel contents: a nested package stays its own wheel."""
+    packages = deepcopy(_packages())
+    assert packages[_UNPUBLISH_PROBE].pop("published", None) is not None, (
+        f"fixture assumption: {_UNPUBLISH_PROBE} carries the published flag"
+    )
+
+    leaked = _entries_under(_wheel_packages(_DATA_OPERATIONS, packages), _dotted_path(_UNPUBLISH_PROBE))
+
+    assert leaked == [], (
+        f"dropping 'published' from {_UNPUBLISH_PROBE} absorbed {leaked} into the {_DATA_OPERATIONS} "
+        "wheel; derive the wheel exclusions from the configured package layout, not from the expanded "
+        f'"{_PUBLISHED_CHILDREN}" extra, or the same modules ship in two distributions.'
+    )
+
+
+def test_shrinking_an_extra_keeps_a_configured_child_out_of_the_base_wheel() -> None:
+    """Same coupling through a hand-written extra: the example base must not absorb example-b either."""
+    packages = deepcopy(_packages())
+    extra: list[str] = packages[_COMMUNITY_EXAMPLE]["optional_dependencies"]["all"]
+    assert _EXAMPLE_B in extra, f"fixture assumption: the {_COMMUNITY_EXAMPLE} 'all' extra lists {_EXAMPLE_B}"
+    packages[_COMMUNITY_EXAMPLE]["optional_dependencies"]["all"] = [dep for dep in extra if dep != _EXAMPLE_B]
+
+    leaked = _entries_under(_wheel_packages(_COMMUNITY_EXAMPLE, packages), _dotted_path(_EXAMPLE_B))
+
+    assert leaked == [], (
+        f"dropping {_EXAMPLE_B} from the {_COMMUNITY_EXAMPLE} 'all' extra absorbed {leaked} into the "
+        f"{_COMMUNITY_EXAMPLE} wheel; a configured package nested under another package's path belongs "
+        "to its own wheel whatever the extras say."
+    )
+
+
+@pytest.mark.parametrize("bundle", _ENTRY_POINT_BUNDLES)
+def test_bundle_wheel_still_ships_every_nested_package(bundle: str) -> None:
+    """Bundles are the deliberate exception to the layout rule: they ship all nested code, published or not."""
+    packages = _packages()
+    prefix = packages[bundle]["path"] + "/"
+    nested = {name: cfg["path"].replace("/", ".") for name, cfg in packages.items() if cfg["path"].startswith(prefix)}
+    assert nested, f"fixture assumption: {bundle} has configured packages nested under {prefix}"
+
+    listed = _wheel_packages(bundle, packages)
+
+    missing = sorted(name for name, dotted in nested.items() if dotted not in listed)
+    assert missing == [], (
+        f"the generated {bundle} wheel no longer ships nested packages {missing}; a package flagged "
+        "'entry_point_bundle = true' must keep including every nested module."
     )
 
 

--- a/tests/test_end2end/test_published_set_single_source.py
+++ b/tests/test_end2end/test_published_set_single_source.py
@@ -1,35 +1,14 @@
 """Tests that the set of distributions published to PyPI is declared in a single source of truth.
 
-The released set must live in exactly ONE place: a ``published = true`` flag per
-package in ``config/packages.toml``. Everywhere else it must be derived, never
-re-typed:
+The released set lives in exactly ONE place: a ``published = true`` flag per package in
+``config/packages.toml``. The release workflow, the ``verify-published`` and ``security``
+tox envs and the data-operations ``all`` extra all derive from it through
+``scripts/published_packages.py``. Re-typed copies are how five distributions reached
+three of the four and never the build array.
 
-* ``scripts/published_packages.py`` reads the flag and prints the set, plain or
-  pinned to a version.
-* ``.github/workflows/release.yaml`` fills its ``packages=( ... )`` build array
-  from that script instead of a hand-written list.
-* ``tox.ini`` builds the ``verify-published`` and ``security`` install lists from
-  the same script.
-* ``config/packages.toml`` declares the data-operations ``all`` extra as the
-  ``"{published_children}"`` placeholder, which ``scripts/generate_pyproject.py``
-  expands to the published packages nested under that path.
-
-These tests encode that contract. Re-typed copies are how five distributions
-reached three of the copies but never the build array, so
-``pip install mloda-community-data-operations[all]`` could not resolve.
-
-The flag governs the RELEASE SET only. Wheel boundaries come from the configured
-package layout: every configured package nested under another package's path stays
-out of that package's wheel, published or not. The ``entry_point_bundle`` packages
-are the deliberate exception and ship all nested code. Deriving the wheel exclusions
-from the expanded extra instead couples the two, so dropping ``published`` from a
-plugin silently absorbs its modules into the base wheel and ships them twice.
-
-The remaining tests keep the derivation honest: the "no hand-written copy" guards
-must catch bare and single-quoted names as well as pinned ones and must look at the
-build array itself rather than at a comment naming the script, and every published
-distribution must be imported by ``tox -e verify-published``, or a newly released
-plugin installs from PyPI without anyone ever importing it.
+The flag governs the released set only. Wheel boundaries come from the configured layout:
+a nested package stays out of its parent's wheel, published or not, with the
+``entry_point_bundle`` packages the deliberate exception.
 """
 
 from __future__ import annotations
@@ -62,8 +41,8 @@ _TOX_INI = _REPO_ROOT / "tox.ini"
 # The bundle distributions, always part of the released set.
 _BUNDLES = ["mloda-registry", "mloda-testing", "mloda-community", "mloda-enterprise"]
 
-# The released set, in config declaration order: the 4 bundles, the 2 examples kept for end-to-end
-# PyPI dependency-resolution coverage, and the data-operations base plus its 17 plugin packages.
+# The released set, in config order: 4 bundles, 2 examples kept for PyPI resolution coverage,
+# and the data-operations base plus its 17 plugin packages.
 _EXPECTED_PUBLISHED = [
     *_BUNDLES,
     "mloda-community-example",
@@ -104,14 +83,12 @@ _COMMUNITY_EXAMPLE = "mloda-community-example"
 
 _EXAMPLE_B = "mloda-community-example-b"
 
-# The published child whose flag the wheel-boundary tests drop to prove 'published' does not
-# control wheel contents.
+# The child whose flag the wheel-boundary tests drop.
 _UNPUBLISH_PROBE = "mloda-community-ema"
 
-# The packages flagged ``entry_point_bundle = true``: the only wheels that ship nested code.
+# The only wheels that ship nested code.
 _ENTRY_POINT_BUNDLES = ["mloda-community", "mloda-enterprise"]
 
-# The placeholder config/packages.toml uses instead of listing the nested published packages.
 _PUBLISHED_CHILDREN = "{published_children}"
 
 # The tox envs that install the released set from PyPI.
@@ -122,16 +99,13 @@ _VERIFY_PUBLISHED_ENV = "verify-published"
 
 _SCRIPT_INVOCATION = "scripts/published_packages.py"
 
-# The release workflow step that builds the wheels.
 _BUILD_STEP = "Build packages"
 
-# A distribution name written out by hand, quoted or bare, e.g. ``"mloda-community-ffill"``. The
-# leading boundary keeps the ``/tmp/mloda-verify*`` venv paths and the dotted ``mloda.community....``
-# import paths of the same tox blocks out.
+# A hand-written distribution name, quoted or bare. The leading boundary keeps the
+# ``/tmp/mloda-verify*`` paths and the dotted ``mloda.community....`` imports out.
 _DISTRIBUTION_NAME_RE = re.compile(r"(?<![\w/-])mloda-(?:registry|testing|community|enterprise)[a-z0-9-]*")
 
-# The build array filled from the script on one line, e.g.
-# ``mapfile -t packages < <(python scripts/published_packages.py)``. A comment cannot match.
+# The array filled from the script on one line. A comment cannot match.
 _ARRAY_FROM_SCRIPT_RE = re.compile(rf"^[^\n#]*\bpackages\b[^\n#]*{re.escape(_SCRIPT_INVOCATION)}", re.MULTILINE)
 
 gen = load_script("generate_pyproject", _GEN_PATH)

--- a/tests/test_end2end/test_py_typed_markers.py
+++ b/tests/test_end2end/test_py_typed_markers.py
@@ -23,7 +23,7 @@ from tests.script_loader import load_script
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
 _VERIFY_BUILDS_PATH = _REPO_ROOT / "scripts" / "verify_builds.py"
-_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yaml"
+_PUBLISHED_PACKAGES_PATH = _REPO_ROOT / "scripts" / "published_packages.py"
 
 # The bundle distributions, always part of the released set.
 _BUNDLES = ["mloda-registry", "mloda-testing", "mloda-community", "mloda-enterprise"]
@@ -51,19 +51,14 @@ def _dotted_path(pkg_name: str) -> str:
 
 
 def _published_packages() -> list[str]:
-    """Distribution names built by the ``packages=( ... )`` array of the release workflow."""
-    match = re.search(r"packages=\(\n(.*?)\n\s*\)\n", _RELEASE_WORKFLOW.read_text(), re.DOTALL)
-    assert match is not None, f"{_RELEASE_WORKFLOW}: no 'packages=( ... )' build array found"
-    block = re.sub(r"^\s*#.*$", "", match.group(1), flags=re.MULTILINE)
-    entries = [line for line in block.splitlines() if line.strip()]
-    names = re.findall(r'"([^"]+)"', block)
-    assert names, f"{_RELEASE_WORKFLOW}: 'packages=( ... )' holds no quoted distribution names"
-    assert len(names) == len(entries), (
-        f"{_RELEASE_WORKFLOW}: 'packages=( ... )' holds {len(entries)} entries but {len(names)} "
-        'double-quoted names; write every entry as "mloda-..." on its own line'
+    """Distribution names flagged ``published = true`` in config/packages.toml, the released set."""
+    assert _PUBLISHED_PACKAGES_PATH.exists(), (
+        f"{_PUBLISHED_PACKAGES_PATH} is missing; it reads the released set from config/packages.toml"
     )
+    pub = load_script("published_packages", _PUBLISHED_PACKAGES_PATH)
+    names: list[str] = pub.published_packages(_packages())
     assert set(_BUNDLES) <= set(names), (
-        f"{_RELEASE_WORKFLOW}: build array lost bundles {sorted(set(_BUNDLES) - set(names))}"
+        f"config/packages.toml lost the published flag on bundles {sorted(set(_BUNDLES) - set(names))}"
     )
     return names
 
@@ -175,7 +170,6 @@ def test_every_published_distribution_has_a_typed_ancestor(pkg_name: str) -> Non
     # test_package_data_is_emitted_only_for_flagged_packages pins the flagged set, so a newly published
     # package can ship untyped without failing it.
     packages = _packages()
-    assert pkg_name in packages, f"{pkg_name} is built by release.yaml but not declared in config/packages.toml"
     pkg_path: str = packages[pkg_name]["path"]
     reachable = {pkg_name} | _dependency_closure(pkg_name, packages)
     typed = {name: cfg["path"] for name, cfg in packages.items() if cfg.get("py_typed")}

--- a/tox.ini
+++ b/tox.ini
@@ -108,14 +108,17 @@ commands =
 
 [testenv:verify-published]
 description = Verify published packages install and import correctly
-# Needs skip_install, which the lock runner ignores.
+# Needs deps and skip_install, which the lock runner ignores.
 runner = uv-venv-runner
 skip_install = true
+# tomli: nothing else here provides it, and Python 3.10 has no tomllib.
+deps =
+    tomli
 allowlist_externals = sh, uv, rm
 commands =
     sh -c 'uv cache clean'
     sh -c 'rm -rf /tmp/mloda-verify && uv venv /tmp/mloda-verify'
-    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify uv pip install mloda-registry=={env:MLODA_REGISTRY_VERSION} mloda-testing=={env:MLODA_REGISTRY_VERSION} mloda-community=={env:MLODA_REGISTRY_VERSION} mloda-enterprise=={env:MLODA_REGISTRY_VERSION} mloda-community-example=={env:MLODA_REGISTRY_VERSION} mloda-community-example-a=={env:MLODA_REGISTRY_VERSION} mloda-community-data-operations=={env:MLODA_REGISTRY_VERSION} mloda-community-aggregation=={env:MLODA_REGISTRY_VERSION} mloda-community-rank=={env:MLODA_REGISTRY_VERSION} mloda-community-offset=={env:MLODA_REGISTRY_VERSION} mloda-community-window-aggregation=={env:MLODA_REGISTRY_VERSION} mloda-community-frame-aggregate=={env:MLODA_REGISTRY_VERSION} mloda-community-scalar-aggregate=={env:MLODA_REGISTRY_VERSION} mloda-community-scalar-arithmetic=={env:MLODA_REGISTRY_VERSION} mloda-community-point-arithmetic=={env:MLODA_REGISTRY_VERSION} mloda-community-datetime=={env:MLODA_REGISTRY_VERSION} mloda-community-string=={env:MLODA_REGISTRY_VERSION} mloda-community-binning=={env:MLODA_REGISTRY_VERSION} mloda-community-percentile=={env:MLODA_REGISTRY_VERSION} mloda-community-time-bucketization=={env:MLODA_REGISTRY_VERSION} mloda-community-ffill=={env:MLODA_REGISTRY_VERSION} mloda-community-ema=={env:MLODA_REGISTRY_VERSION} mloda-community-sessionization=={env:MLODA_REGISTRY_VERSION} mloda-community-resample=={env:MLODA_REGISTRY_VERSION}'
+    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify uv pip install $(python scripts/published_packages.py --pin {env:MLODA_REGISTRY_VERSION})'
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.registry import discover, search; print(\"mloda.registry OK\")"'
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.testing import FeatureGroupTestBase; print(\"mloda.testing OK\")"'
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.community.feature_groups.example import CommunityExampleFeatureGroup; print(\"mloda.community.example OK\")"'
@@ -196,13 +199,15 @@ description = CVE scanning of published packages
 # Needs deps and skip_install, which the lock runner ignores.
 runner = uv-venv-runner
 skip_install = true
+# tomli: nothing else here provides it, and Python 3.10 has no tomllib.
 deps =
     pip-audit
+    tomli
 allowlist_externals = sh, mkdir, uv
 commands =
     mkdir -p security-reports
-    sh -c "uv pip uninstall mloda-registry mloda-testing mloda-community mloda-enterprise mloda-community-example mloda-community-example-a mloda-community-data-operations mloda-community-aggregation mloda-community-rank mloda-community-offset mloda-community-window-aggregation mloda-community-frame-aggregate mloda-community-scalar-aggregate mloda-community-scalar-arithmetic mloda-community-point-arithmetic mloda-community-datetime mloda-community-string mloda-community-binning mloda-community-percentile mloda-community-time-bucketization mloda-community-ffill mloda-community-ema mloda-community-sessionization mloda-community-resample 2>/dev/null || true"
-    uv pip install mloda-registry=={env:MLODA_REGISTRY_VERSION} mloda-testing=={env:MLODA_REGISTRY_VERSION} mloda-community=={env:MLODA_REGISTRY_VERSION} mloda-enterprise=={env:MLODA_REGISTRY_VERSION} mloda-community-example=={env:MLODA_REGISTRY_VERSION} mloda-community-example-a=={env:MLODA_REGISTRY_VERSION} mloda-community-data-operations=={env:MLODA_REGISTRY_VERSION} mloda-community-aggregation=={env:MLODA_REGISTRY_VERSION} mloda-community-rank=={env:MLODA_REGISTRY_VERSION} mloda-community-offset=={env:MLODA_REGISTRY_VERSION} mloda-community-window-aggregation=={env:MLODA_REGISTRY_VERSION} mloda-community-frame-aggregate=={env:MLODA_REGISTRY_VERSION} mloda-community-scalar-aggregate=={env:MLODA_REGISTRY_VERSION} mloda-community-scalar-arithmetic=={env:MLODA_REGISTRY_VERSION} mloda-community-point-arithmetic=={env:MLODA_REGISTRY_VERSION} mloda-community-datetime=={env:MLODA_REGISTRY_VERSION} mloda-community-string=={env:MLODA_REGISTRY_VERSION} mloda-community-binning=={env:MLODA_REGISTRY_VERSION} mloda-community-percentile=={env:MLODA_REGISTRY_VERSION} mloda-community-time-bucketization=={env:MLODA_REGISTRY_VERSION} mloda-community-ffill=={env:MLODA_REGISTRY_VERSION} mloda-community-ema=={env:MLODA_REGISTRY_VERSION} mloda-community-sessionization=={env:MLODA_REGISTRY_VERSION} mloda-community-resample=={env:MLODA_REGISTRY_VERSION}
+    sh -c "uv pip uninstall $(python scripts/published_packages.py) 2>/dev/null || true"
+    sh -c 'uv pip install $(python scripts/published_packages.py --pin {env:MLODA_REGISTRY_VERSION})'
     sh -c "pip-audit --desc --format=json --output=security-reports/pip-audit.json || pip-audit --desc"
     sh -c "echo '=== CVE Scan Complete ==='"
     sh -c "echo 'Report: security-reports/pip-audit.json'"


### PR DESCRIPTION
Closes #345.

`mloda-community-time-bucketization`, `-ffill`, `-ema`, `-sessionization` and `-resample` were declared in `config/packages.toml` but missing from the release workflow's build array, so they never reached PyPI (all five 404 today, while `mloda-community-percentile` from the same family returns 200). That makes `pip install mloda-community-data-operations[all]` unresolvable and `tox -e verify-published` unpassable.

The released set was four hand-maintained copies plus a regex that parsed the build array out of the workflow. It now lives once.

## Single source

`published = true` per package in `config/packages.toml`. Every consumer derives from it:

- `scripts/published_packages.py` prints the set, plain or `--pin`ned to a version
- `.github/workflows/release.yaml` fills its build array from that command
- the `verify-published` and `security` tox envs build their install lists from it
- the generator expands a `{published_children}` placeholder into the data-operations `[all]` extra
- `tests/test_end2end/test_py_typed_markers.py` reads the flag instead of regexing the workflow

`tests/test_end2end/test_published_set_single_source.py` asserts no second copy survives: the build step names no distribution itself, neither tox env re-types a list (pinned or not), and every published distribution has an import check in `verify-published`.

## From review

Two independent deep reviews ran against the first commit. Both found the same real defect: deriving the setuptools exclusions from the expanded extra tied wheel *contents* to the release set, so unflagging a nested package would have absorbed its modules into the base wheel while it still existed on PyPI. Exclusions now come from the configured layout instead, with the bundle packages the deliberate exception.

Also fixed: the build array is status-checked before it is split (a process substitution hides the producer's exit code, so a partial list would have shipped a partial release); `twine upload` gets `--skip-existing`, since this release introduces five brand-new project names in one non-idempotent upload; `published` counts only as a boolean; `--pin` rejects an empty version instead of emitting bare `name==` specifiers.

## Notes

- The five names are new on PyPI. `PYPI_API_TOKEN` must be able to create projects for the next release, and `tox -e verify-published` stays red for them until that release runs. Both are now documented.
- `mloda-community-example`'s `[all]` extra deliberately keeps the unpublished `mloda-community-example-b` (unpinned extras resolve at its last published version); a test pins that exception.

## Verification

`tox` green (4772 passed, 210 skipped; ruff format, ruff check, mypy --strict, bandit), plus `tox -e check-generated` and `scripts/lint_docs.py`. The generated `pyproject.toml` files are byte-identical apart from the data-operations `[all]` extra, which now emits in config order.