### PR TITLE
fix(packaging): correct internal floors, verify floor and typed installs

### DIFF
--- a/.github/workflows/verify-published.yaml
+++ b/.github/workflows/verify-published.yaml
@@ -53,3 +53,15 @@ jobs:
         MLODA_REGISTRY_VERSION: ${{ steps.get_version.outputs.version }}
       run: tox -e verify-extras
       timeout-minutes: 10
+
+    - name: Verify floors install
+      env:
+        MLODA_REGISTRY_VERSION: ${{ steps.get_version.outputs.version }}
+      run: tox -e verify-floor-installs
+      timeout-minutes: 10
+
+    - name: Verify typed leaf install
+      env:
+        MLODA_REGISTRY_VERSION: ${{ steps.get_version.outputs.version }}
+      run: tox -e verify-typed-install
+      timeout-minutes: 10

--- a/config/packages.toml
+++ b/config/packages.toml
@@ -53,14 +53,15 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-example-a]
 description = "Example A FeatureGroup extending community example base"
-dependencies = ["mloda-community-example>=0.2.0"]
+# Floor 0.2.6: 0.2.0 through 0.2.3 never reached PyPI, and 0.2.4/0.2.5 lack the base module the variants import.
+dependencies = ["mloda-community-example>=0.2.6"]
 path = "mloda/community/feature_groups/example/example_a"
 published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-example-b]
 description = "Example B FeatureGroup extending community example base"
-dependencies = ["mloda-community-example>=0.2.0"]
+dependencies = ["mloda-community-example>=0.2.6"]
 path = "mloda/community/feature_groups/example/example_b"
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -89,6 +90,7 @@ path = "mloda/enterprise/extenders/example"
 entry_point_groups = ["mloda.extenders"]
 
 # --- Data Operations ---
+# Leaf floors are 0.4.0, the first release shipping the shared guard helpers; policy in docs/packaging.md.
 
 [packages.mloda-community-data-operations]
 description = "Shared base classes for data operation feature groups"
@@ -100,7 +102,7 @@ py_typed = true
 
 [packages.mloda-community-aggregation]
 description = "Aggregation feature group (reduce, partition_by, one row per group)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/aggregation"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -108,7 +110,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-rank]
 description = "Rank feature group (row_number, rank, dense_rank, percent_rank, ntile, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/rank"
 published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
@@ -116,7 +118,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-offset]
 description = "Offset feature group (lag, lead, diff, pct_change, first_value, last_value, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/offset"
 published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
@@ -124,7 +126,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-window-aggregation]
 description = "Window aggregation feature group (broadcast, partition_by, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -132,7 +134,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-frame-aggregate]
 description = "Frame aggregate feature group (rolling, cumulative, expanding, time window, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate"
 published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas>=2.2"], all = ["polars", "pandas>=2.2", "duckdb"] }
@@ -140,7 +142,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-scalar-aggregate]
 description = "Scalar aggregate feature group (single-column global aggregate broadcast)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -148,8 +150,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-scalar-arithmetic]
 description = "Scalar arithmetic feature group (element-wise column op constant: add, subtract, multiply, divide)"
-# Floor 0.3.3: first data-operations release shipping the data_operations.row_preserving.arithmetic package.
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -157,8 +158,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-point-arithmetic]
 description = "Point arithmetic feature group (element-wise two-column op: add, subtract, multiply, divide; PyArrow-reference null/IEEE-754 semantics on divide-by-zero; SQLite returns NULL)"
-# Floor 0.3.3: first data-operations release shipping the data_operations.row_preserving.arithmetic package.
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -166,21 +166,21 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-datetime]
 description = "Datetime extraction feature group (element-wise, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/datetime"
 published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-string]
 description = "String operation feature group (element-wise, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/string"
 published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-binning]
 description = "Binning feature group (equal-width, quantile, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/binning"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -188,7 +188,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-percentile]
 description = "Percentile feature group (PERCENTILE_CONT, partition_by, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/percentile"
 published = true
 optional_dependencies = { duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
@@ -196,7 +196,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-time-bucketization]
 description = "Time bucketization feature group (floor, ceil, round a timestamp to a bucket interval, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/time_bucketization"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -204,7 +204,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-ffill]
 description = "Forward-fill feature group (ffill a value column across time gaps, per partition, ordered by time, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ffill"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -212,7 +212,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-ema]
 description = "EMA feature group (exponential moving average, adjust=False, null-skipping recurrence, per partition, row-preserving; pandas/polars native, pyarrow/duckdb/sqlite reject)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ema"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -220,7 +220,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-sessionization]
 description = "Sessionization feature group (gap-threshold session id on an ordered timestamp, per partition, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/sessionization"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -228,7 +228,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-resample]
 description = "Resample feature group (collapse events onto a regular time grid: floor to bucket, group, aggregate; one row per non-empty bucket, row-changing)"
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 path = "mloda/community/feature_groups/data_operations/row_changing/resample"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -67,6 +67,19 @@ optional_dependencies = { dev = ["mloda-testing", "pytest>=9.0.3"] }
 
 A marker declares its whole subtree typed, including third-party distributions installed into it: on a namespace portion (`mloda/community`, `mloda/enterprise`) that is the entire namespace, on a shared base package (`mloda/community/feature_groups/data_operations`, `mloda/community/feature_groups/example`) it is everything published from below that base. mypy returns at the first `py.typed` on the module path, so those leaf packages need no flag of their own. The leaf's typing then depends on the marker-shipping base being installed, so its dependency floor has to be at or above the release that first shipped the marker. Raise that floor only in a follow-up change, after the marker-bearing release is published: a workspace member cannot require a sibling version above the workspace's own version in `config/shared.toml`, so bumping it in the same change makes `uv sync --all-extras` unsatisfiable.
 
+### Cross-package dependency floors
+
+The floor of an internal dependency is the oldest published release containing every
+symbol the depending package imports from it. A floor can never exceed
+`[project].version` in `config/shared.toml`, because a workspace member cannot require
+a sibling above the workspace version; a package that starts importing a
+not-yet-released symbol therefore keeps the current cap, and the floor moves in a
+follow-up after that release ships.
+
+`tox -e verify-floor-installs` (weekly workflow) installs each pair at
+`dependency==floor` plus `package==released version` and goes red until the follow-up
+lands; it also rejects floors naming versions that never reached PyPI.
+
 **Generator infers:**
 
 - `license` from path (`mloda/enterprise/*` → proprietary, else default)

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -77,7 +77,8 @@ not-yet-released symbol therefore keeps the current cap, and the floor moves in 
 follow-up after that release ships.
 
 `tox -e verify-floor-installs` (weekly workflow) installs each pair at
-`dependency==floor` plus `package==released version` and goes red until the follow-up
+`dependency==floor` plus `package==released version`, imports the package's import
+surface (the package root plus its base module), and goes red until the follow-up
 lands; it also rejects floors naming versions that never reached PyPI.
 
 **Generator infers:**

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,11 +37,15 @@ It sets `MLODA_REGISTRY_VERSION` and runs five tox envs:
 | `verify-published` | The released set installs together and imports |
 | `verify-published-independent` | Each package installs and imports on its own |
 | `verify-extras` | The `[all]` extras resolve and pull in their variants |
-| `verify-floor-installs` | Each package imports with its internal dependency pinned to the declared floor |
+| `verify-floor-installs` | Each package's import surface loads with its internal dependency pinned to the declared floor |
 | `verify-typed-install` | A standalone leaf install is typed under mypy --strict |
 
 `verify-typed-install` stays red until the release that first ships the
-data-operations `py.typed` marker.
+data-operations `py.typed` marker. `verify-floor-installs` is red for any package
+flagged published whose first release has not shipped yet (currently the five
+data-operations leaves first shipping with the next release), the same
+fails-until-release pattern `verify-published` has; distinct from the follow-up
+floor-bump red described in [packaging.md](packaging.md#cross-package-dependency-floors).
 
 ## Published packages
 
@@ -53,7 +57,7 @@ The released set is the `published = true` flag in `config/packages.toml`.
 the four bundles and `mloda-community-example`, not the set as a whole.
 
 Flagging a package does not publish it: it ships with the next release run, and
-`tox -e verify-published` fails for it until then.
+`tox -e verify-published` and `tox -e verify-floor-installs` fail for it until then.
 
 Not every package ships standalone. Most demo and example packages reach users inside the
 `mloda-community` / `mloda-enterprise` bundle wheels instead; `mloda-community-example`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -30,13 +30,18 @@ Verification is not part of the release. It runs in a separate workflow,
 Monday cron plus manual dispatch, so a fresh release stays unverified until the next
 run. To check a release immediately, dispatch that workflow.
 
-It sets `MLODA_REGISTRY_VERSION` and runs three tox envs:
+It sets `MLODA_REGISTRY_VERSION` and runs five tox envs:
 
 | Env | Checks |
 |-----|--------|
 | `verify-published` | The released set installs together and imports |
 | `verify-published-independent` | Each package installs and imports on its own |
 | `verify-extras` | The `[all]` extras resolve and pull in their variants |
+| `verify-floor-installs` | Each package imports with its internal dependency pinned to the declared floor |
+| `verify-typed-install` | A standalone leaf install is typed under mypy --strict |
+
+`verify-typed-install` stays red until the release that first ships the
+data-operations `py.typed` marker.
 
 ## Published packages
 

--- a/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Aggregation feature group (reduce, partition_by, one row per group)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Resample feature group (collapse events onto a regular time grid: floor to bucket, group, aggregate; one row per non-empty bucket, row-changing)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Binning feature group (equal-width, quantile, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Datetime extraction feature group (element-wise, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "EMA feature group (exponential moving average, adjust=False, null-skipping recurrence, per partition, row-preserving; pandas/polars native, pyarrow/duckdb/sqlite reject)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Forward-fill feature group (ffill a value column across time gaps, per partition, ordered by time, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Frame aggregate feature group (rolling, cumulative, expanding, time window, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Offset feature group (lag, lead, diff, pct_change, first_value, last_value, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Percentile feature group (PERCENTILE_CONT, partition_by, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Point arithmetic feature group (element-wise two-column op: add, subtract, multiply, divide; PyArrow-reference null/IEEE-754 semantics on divide-by-zero; SQLite returns NULL)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Rank feature group (row_number, rank, dense_rank, percent_rank, ntile, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Scalar aggregate feature group (single-column global aggregate broadcast)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Scalar arithmetic feature group (element-wise column op constant: add, subtract, multiply, divide)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Sessionization feature group (gap-threshold session id on an ordered timestamp, per partition, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Time bucketization feature group (floor, ceil, round a timestamp to a bucket interval, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Window aggregation feature group (broadcast, partition_by, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/string/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/string/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "String operation feature group (element-wise, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.3.3"]
+dependencies = ["mloda-community-data-operations>=0.4.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/example/example_a/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_a/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Example A FeatureGroup extending community example base"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-example>=0.2.0"]
+dependencies = ["mloda-community-example>=0.2.6"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/example/example_b/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 description = "Example B FeatureGroup extending community example base"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-example>=0.2.0"]
+dependencies = ["mloda-community-example>=0.2.6"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/scripts/verify_floor_installs.py
+++ b/scripts/verify_floor_installs.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Install each published package at its released version with its in-repo dependency pinned to the declared floor.
+
+Run: python scripts/verify_floor_installs.py <version>
+Exit code: 1 if any floored pair fails to install or import, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess  # nosec
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The distribution name a PEP 508 dependency string starts with; "{core_dependency}" starts with none.
+DEP_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+# Only the lower bound matters: ">=0.4.0" and " >= 0.4.0, <1" both floor at 0.4.0.
+FLOOR_RE = re.compile(r">=\s*([^\s,;]+)")
+
+
+class FloorPair(NamedTuple):
+    """One published package with the in-repo dependency floor it declares."""
+
+    package: str
+    dependency: str
+    floor: str
+    module: str
+
+
+def internal_floor_pairs(packages: dict[str, dict[str, Any]]) -> list[FloorPair]:
+    """Pairs of every published package whose dependency names another key of the packages table."""
+    pairs: list[FloorPair] = []
+    for pkg_name, pkg_config in packages.items():
+        if pkg_config.get("published") is not True:
+            continue
+        for dependency in pkg_config.get("dependencies", []):
+            name_match = DEP_NAME_RE.match(dependency)
+            if name_match is None or name_match.group(1) not in packages:
+                continue
+            floor_match = FLOOR_RE.search(dependency)
+            if floor_match is None:
+                raise ValueError(f"{pkg_name}: in-repo dependency {dependency!r} declares no '>=' floor")
+            module = str(pkg_config["path"]).replace("/", ".")
+            pairs.append(FloorPair(pkg_name, name_match.group(1), floor_match.group(1), module))
+    return pairs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify each package imports against its declared internal floors")
+    parser.add_argument("version", nargs="?", default="", help="Released version to install every package at")
+    args = parser.parse_args()
+
+    # tox renders an empty argument when MLODA_REGISTRY_VERSION is unset.
+    if not args.version.strip():
+        parser.error("version must not be empty (is MLODA_REGISTRY_VERSION set?)")
+
+    # The reused published_packages helper resolves the config relative to cwd.
+    os.chdir(REPO_ROOT)
+    from published_packages import load_packages_config
+    from verify_build_floor import venv_python
+
+    pairs = internal_floor_pairs(load_packages_config())
+
+    # An empty set would silently verify nothing.
+    if not pairs:
+        print("❌ config/packages.toml declares no in-repo dependency floors")
+        return 1
+
+    errors: list[str] = []
+    for pair in pairs:
+        print(f"\nInstalling {pair.package}=={args.version} with {pair.dependency}=={pair.floor}...")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv = Path(tmpdir) / "venv"
+            commands = [
+                ["uv", "venv", "--python", sys.executable, str(venv)],
+                ["uv", "pip", "install", "--python", str(venv_python(venv))]
+                + [f"{pair.dependency}=={pair.floor}", f"{pair.package}=={args.version}"],
+                [str(venv_python(venv)), "-c", f"import {pair.module}"],
+            ]
+            for command in commands:
+                # cwd is the temp dir, so the checkout cannot shadow the installed packages.
+                result = subprocess.run(command, capture_output=True, text=True, cwd=tmpdir)  # nosec
+                if result.returncode != 0:
+                    errors.append(
+                        f"{pair.package} ({pair.dependency}=={pair.floor}): "
+                        f"{' '.join(command)} failed:\n{result.stderr[-500:]}"
+                    )
+                    break
+            else:
+                print(f"  ✓ import {pair.module}")
+
+    if errors:
+        print("\n❌ Errors:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"\n✅ every declared internal floor installs and imports at {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_floor_installs.py
+++ b/scripts/verify_floor_installs.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Install each published package at its released version with its in-repo dependency pinned to the declared floor.
+"""Install each published package with its in-repo dependency pinned to the declared floor, probing its import surface.
+
+The import surface is the dotted package root plus its base module when the checkout ships a base.py.
 
 Run: python scripts/verify_floor_installs.py <version>
-Exit code: 1 if any floored pair fails to install or import, 0 otherwise.
+Exit code: 1 if any floored pair fails to install or its import surface fails to load, 0 otherwise.
 """
 
 from __future__ import annotations
@@ -31,29 +33,52 @@ class FloorPair(NamedTuple):
     package: str
     dependency: str
     floor: str
-    module: str
+    modules: tuple[str, ...]
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 normal form: lowercase, runs of '-', '_', '.' collapsed to '-'."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _import_modules(path: str) -> tuple[str, ...]:
+    """The dotted package root, plus its base module when <path>/base.py exists in the checkout."""
+    root = path.replace("/", ".")
+    # Most leaf __init__.py files are empty and the cross-package imports live in the leaf's base
+    # module, so importing only the root is vacuous. Resolve against the checkout, never the cwd.
+    if (REPO_ROOT / path / "base.py").exists():
+        return (root, f"{root}.base")
+    return (root,)
 
 
 def internal_floor_pairs(packages: dict[str, dict[str, Any]]) -> list[FloorPair]:
     """Pairs of every published package whose dependency names another key of the packages table."""
+    canonical = {_normalize(name): name for name in packages}
     pairs: list[FloorPair] = []
     for pkg_name, pkg_config in packages.items():
         if pkg_config.get("published") is not True:
             continue
         for dependency in pkg_config.get("dependencies", []):
-            name_match = DEP_NAME_RE.match(dependency)
-            if name_match is None or name_match.group(1) not in packages:
+            # The '>=' inside a PEP 508 environment marker is not a version floor.
+            requirement = dependency.split(";", 1)[0]
+            name_match = DEP_NAME_RE.match(requirement)
+            if name_match is None:
                 continue
-            floor_match = FLOOR_RE.search(dependency)
+            dep_name = canonical.get(_normalize(name_match.group(1)))
+            if dep_name is None:
+                continue
+            floor_match = FLOOR_RE.search(requirement)
             if floor_match is None:
                 raise ValueError(f"{pkg_name}: in-repo dependency {dependency!r} declares no '>=' floor")
-            module = str(pkg_config["path"]).replace("/", ".")
-            pairs.append(FloorPair(pkg_name, name_match.group(1), floor_match.group(1), module))
+            modules = _import_modules(str(pkg_config["path"]))
+            pairs.append(FloorPair(pkg_name, dep_name, floor_match.group(1), modules))
     return pairs
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Verify each package imports against its declared internal floors")
+    parser = argparse.ArgumentParser(
+        description="Verify each package's import surface loads against its declared internal floors"
+    )
     parser.add_argument("version", nargs="?", default="", help="Released version to install every package at")
     args = parser.parse_args()
 
@@ -78,11 +103,13 @@ def main() -> int:
         print(f"\nInstalling {pair.package}=={args.version} with {pair.dependency}=={pair.floor}...")
         with tempfile.TemporaryDirectory() as tmpdir:
             venv = Path(tmpdir) / "venv"
+            # One import statement per probe: the package root plus its base module.
+            imports = "\n".join(f"import {module}" for module in pair.modules)
             commands = [
                 ["uv", "venv", "--python", sys.executable, str(venv)],
                 ["uv", "pip", "install", "--python", str(venv_python(venv))]
                 + [f"{pair.dependency}=={pair.floor}", f"{pair.package}=={args.version}"],
-                [str(venv_python(venv)), "-c", f"import {pair.module}"],
+                [str(venv_python(venv)), "-c", imports],
             ]
             for command in commands:
                 # cwd is the temp dir, so the checkout cannot shadow the installed packages.
@@ -94,7 +121,7 @@ def main() -> int:
                     )
                     break
             else:
-                print(f"  ✓ import {pair.module}")
+                print(f"  ✓ import surface loads: {', '.join(pair.modules)}")
 
     if errors:
         print("\n❌ Errors:")
@@ -102,7 +129,7 @@ def main() -> int:
             print(f"  - {error}")
         return 1
 
-    print(f"\n✅ every declared internal floor installs and imports at {args.version}")
+    print(f"\n✅ every internal floor installs and its import surface (root plus base module) loads at {args.version}")
     return 0
 
 

--- a/scripts/verify_typed_install.py
+++ b/scripts/verify_typed_install.py
@@ -17,13 +17,13 @@ from pathlib import Path
 # The leaf under probe plus the base distribution that ships the py.typed marker.
 PROBE_DISTRIBUTIONS = ("mloda-community-aggregation", "mloda-community-data-operations")
 
-# Line 4 reveals the attribute's type; line 5 provokes [call-arg] and [assignment] on a typed install.
+# Line 4 reveals the leaf-defined classmethod; line 5 provokes [arg-type] and [assignment] on a typed install.
 PROBE_SOURCE = '''\
 """Probe: a typed install reveals a concrete signature and yields both provoked errors."""
 from mloda.community.feature_groups.data_operations.aggregation.pyarrow_aggregation import PyArrowAggregation
 
-reveal_type(PyArrowAggregation.supported_subtypes)
-BAD: int = PyArrowAggregation.supported_subtypes(secondary=123)
+reveal_type(PyArrowAggregation.supported_op_subtypes)
+BAD: int = PyArrowAggregation.supported_op_subtypes(secondary=123)
 '''
 
 
@@ -34,8 +34,8 @@ def mypy_output_problems(output: str) -> list[str]:
         problems.append("the probe import resolved to Any: 'Revealed type is \"Any\"' (py.typed marker missing?)")
     elif "Revealed type is" not in output:
         problems.append("no 'Revealed type is' line: the probe never ran")
-    if 'Unexpected keyword argument "secondary"' not in output:
-        problems.append("missing the provoked 'Unexpected keyword argument \"secondary\"' [call-arg] error")
+    if "[arg-type]" not in output:
+        problems.append("missing the provoked '[arg-type]' error on secondary=123 (int vs str | None)")
     if "[assignment]" not in output:
         problems.append("missing the provoked '[assignment]' error")
     return problems

--- a/scripts/verify_typed_install.py
+++ b/scripts/verify_typed_install.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Prove a standalone leaf install is typed: run mypy --strict over a probe against the released wheels.
+
+Run: python scripts/verify_typed_install.py <version>
+Exit code: 1 if the captured mypy output does not prove the install typed, 0 otherwise. Only the output
+counts: against an install missing py.typed, mypy sees Any everywhere and still exits 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess  # nosec
+import sys
+import tempfile
+from pathlib import Path
+
+# The leaf under probe plus the base distribution that ships the py.typed marker.
+PROBE_DISTRIBUTIONS = ("mloda-community-aggregation", "mloda-community-data-operations")
+
+# Line 4 reveals the attribute's type; line 5 provokes [call-arg] and [assignment] on a typed install.
+PROBE_SOURCE = '''\
+"""Probe: a typed install reveals a concrete signature and yields both provoked errors."""
+from mloda.community.feature_groups.data_operations.aggregation.pyarrow_aggregation import PyArrowAggregation
+
+reveal_type(PyArrowAggregation.supported_subtypes)
+BAD: int = PyArrowAggregation.supported_subtypes(secondary=123)
+'''
+
+
+def mypy_output_problems(output: str) -> list[str]:
+    """Reasons the captured mypy output does not prove the install typed; empty means proven."""
+    problems: list[str] = []
+    if 'Revealed type is "Any"' in output:
+        problems.append("the probe import resolved to Any: 'Revealed type is \"Any\"' (py.typed marker missing?)")
+    elif "Revealed type is" not in output:
+        problems.append("no 'Revealed type is' line: the probe never ran")
+    if 'Unexpected keyword argument "secondary"' not in output:
+        problems.append("missing the provoked 'Unexpected keyword argument \"secondary\"' [call-arg] error")
+    if "[assignment]" not in output:
+        problems.append("missing the provoked '[assignment]' error")
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify a standalone leaf install is typed under mypy --strict")
+    parser.add_argument("version", nargs="?", default="", help="Released version to install the probe pair at")
+    args = parser.parse_args()
+
+    # tox renders an empty argument when MLODA_REGISTRY_VERSION is unset.
+    if not args.version.strip():
+        parser.error("version must not be empty (is MLODA_REGISTRY_VERSION set?)")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        venv = Path(tmpdir) / "venv"
+        # Not verify_build_floor.venv_python: importing it would drag a toml parser into this env.
+        python = venv / "bin" / "python"
+        pins = [f"{name}=={args.version}" for name in PROBE_DISTRIBUTIONS]
+        commands = [
+            ["uv", "venv", "--python", sys.executable, str(venv)],
+            ["uv", "pip", "install", "--python", str(python), *pins, "mypy"],
+        ]
+        for command in commands:
+            # cwd is the temp dir, so the workspace [tool.uv] config cannot filter the install.
+            result = subprocess.run(command, capture_output=True, text=True, cwd=tmpdir)  # nosec
+            if result.returncode != 0:
+                print(f"❌ {' '.join(command)} failed:\n{result.stderr[-500:]}")
+                return 1
+
+        (Path(tmpdir) / "probe.py").write_text(PROBE_SOURCE)
+        # cwd is the temp dir, so the checkout cannot shadow the installed packages.
+        result = subprocess.run(  # nosec
+            [str(python), "-m", "mypy", "--strict", "--ignore-missing-imports", "probe.py"],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+        )
+
+    output = result.stdout + result.stderr
+    problems = mypy_output_problems(output)
+    if problems:
+        print(output)
+        print("❌ Problems:")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+
+    print(f"✅ {PROBE_DISTRIBUTIONS[0]}=={args.version} installs typed under mypy --strict")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_end2end/test_verify_floor_installs.py
+++ b/tests/test_end2end/test_verify_floor_installs.py
@@ -26,12 +26,20 @@ _PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
 # First data-operations release shipping the shared guard helpers the leaves import; 0.3.3 never shipped.
 _DATA_OPERATIONS_FIRST_RELEASE = (0, 4, 0)
 
-# First published mloda-community-example release; 0.2.0 never reached an index.
-_EXAMPLE_FIRST_RELEASE = (0, 2, 4)
+# Oldest usable mloda-community-example release: 0.2.0 through 0.2.3 never reached PyPI, and
+# 0.2.4/0.2.5 lack the base module the variants import.
+_EXAMPLE_FIRST_RELEASE = (0, 2, 6)
 
 _DEP = "mloda-community-data-operations"
 _LEAF = "mloda-community-aggregation"
+_LEAF_PATH = "mloda/community/feature_groups/data_operations/aggregation"
 _LEAF_MODULE = "mloda.community.feature_groups.data_operations.aggregation"
+# The dotted path is always the first probe; aggregation ships base.py, so its base module probes too.
+_LEAF_MODULES = (_LEAF_MODULE, f"{_LEAF_MODULE}.base")
+
+# A leaf whose checkout directory has no base.py, so the dotted path is its only probe.
+_NO_BASE_PATH = "mloda/community/feature_groups/example/example_a"
+_NO_BASE_MODULE = "mloda.community.feature_groups.example.example_a"
 
 
 def _internal_floor_pairs() -> Callable[[dict[str, dict[str, Any]]], list[Any]]:
@@ -54,13 +62,13 @@ def _version_tuple(version: str) -> tuple[int, ...]:
 
 
 def _synthetic_packages(
-    leaf_dependency: str = f"{_DEP}>=0.4.0", *, published: bool | None = True
+    leaf_dependency: str = f"{_DEP}>=0.4.0", *, published: bool | None = True, path: str = _LEAF_PATH
 ) -> dict[str, dict[str, Any]]:
     """A minimal packages table shaped like config/packages.toml; ``published=None`` omits the flag."""
     leaf: dict[str, Any] = {
         "description": "leaf",
         "dependencies": [leaf_dependency],
-        "path": "mloda/community/feature_groups/data_operations/aggregation",
+        "path": path,
     }
     if published is not None:
         leaf["published"] = published
@@ -81,7 +89,8 @@ def _real_pairs() -> list[Any]:
 
 
 def test_a_published_leaf_yields_its_internal_floor_pair() -> None:
-    """The pair carries the leaf, the floored distribution, the floor, and the leaf's dotted module path."""
+    """The pair carries the leaf, the floored distribution, the floor, and the import probes: the dotted
+    path first, then its '.base' module because <path>/base.py exists in the checkout."""
     pairs = _internal_floor_pairs()(_synthetic_packages())
 
     assert len(pairs) == 1, f"expected exactly one pair, got {pairs!r}"
@@ -89,9 +98,32 @@ def test_a_published_leaf_yields_its_internal_floor_pair() -> None:
     assert pair.package == _LEAF, f"pair.package must be the depending distribution, got {pair.package!r}"
     assert pair.dependency == _DEP, f"pair.dependency must be the floored distribution, got {pair.dependency!r}"
     assert pair.floor == "0.4.0", f"pair.floor must be the '>=' bound, got {pair.floor!r}"
-    assert pair.module == _LEAF_MODULE, f"pair.module must derive from the path field, got {pair.module!r}"
-    assert tuple(pair) == (_LEAF, _DEP, "0.4.0", _LEAF_MODULE), (
-        "FloorPair must be a NamedTuple ordered (package, dependency, floor, module)"
+    assert pair.modules == _LEAF_MODULES, (
+        f"pair.modules must be the dotted path plus its base module, got {pair.modules!r}"
+    )
+    assert tuple(pair) == (_LEAF, _DEP, "0.4.0", _LEAF_MODULES), (
+        "FloorPair must be a NamedTuple ordered (package, dependency, floor, modules)"
+    )
+
+
+def test_a_leaf_without_a_base_module_probes_only_its_package_root() -> None:
+    """example_a ships no base.py, so the dotted package root is its only import probe."""
+    pairs = _internal_floor_pairs()(_synthetic_packages(path=_NO_BASE_PATH))
+
+    assert len(pairs) == 1, f"expected exactly one pair, got {pairs!r}"
+    assert pairs[0].modules == (_NO_BASE_MODULE,), (
+        f"a leaf without base.py must probe only its package root, got {pairs[0].modules!r}"
+    )
+
+
+def test_module_derivation_resolves_base_py_against_the_repo_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The base.py existence check must resolve against the checkout, not the process cwd."""
+    monkeypatch.chdir(tmp_path)
+    pairs = _internal_floor_pairs()(_synthetic_packages())
+    assert pairs[0].modules == _LEAF_MODULES, (
+        f"from cwd {tmp_path} the aggregation base.py went undetected, got {pairs[0].modules!r}"
     )
 
 
@@ -109,16 +141,40 @@ def test_an_external_dependency_yields_no_pair(dependency: str) -> None:
     assert pairs == [], f"{dependency!r} names no in-repo distribution, got pairs {pairs!r}"
 
 
-@pytest.mark.parametrize("dependency", [_DEP, f"{_DEP}==0.4.0"], ids=["bare", "exact-pin"])
+@pytest.mark.parametrize(
+    "dependency",
+    ["mloda_community_data_operations>=0.4.0", "MLODA-Community-Data-Operations>=0.4.0"],
+    ids=["underscores", "mixed-case"],
+)
+def test_a_variant_spelling_normalizes_to_the_canonical_table_key(dependency: str) -> None:
+    """PEP 503 treats case and runs of '-', '_', '.' as equal; a variant spelling must not silently
+    skip the floor check, and pair.dependency must be the canonical packages-table key."""
+    pairs = _internal_floor_pairs()(_synthetic_packages(dependency))
+    assert [(pair.dependency, pair.floor) for pair in pairs] == [(_DEP, "0.4.0")], (
+        f"{dependency!r} names {_DEP} under PEP 503 normalization, but produced pairs {pairs!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "dependency",
+    [_DEP, f"{_DEP}==0.4.0", f'{_DEP}; python_version>="3.11"'],
+    ids=["bare", "exact-pin", "marker-no-floor"],
+)
 def test_an_internal_dependency_without_a_floor_is_rejected(dependency: str) -> None:
-    """An in-repo dependency must declare a '>=' floor; anything else fails loudly, naming the package."""
+    """An in-repo dependency must declare a '>=' floor; anything else fails loudly, naming the package.
+    The '>=' inside a PEP 508 environment marker is not a version floor."""
     with pytest.raises(ValueError, match=_LEAF):
         _internal_floor_pairs()(_synthetic_packages(dependency))
 
 
-@pytest.mark.parametrize("dependency", [f"{_DEP} >= 0.4.0", f"{_DEP}>=0.4.0,<1"], ids=["whitespace", "upper-bound"])
+@pytest.mark.parametrize(
+    "dependency",
+    [f"{_DEP} >= 0.4.0", f"{_DEP}>=0.4.0,<1", f'{_DEP}>=0.4.0; python_version>="3.11"'],
+    ids=["whitespace", "upper-bound", "env-marker"],
+)
 def test_floor_extraction_tolerates_spec_variants(dependency: str) -> None:
-    """Whitespace around '>=' and a trailing spec after a comma are legitimate PEP 508 spellings."""
+    """Whitespace around '>=', a trailing spec after a comma, and an environment marker are legitimate
+    PEP 508 spellings; the marker part must never be scanned for '>='."""
     pairs = _internal_floor_pairs()(_synthetic_packages(dependency))
     assert [(pair.dependency, pair.floor) for pair in pairs] == [(_DEP, "0.4.0")], (
         f"parsing {dependency!r} produced {pairs!r}"
@@ -152,12 +208,27 @@ def test_data_operations_floors_point_at_a_released_version() -> None:
         )
 
 
-def test_example_a_floors_the_first_published_example_release() -> None:
-    """config/packages.toml says 0.2.0, but mloda-community-example first shipped at 0.2.4."""
+def test_real_data_operations_pairs_probe_the_leaf_base_module() -> None:
+    """base.py is where each data-operations leaf keeps its cross-package imports; importing only the
+    package root is vacuous because most leaf __init__.py files are empty."""
+    packages = _load_toml(_PACKAGES_CONFIG)["packages"]
+    pairs = [pair for pair in _real_pairs() if pair.dependency == _DEP]
+    assert pairs, f"expected published leaves flooring {_DEP} in config/packages.toml"
+    for pair in pairs:
+        root = str(packages[pair.package]["path"]).replace("/", ".")
+        assert f"{root}.base" in pair.modules, (
+            f"{pair.package}: modules {pair.modules!r} must include {root + '.base'!r}, the import "
+            f"surface the {_DEP} floor protects"
+        )
+
+
+def test_example_a_floors_the_oldest_usable_example_release() -> None:
+    """0.2.0 through 0.2.3 never reached PyPI, and 0.2.4/0.2.5 lack the base module the variants
+    import; 0.2.6 is the oldest usable mloda-community-example release."""
     pairs = [pair for pair in _real_pairs() if pair.package == "mloda-community-example-a"]
     assert pairs, "expected mloda-community-example-a to floor an in-repo distribution"
     for pair in pairs:
         assert _version_tuple(pair.floor) >= _EXAMPLE_FIRST_RELEASE, (
-            f"mloda-community-example-a: floors {pair.dependency} at {pair.floor}, which was never published; "
-            "the first published mloda-community-example release is 0.2.4"
+            f"mloda-community-example-a: floors {pair.dependency} at {pair.floor}; the oldest usable "
+            "mloda-community-example release is 0.2.6"
         )

--- a/tests/test_end2end/test_verify_floor_installs.py
+++ b/tests/test_end2end/test_verify_floor_installs.py
@@ -1,0 +1,163 @@
+"""Internal dependency floors in scripts/verify_floor_installs.py. Published leaves floor in-repo
+distributions; a floor naming a version that never shipped makes the floored install unresolvable,
+so every declared floor must be a released version at or below the workspace version."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+import pytest
+
+from tests.script_loader import load_script
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "verify_floor_installs.py"
+_SHARED_CONFIG = _REPO_ROOT / "config" / "shared.toml"
+_PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
+
+# First data-operations release shipping the shared guard helpers the leaves import; 0.3.3 never shipped.
+_DATA_OPERATIONS_FIRST_RELEASE = (0, 4, 0)
+
+# First published mloda-community-example release; 0.2.0 never reached an index.
+_EXAMPLE_FIRST_RELEASE = (0, 2, 4)
+
+_DEP = "mloda-community-data-operations"
+_LEAF = "mloda-community-aggregation"
+_LEAF_MODULE = "mloda.community.feature_groups.data_operations.aggregation"
+
+
+def _internal_floor_pairs() -> Callable[[dict[str, dict[str, Any]]], list[Any]]:
+    """The pair extractor scripts/verify_floor_installs.py must expose."""
+    assert _SCRIPT_PATH.exists(), f"{_SCRIPT_PATH} is missing; it is what proves the declared floors install"
+    module = load_script("verify_floor_installs", _SCRIPT_PATH)
+    pairs: Callable[[dict[str, dict[str, Any]]], list[Any]] | None = getattr(module, "internal_floor_pairs", None)
+    assert callable(pairs), "verify_floor_installs.internal_floor_pairs(packages) must be a callable"
+    return pairs
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Comparable form of a numeric release version."""
+    return tuple(int(part) for part in version.split("."))
+
+
+def _synthetic_packages(
+    leaf_dependency: str = f"{_DEP}>=0.4.0", *, published: bool | None = True
+) -> dict[str, dict[str, Any]]:
+    """A minimal packages table shaped like config/packages.toml; ``published=None`` omits the flag."""
+    leaf: dict[str, Any] = {
+        "description": "leaf",
+        "dependencies": [leaf_dependency],
+        "path": "mloda/community/feature_groups/data_operations/aggregation",
+    }
+    if published is not None:
+        leaf["published"] = published
+    return {
+        _DEP: {
+            "description": "base",
+            "dependencies": ["{core_dependency}"],
+            "path": "mloda/community/feature_groups/data_operations",
+            "published": True,
+        },
+        _LEAF: leaf,
+    }
+
+
+def _real_pairs() -> list[Any]:
+    """Pairs extracted from the real config, resolved against the repo root, not the cwd."""
+    return _internal_floor_pairs()(_load_toml(_PACKAGES_CONFIG)["packages"])
+
+
+def test_a_published_leaf_yields_its_internal_floor_pair() -> None:
+    """The pair carries the leaf, the floored distribution, the floor, and the leaf's dotted module path."""
+    pairs = _internal_floor_pairs()(_synthetic_packages())
+
+    assert len(pairs) == 1, f"expected exactly one pair, got {pairs!r}"
+    pair = pairs[0]
+    assert pair.package == _LEAF, f"pair.package must be the depending distribution, got {pair.package!r}"
+    assert pair.dependency == _DEP, f"pair.dependency must be the floored distribution, got {pair.dependency!r}"
+    assert pair.floor == "0.4.0", f"pair.floor must be the '>=' bound, got {pair.floor!r}"
+    assert pair.module == _LEAF_MODULE, f"pair.module must derive from the path field, got {pair.module!r}"
+    assert tuple(pair) == (_LEAF, _DEP, "0.4.0", _LEAF_MODULE), (
+        "FloorPair must be a NamedTuple ordered (package, dependency, floor, module)"
+    )
+
+
+@pytest.mark.parametrize("published", [None, False], ids=["flag-omitted", "flag-false"])
+def test_an_unpublished_leaf_yields_no_pair(published: bool | None) -> None:
+    """Unpublished packages ship only inside the bundle wheels, so their floors are never installed alone."""
+    pairs = _internal_floor_pairs()(_synthetic_packages(published=published))
+    assert pairs == [], f"unpublished {_LEAF} must yield no pairs, got {pairs!r}"
+
+
+@pytest.mark.parametrize("dependency", ["{core_dependency}", "mloda>=0.10.0,<0.11.0"])
+def test_an_external_dependency_yields_no_pair(dependency: str) -> None:
+    """Only names that are themselves keys of the packages table are in-repo floors."""
+    pairs = _internal_floor_pairs()(_synthetic_packages(dependency))
+    assert pairs == [], f"{dependency!r} names no in-repo distribution, got pairs {pairs!r}"
+
+
+@pytest.mark.parametrize("dependency", [_DEP, f"{_DEP}==0.4.0"], ids=["bare", "exact-pin"])
+def test_an_internal_dependency_without_a_floor_is_rejected(dependency: str) -> None:
+    """An in-repo dependency must declare a '>=' floor; anything else fails loudly, naming the package."""
+    with pytest.raises(ValueError, match=_LEAF):
+        _internal_floor_pairs()(_synthetic_packages(dependency))
+
+
+@pytest.mark.parametrize("dependency", [f"{_DEP} >= 0.4.0", f"{_DEP}>=0.4.0,<1"], ids=["whitespace", "upper-bound"])
+def test_floor_extraction_tolerates_spec_variants(dependency: str) -> None:
+    """Whitespace around '>=' and a trailing spec after a comma are legitimate PEP 508 spellings."""
+    pairs = _internal_floor_pairs()(_synthetic_packages(dependency))
+    assert [(pair.dependency, pair.floor) for pair in pairs] == [(_DEP, "0.4.0")], (
+        f"parsing {dependency!r} produced {pairs!r}"
+    )
+
+
+def test_real_floors_are_numeric_and_at_most_the_workspace_version() -> None:
+    """A floor above config/shared.toml [project].version names a release that cannot exist yet."""
+    workspace = _load_toml(_SHARED_CONFIG)["project"]["version"]
+    pairs = _real_pairs()
+    assert pairs, "expected config/packages.toml to declare at least one internal floor"
+    for pair in pairs:
+        parts = pair.floor.split(".")
+        assert len(parts) == 3 and all(part.isdigit() for part in parts), (
+            f"{pair.package}: floor {pair.floor!r} on {pair.dependency} is not three dot-separated integers"
+        )
+        assert _version_tuple(pair.floor) <= _version_tuple(workspace), (
+            f"{pair.package}: floors {pair.dependency} at {pair.floor}, above the workspace version {workspace}; "
+            "per docs/packaging.md that floor is undeclarable"
+        )
+
+
+def test_data_operations_floors_point_at_a_released_version() -> None:
+    """0.3.3 was never released; 0.4.0 first shipped the shared guard helpers the leaves import."""
+    pairs = [pair for pair in _real_pairs() if pair.dependency == _DEP]
+    assert pairs, f"expected published leaves flooring {_DEP} in config/packages.toml"
+    for pair in pairs:
+        assert _version_tuple(pair.floor) >= _DATA_OPERATIONS_FIRST_RELEASE, (
+            f"{pair.package}: floors {_DEP} at {pair.floor}, which was never released; the first release "
+            "shipping the shared guard helpers is 0.4.0, so an install at the floor could not import"
+        )
+
+
+def test_example_a_floors_the_first_published_example_release() -> None:
+    """config/packages.toml says 0.2.0, but mloda-community-example first shipped at 0.2.4."""
+    pairs = [pair for pair in _real_pairs() if pair.package == "mloda-community-example-a"]
+    assert pairs, "expected mloda-community-example-a to floor an in-repo distribution"
+    for pair in pairs:
+        assert _version_tuple(pair.floor) >= _EXAMPLE_FIRST_RELEASE, (
+            f"mloda-community-example-a: floors {pair.dependency} at {pair.floor}, which was never published; "
+            "the first published mloda-community-example release is 0.2.4"
+        )

--- a/tests/test_end2end/test_verify_typed_install.py
+++ b/tests/test_end2end/test_verify_typed_install.py
@@ -1,0 +1,119 @@
+"""Typed-install probe in scripts/verify_typed_install.py. Against an install missing py.typed, mypy
+sees the plugin as Any and exits 0 with 'Success: no issues found'; only judging the captured output
+distinguishes that silent success from a genuinely typed install."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from tests.script_loader import load_script
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "verify_typed_install.py"
+
+_PROBE_MODULE = "mloda.community.feature_groups.data_operations.aggregation.pyarrow_aggregation"
+
+# Lines a real mypy run over the probe produces against a typed install.
+_TYPED_REVEAL = 'probe.py:4: note: Revealed type is "def (compute_framework: Any =) -> frozenset[builtins.str]"'
+_CALL_ARG_ERROR = (
+    'probe.py:5: error: Unexpected keyword argument "secondary" for "supported_subtypes" '
+    'of "PyArrowAggregation"  [call-arg]'
+)
+_ASSIGNMENT_ERROR = (
+    'probe.py:5: error: Incompatible types in assignment (expression has type "frozenset[str]", '
+    'variable has type "int")  [assignment]'
+)
+
+_GOOD_OUTPUT = "\n".join(
+    [_TYPED_REVEAL, _CALL_ARG_ERROR, _ASSIGNMENT_ERROR, "Found 2 errors in 1 file (checked 1 source file)"]
+)
+
+# The silent-untyped case: mypy reveals bare Any, reports nothing, and exits 0.
+_UNTYPED_OUTPUT = "\n".join(['probe.py:4: note: Revealed type is "Any"', "Success: no issues found in 1 source file"])
+
+_NO_REVEAL_OUTPUT = "Success: no issues found in 1 source file"
+
+_MISSING_CALL_ARG_OUTPUT = "\n".join(
+    [_TYPED_REVEAL, _ASSIGNMENT_ERROR, "Found 1 error in 1 file (checked 1 source file)"]
+)
+
+_MISSING_ASSIGNMENT_OUTPUT = "\n".join(
+    [_TYPED_REVEAL, _CALL_ARG_ERROR, "Found 1 error in 1 file (checked 1 source file)"]
+)
+
+# Any as a parameter annotation inside the revealed signature, not the bare 'Revealed type is "Any"'.
+_ANY_IN_SIGNATURE_OUTPUT = "\n".join(
+    [
+        'probe.py:4: note: Revealed type is "def (compute_framework: Any) -> frozenset[str]"',
+        _CALL_ARG_ERROR,
+        _ASSIGNMENT_ERROR,
+        "Found 2 errors in 1 file (checked 1 source file)",
+    ]
+)
+
+
+def _load() -> ModuleType:
+    """Import scripts/verify_typed_install.py, the probe runner the typed-install gate uses."""
+    assert _SCRIPT_PATH.exists(), f"{_SCRIPT_PATH} is missing; it is what proves the published wheels install typed"
+    return load_script("verify_typed_install", _SCRIPT_PATH)
+
+
+def _probe_source() -> str:
+    """The PROBE_SOURCE constant verify_typed_install must expose."""
+    source = getattr(_load(), "PROBE_SOURCE", None)
+    assert isinstance(source, str), "verify_typed_install.PROBE_SOURCE must be a str constant"
+    return source
+
+
+def _mypy_output_problems() -> Callable[[str], list[str]]:
+    """The pure output judge verify_typed_install must expose."""
+    judge: Callable[[str], list[str]] | None = getattr(_load(), "mypy_output_problems", None)
+    assert callable(judge), "verify_typed_install.mypy_output_problems(output) must be a callable"
+    return judge
+
+
+def test_probe_source_imports_reveals_and_miscalls_the_plugin() -> None:
+    """The probe must import the installed class, reveal its type, and provoke two typed-only errors."""
+    source = _probe_source()
+    assert _PROBE_MODULE in source, f"PROBE_SOURCE must import from {_PROBE_MODULE}"
+    assert "PyArrowAggregation" in source, "PROBE_SOURCE must import PyArrowAggregation"
+    assert "reveal_type(" in source, "PROBE_SOURCE must reveal_type the supported_subtypes attribute"
+    assert "secondary=123" in source, "PROBE_SOURCE must call supported_subtypes(secondary=123) to provoke [call-arg]"
+
+
+def test_a_bare_any_reveal_is_a_problem() -> None:
+    """'Revealed type is "Any"' is exactly the silent-untyped case that still exits 0."""
+    problems = _mypy_output_problems()(_UNTYPED_OUTPUT)
+    assert problems, f"a bare Any reveal must be flagged, output:\n{_UNTYPED_OUTPUT}"
+    assert any("Any" in problem for problem in problems), f"the problem must mention Any, got {problems!r}"
+
+
+@pytest.mark.parametrize(
+    ("output", "missing"),
+    [
+        (_NO_REVEAL_OUTPUT, "a 'Revealed type is' line, so the probe never ran"),
+        (_MISSING_CALL_ARG_OUTPUT, "the expected 'Unexpected keyword argument \"secondary\"' error"),
+        (_MISSING_ASSIGNMENT_OUTPUT, "an '[assignment]' error"),
+    ],
+    ids=["no-reveal", "no-call-arg-error", "no-assignment-error"],
+)
+def test_an_incomplete_output_is_a_problem(output: str, missing: str) -> None:
+    """Each expected line proves one thing; with any of them missing the install is not proven typed."""
+    problems = _mypy_output_problems()(output)
+    assert problems, f"output missing {missing} must yield a problem, but judged clean:\n{output}"
+
+
+def test_a_fully_typed_output_yields_no_problems() -> None:
+    """A concrete reveal plus both provoked errors is the proof that the install is typed."""
+    problems = _mypy_output_problems()(_GOOD_OUTPUT)
+    assert problems == [], f"a fully typed output must judge clean, got {problems!r}"
+
+
+def test_any_inside_a_revealed_signature_is_not_flagged() -> None:
+    """Only the bare 'Revealed type is "Any"' is untyped; Any as a parameter annotation is legitimate."""
+    problems = _mypy_output_problems()(_ANY_IN_SIGNATURE_OUTPUT)
+    assert problems == [], f"'compute_framework: Any' inside a signature must not be flagged, got {problems!r}"

--- a/tests/test_end2end/test_verify_typed_install.py
+++ b/tests/test_end2end/test_verify_typed_install.py
@@ -4,9 +4,16 @@ distinguishes that silent success from a genuinely typed install."""
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
 
 import pytest
 
@@ -14,22 +21,31 @@ from tests.script_loader import load_script
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT_PATH = _REPO_ROOT / "scripts" / "verify_typed_install.py"
+_PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
 
+# The probe targets supported_op_subtypes, a symbol the leaf itself defines; supported_subtypes
+# comes from mloda core, so revealing it proves less about the leaf's own typing.
 _PROBE_MODULE = "mloda.community.feature_groups.data_operations.aggregation.pyarrow_aggregation"
+_PROBE_LEAF = "mloda-community-aggregation"
+_PROBE_BASE = "mloda-community-data-operations"
 
-# Lines a real mypy run over the probe produces against a typed install.
-_TYPED_REVEAL = 'probe.py:4: note: Revealed type is "def (compute_framework: Any =) -> frozenset[builtins.str]"'
-_CALL_ARG_ERROR = (
-    'probe.py:5: error: Unexpected keyword argument "secondary" for "supported_subtypes" '
-    'of "PyArrowAggregation"  [call-arg]'
+# Shaped like a real mypy run over the probe against a typed install (line 4 reveals, line 5 miscalls);
+# the Green agent replaces these with genuinely captured lines.
+_TYPED_REVEAL = (
+    "probe.py:4: note: Revealed type is "
+    '"def (secondary: Union[builtins.str, None] =) -> Union[frozenset[builtins.str], None]"'
+)
+_ARG_TYPE_ERROR = (
+    'probe.py:5: error: Argument "secondary" to "supported_op_subtypes" of "PyArrowAggregation" '
+    'has incompatible type "int"; expected "str | None"  [arg-type]'
 )
 _ASSIGNMENT_ERROR = (
-    'probe.py:5: error: Incompatible types in assignment (expression has type "frozenset[str]", '
+    'probe.py:5: error: Incompatible types in assignment (expression has type "frozenset[str] | None", '
     'variable has type "int")  [assignment]'
 )
 
 _GOOD_OUTPUT = "\n".join(
-    [_TYPED_REVEAL, _CALL_ARG_ERROR, _ASSIGNMENT_ERROR, "Found 2 errors in 1 file (checked 1 source file)"]
+    [_TYPED_REVEAL, _ARG_TYPE_ERROR, _ASSIGNMENT_ERROR, "Found 2 errors in 1 file (checked 1 source file)"]
 )
 
 # The silent-untyped case: mypy reveals bare Any, reports nothing, and exits 0.
@@ -37,19 +53,19 @@ _UNTYPED_OUTPUT = "\n".join(['probe.py:4: note: Revealed type is "Any"', "Succes
 
 _NO_REVEAL_OUTPUT = "Success: no issues found in 1 source file"
 
-_MISSING_CALL_ARG_OUTPUT = "\n".join(
+_MISSING_ARG_TYPE_OUTPUT = "\n".join(
     [_TYPED_REVEAL, _ASSIGNMENT_ERROR, "Found 1 error in 1 file (checked 1 source file)"]
 )
 
 _MISSING_ASSIGNMENT_OUTPUT = "\n".join(
-    [_TYPED_REVEAL, _CALL_ARG_ERROR, "Found 1 error in 1 file (checked 1 source file)"]
+    [_TYPED_REVEAL, _ARG_TYPE_ERROR, "Found 1 error in 1 file (checked 1 source file)"]
 )
 
 # Any as a parameter annotation inside the revealed signature, not the bare 'Revealed type is "Any"'.
 _ANY_IN_SIGNATURE_OUTPUT = "\n".join(
     [
-        'probe.py:4: note: Revealed type is "def (compute_framework: Any) -> frozenset[str]"',
-        _CALL_ARG_ERROR,
+        'probe.py:4: note: Revealed type is "def (secondary: Any =) -> Union[frozenset[builtins.str], None]"',
+        _ARG_TYPE_ERROR,
         _ASSIGNMENT_ERROR,
         "Found 2 errors in 1 file (checked 1 source file)",
     ]
@@ -60,6 +76,11 @@ def _load() -> ModuleType:
     """Import scripts/verify_typed_install.py, the probe runner the typed-install gate uses."""
     assert _SCRIPT_PATH.exists(), f"{_SCRIPT_PATH} is missing; it is what proves the published wheels install typed"
     return load_script("verify_typed_install", _SCRIPT_PATH)
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
 
 
 def _probe_source() -> str:
@@ -77,12 +98,35 @@ def _mypy_output_problems() -> Callable[[str], list[str]]:
 
 
 def test_probe_source_imports_reveals_and_miscalls_the_plugin() -> None:
-    """The probe must import the installed class, reveal its type, and provoke two typed-only errors."""
+    """The probe must import the installed class, reveal a leaf-defined symbol, and provoke two typed-only errors."""
     source = _probe_source()
     assert _PROBE_MODULE in source, f"PROBE_SOURCE must import from {_PROBE_MODULE}"
     assert "PyArrowAggregation" in source, "PROBE_SOURCE must import PyArrowAggregation"
-    assert "reveal_type(" in source, "PROBE_SOURCE must reveal_type the supported_subtypes attribute"
-    assert "secondary=123" in source, "PROBE_SOURCE must call supported_subtypes(secondary=123) to provoke [call-arg]"
+    assert "supported_op_subtypes" in source, (
+        "PROBE_SOURCE must probe supported_op_subtypes, the symbol the leaf itself defines"
+    )
+    assert "reveal_type(" in source, "PROBE_SOURCE must reveal_type the supported_op_subtypes attribute"
+    assert "secondary=123" in source, (
+        "PROBE_SOURCE must call supported_op_subtypes(secondary=123) to provoke [arg-type]"
+    )
+
+
+def test_probe_distributions_and_module_track_the_config() -> None:
+    """A delisted or moved probe package must fail loudly here, not silently probe a stale wheel."""
+    packages = _load_toml(_PACKAGES_CONFIG)["packages"]
+    distributions = getattr(_load(), "PROBE_DISTRIBUTIONS", None)
+    assert isinstance(distributions, tuple), "verify_typed_install.PROBE_DISTRIBUTIONS must be a tuple constant"
+    assert {_PROBE_LEAF, _PROBE_BASE} <= set(distributions), (
+        f"PROBE_DISTRIBUTIONS must pin at least the leaf and its base, got {distributions!r}"
+    )
+    for name in distributions:
+        assert packages.get(name, {}).get("published") is True, (
+            f"PROBE_DISTRIBUTIONS lists {name!r}, which config/packages.toml does not flag published = true"
+        )
+    leaf_root = str(packages[_PROBE_LEAF]["path"]).replace("/", ".")
+    assert _PROBE_MODULE.startswith(f"{leaf_root}."), (
+        f"the probe module {_PROBE_MODULE!r} must live under the configured {_PROBE_LEAF} path {leaf_root!r}"
+    )
 
 
 def test_a_bare_any_reveal_is_a_problem() -> None:
@@ -96,10 +140,10 @@ def test_a_bare_any_reveal_is_a_problem() -> None:
     ("output", "missing"),
     [
         (_NO_REVEAL_OUTPUT, "a 'Revealed type is' line, so the probe never ran"),
-        (_MISSING_CALL_ARG_OUTPUT, "the expected 'Unexpected keyword argument \"secondary\"' error"),
+        (_MISSING_ARG_TYPE_OUTPUT, "the provoked '[arg-type]' error"),
         (_MISSING_ASSIGNMENT_OUTPUT, "an '[assignment]' error"),
     ],
-    ids=["no-reveal", "no-call-arg-error", "no-assignment-error"],
+    ids=["no-reveal", "no-arg-type-error", "no-assignment-error"],
 )
 def test_an_incomplete_output_is_a_problem(output: str, missing: str) -> None:
     """Each expected line proves one thing; with any of them missing the install is not proven typed."""
@@ -116,4 +160,4 @@ def test_a_fully_typed_output_yields_no_problems() -> None:
 def test_any_inside_a_revealed_signature_is_not_flagged() -> None:
     """Only the bare 'Revealed type is "Any"' is untyped; Any as a parameter annotation is legitimate."""
     problems = _mypy_output_problems()(_ANY_IN_SIGNATURE_OUTPUT)
-    assert problems == [], f"'compute_framework: Any' inside a signature must not be flagged, got {problems!r}"
+    assert problems == [], f"'secondary: Any' inside a signature must not be flagged, got {problems!r}"

--- a/tox.ini
+++ b/tox.ini
@@ -148,6 +148,27 @@ commands =
     sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_changing.resample; print(\"mloda.community.resample OK\")"'
     sh -c 'echo "=== All packages verified ==="'
 
+[testenv:verify-floor-installs]
+description = Verify each package imports against its declared minimum internal dependency
+# Needs deps and skip_install, which the lock runner ignores.
+runner = uv-venv-runner
+skip_install = true
+# tomli: nothing else here provides it, and Python 3.10 has no tomllib.
+deps =
+    tomli
+allowlist_externals = uv
+commands =
+    python scripts/verify_floor_installs.py {env:MLODA_REGISTRY_VERSION}
+
+[testenv:verify-typed-install]
+description = Verify a standalone leaf install is typed under mypy --strict
+# Needs skip_install, which the lock runner ignores.
+runner = uv-venv-runner
+skip_install = true
+allowlist_externals = uv
+commands =
+    python scripts/verify_typed_install.py {env:MLODA_REGISTRY_VERSION}
+
 [testenv:verify-extras]
 description = Verify optional dependencies install correctly
 # Needs skip_install, which the lock runner ignores.

--- a/tox.ini
+++ b/tox.ini
@@ -149,7 +149,7 @@ commands =
     sh -c 'echo "=== All packages verified ==="'
 
 [testenv:verify-floor-installs]
-description = Verify each package imports against its declared minimum internal dependency
+description = Verify each package's import surface loads with its internal dependency pinned to the declared floor
 # Needs deps and skip_install, which the lock runner ignores.
 runner = uv-venv-runner
 skip_install = true

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -333,7 +333,7 @@ wheels = [
 
 [[package]]
 name = "mloda-community"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community" }
 dependencies = [
     { name = "mloda" },
@@ -344,7 +344,7 @@ requires-dist = [{ name = "mloda", specifier = ">=0.10.0,<0.11.0" }]
 
 [[package]]
 name = "mloda-community-aggregation"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/aggregation" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -380,7 +380,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -394,7 +394,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-binning"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/binning" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -430,7 +430,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -444,7 +444,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-compute-frameworks-example"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/compute_frameworks/example" }
 dependencies = [
     { name = "mloda" },
@@ -466,7 +466,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-data-operations"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations" }
 dependencies = [
     { name = "mloda" },
@@ -524,7 +524,7 @@ provides-extras = ["dev", "all"]
 
 [[package]]
 name = "mloda-community-datetime"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/datetime" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -538,7 +538,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -546,7 +546,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-ema"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/ema" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -582,7 +582,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -596,7 +596,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-example"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/example" }
 dependencies = [
     { name = "mloda" },
@@ -624,7 +624,7 @@ provides-extras = ["dev", "all"]
 
 [[package]]
 name = "mloda-community-example-a"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/example/example_a" }
 dependencies = [
     { name = "mloda-community-example" },
@@ -638,7 +638,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-example", specifier = ">=0.2.0" },
+    { name = "mloda-community-example", specifier = ">=0.2.6" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -646,7 +646,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-example-b"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/example/example_b" }
 dependencies = [
     { name = "mloda-community-example" },
@@ -660,7 +660,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-example", specifier = ">=0.2.0" },
+    { name = "mloda-community-example", specifier = ">=0.2.6" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -668,7 +668,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-extenders-example"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/extenders/example" }
 dependencies = [
     { name = "mloda" },
@@ -690,7 +690,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-ffill"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/ffill" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -726,7 +726,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -740,7 +740,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-frame-aggregate"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -772,7 +772,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'", specifier = ">=2.2" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2" },
@@ -784,7 +784,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-offset"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/offset" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -816,7 +816,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -828,7 +828,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-percentile"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/percentile" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -860,7 +860,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -872,7 +872,7 @@ provides-extras = ["dev", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-point-arithmetic"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -908,7 +908,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -922,7 +922,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-rank"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/rank" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -954,7 +954,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -966,7 +966,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-resample"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_changing/resample" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1002,7 +1002,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1016,7 +1016,7 @@ provides-extras = ["dev", "pyarrow", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-scalar-aggregate"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1052,7 +1052,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1066,7 +1066,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-scalar-arithmetic"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1102,7 +1102,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1116,7 +1116,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-sessionization"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/sessionization" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1152,7 +1152,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1166,7 +1166,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-string"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/string" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1180,7 +1180,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1188,7 +1188,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-time-bucketization"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/time_bucketization" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1224,7 +1224,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1238,7 +1238,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-window-aggregation"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1274,7 +1274,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.3.3" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1288,7 +1288,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-enterprise"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/enterprise" }
 dependencies = [
     { name = "mloda" },
@@ -1299,7 +1299,7 @@ requires-dist = [{ name = "mloda", specifier = ">=0.10.0,<0.11.0" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/enterprise/compute_frameworks/example" }
 dependencies = [
     { name = "mloda" },
@@ -1321,7 +1321,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-enterprise-example"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/enterprise/feature_groups/example" }
 dependencies = [
     { name = "mloda" },
@@ -1343,7 +1343,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-enterprise-extenders-example"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/enterprise/extenders/example" }
 dependencies = [
     { name = "mloda" },
@@ -1365,7 +1365,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-registry"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/registry" }
 dependencies = [
     { name = "mloda" },
@@ -1434,7 +1434,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-testing"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "mloda/testing" }
 dependencies = [
     { name = "mloda" },
@@ -1691,10 +1691,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -1760,9 +1760,9 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [


### PR DESCRIPTION
Fixes #350. Fixes #347.

## Floors (#350)

Every data-operations leaf declared `mloda-community-data-operations>=0.3.3`, a version that never reached PyPI, while importing helpers first shipped in 0.4.0. The example variants declared `>=0.2.0`, but only 0.2.6 ships the module they import. Floors now name the oldest published release containing what the package imports. Policy in docs/packaging.md: a floor can never exceed the workspace version, so a package importing a not-yet-released symbol keeps the current cap and the floor moves in a follow-up after that release ships.

## Enforcement (#350)

`tox -e verify-floor-installs` (weekly workflow) installs each internal pair at `dependency==floor` plus `package==released version` and imports the package's import surface: the package root plus its `base` module, where the cross-package imports live (the roots are mostly empty `__init__.py` files, so a root import alone proves nothing). It also fails loudly on floors naming versions that never reached PyPI. Dependency names are PEP 503 normalized and PEP 508 markers are stripped before parsing, so a misspelled internal dependency cannot silently escape the check.

## Typing (#347)

`tox -e verify-typed-install` installs `mloda-community-aggregation` standalone outside the checkout and runs `mypy --strict` on a probe that reveals the leaf-defined `supported_op_subtypes` and provokes `[arg-type]` and `[assignment]` errors. It judges captured output, never exit status: the untyped case exits 0 with 'Success: no issues found' next to `Revealed type is "Any"`.

## Expected weekly reds at 0.4.0 (documented in docs/releasing.md)

- `verify-typed-install` stays red until the release that first ships the data-operations `py.typed` marker.
- `verify-floor-installs` is red for the five leaves flagged published after 0.4.0, until the next release ships them. All 13 pairs already on PyPI pass, verified live.

Neither env gates PRs; both run in the weekly verification workflow.

`uv.lock`: regenerating the pyprojects updates the workspace members' floors in the lock; no third-party version changed.

Gate: 4799 passed, 210 skipped, ruff format, ruff check, mypy --strict, bandit all clean. Reviewed independently by two deep reviews before opening; accepted findings are in the second commit.