### PR TITLE
fix(data_operations): require options at match time and report mistyped scalar rejections

### DIFF
--- a/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
+++ b/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
@@ -29,7 +29,7 @@ feature = Feature(
 )
 ```
 
-All rows of the same `service` share the same P95 value. Percentiles use the framework's native method (linear interpolation by default in Pandas, DuckDB and Polars; PyArrow is not a supported percentile backend). Cross-framework tests allow `pytest.approx` tolerance for floating-point comparisons.
+All rows of the same `service` share the same P95 value. Percentiles use the framework's native method (linear interpolation by default in Pandas, DuckDB and Polars; PyArrow is not a supported percentile backend). Cross-framework tests allow `pytest.approx` tolerance for floating-point comparisons. Config-style features report a wrong-typed or out-of-range `percentile` as a rejection reason in the resolution error.
 
 ---
 

--- a/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
+++ b/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
@@ -50,7 +50,7 @@ Supported operations are `add`, `subtract`, `multiply`, and `divide`. The consta
 
 The source column must be numeric; passing a string or boolean column raises `ValueError` at validation.
 
-`constant` carries `strict_validation=False` on its `PROPERTY_MAPPING` entry so that pattern-only matches (`value_int__add_constant`) succeed without it; the missing-constant check then fires at compute time with a clear error. This lets feature names compose into chains before the constant is bound.
+`constant` is strict on its `PROPERTY_MAPPING` entry with an element validator, so a mistyped value on a config-style feature is reported as a rejection reason in the resolution error. A pattern match skips property validation, so `value_int__add_constant` still matches without a constant and feature names compose into chains before the constant is bound; the missing-constant check then fires at compute time with a clear error.
 
 Type semantics across backends:
 

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -198,6 +198,11 @@ def positive_int_value(value: object) -> int:
     return n
 
 
+def always_required(_options: Options) -> bool:
+    """required_when predicate for a key required on every path: a PREFIX_PATTERN match otherwise skips the check."""
+    return True
+
+
 #: ASCII decimal >= 1. str.isdigit also accepts superscripts (int() raises) and non-ASCII digits.
 _PARAMETRIC_SUFFIX_PATTERN = re.compile(r"[1-9][0-9]*")
 

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -165,6 +165,11 @@ def is_scalar_number(value: object) -> bool:
     return isinstance(number, (int, float)) and not isinstance(number, bool)
 
 
+def is_number_element(value: object) -> bool:
+    """Bare element predicate for element_validator slots: core has already unpacked, so no unwrapping (bool is not a number)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
 def scalar_number_value(value: object) -> int | float:
     """The single number of a value is_scalar_number accepts, unwrapped from its container."""
     number: int | float = _unwrap_singleton(value)

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -47,6 +47,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.base import (
+    always_required,
     column_ref_value,
     is_column_ref,
     is_op_token,
@@ -149,6 +150,7 @@ class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.match_guard: is_column_ref,
+            DefaultOptionKeys.required_when: always_required,
         },
         RESAMPLE_OP: {
             "explanation": "Resample token '{n}_{unit}_{agg}' (e.g. '1_hour_mean') when the op is not encoded in the feature name.",

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_integration.py
@@ -121,6 +121,16 @@ class TestResampleMatchFeatureGroupCriteria:
         opts_bad = Options(context={"time_column": "ts", "resample_op": "not_a_token"})
         assert ResampleFeatureGroup.match_feature_group_criteria("my_resampled", opts_bad, None) is False
 
+    def test_missing_time_column_does_not_match(self) -> None:
+        """Name path: a pattern name without time_column is a non-match."""
+        options = Options(context={"partition_by": ["region"]})
+        assert not PyArrowResample.match_feature_group_criteria("value_float__resample_1_hour_mean", options)
+
+    def test_config_path_missing_time_column_does_not_match(self) -> None:
+        """Config path: a config feature without time_column stays a non-match."""
+        options = Options(context={"in_features": "value_float", "resample_op": "1_hour_mean"})
+        assert ResampleFeatureGroup.match_feature_group_criteria("my_resampled", options, None) is False
+
     def test_config_valid_resample_op_not_rejected_by_validator(self) -> None:
         # Exercise the actual match_guard wired into PROPERTY_MAPPING: a valid token
         # passes, a garbage token and a non-string are rejected.

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
@@ -50,7 +50,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import column_ref_value, is_column_ref
+from mloda.community.feature_groups.data_operations.base import always_required, column_ref_value, is_column_ref
 
 
 class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -80,6 +80,7 @@ class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.match_guard: is_column_ref,
+            DefaultOptionKeys.required_when: always_required,
         },
     }
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/tests/test_integration.py
@@ -156,6 +156,16 @@ class TestEmaMatchFeatureGroupCriteria:
         """Name-based: a non-pattern name without config must fail to match."""
         assert not PandasEma.match_feature_group_criteria("my_custom_result", Options())
 
+    def test_missing_order_by_does_not_match(self) -> None:
+        """Name path: a pattern name without order_by is a non-match."""
+        options = Options(context={"partition_by": ["region"]})
+        assert not PandasEma.match_feature_group_criteria("value_float__ema_2", options)
+
+    def test_config_path_missing_order_by_does_not_match(self) -> None:
+        """Config path: a config feature without order_by stays a non-match."""
+        options = Options(context={"in_features": "value_float", "partition_by": ["region"]})
+        assert not PandasEma.match_feature_group_criteria("my_result", options, None)
+
 
 class TestEmaRejectionRouting:
     """EMA must fail loudly rather than emulate, via two distinct paths.

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
@@ -41,7 +41,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import column_ref_value, is_column_ref
+from mloda.community.feature_groups.data_operations.base import always_required, column_ref_value, is_column_ref
 
 
 class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -75,6 +75,7 @@ class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.match_guard: is_column_ref,
+            DefaultOptionKeys.required_when: always_required,
         },
     }
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_integration.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Any
 
 import pyarrow as pa
+import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
@@ -107,6 +108,40 @@ class TestFfillIntegration(DataOpsIntegrationTestBase):
         """Name-based: a non-pattern name without config must fail to match."""
         options = Options()
         assert not PyArrowFfill.match_feature_group_criteria("my_custom_result", options)
+
+
+class TestFfillRequiredOrderBy:
+    """ffill requires ``order_by``: a feature missing it must NOT match at discovery."""
+
+    def test_name_path_missing_order_by_does_not_match(self) -> None:
+        """Name path: a pattern name without order_by is a non-match."""
+        options = Options(context={"partition_by": ["region"]})
+        assert not PyArrowFfill.match_feature_group_criteria("amount__ffill", options)
+
+    def test_name_path_with_order_by_matches(self) -> None:
+        """Control: the same pattern name WITH order_by still matches."""
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        assert PyArrowFfill.match_feature_group_criteria("amount__ffill", options)
+
+    def test_config_path_missing_order_by_does_not_match(self) -> None:
+        """Config path: a config feature without order_by stays a non-match."""
+        options = Options(context={"in_features": "amount", "partition_by": ["region"]})
+        assert not PyArrowFfill.match_feature_group_criteria("my_result", options, None)
+
+    def test_missing_order_by_rejected_at_discovery(self) -> None:
+        """Engine level: missing order_by fails resolution with core's generic no-feature-group error, not compute."""
+        plugin_collector = PluginCollector.enabled_feature_groups({PyArrowDataOpsTestDataCreator, PyArrowFfill})
+        feature = Feature(
+            "value_float__ffill",
+            options=Options(context={"partition_by": ["region"]}),
+        )
+
+        with pytest.raises(ValueError, match=r"(?i)no feature group"):
+            mloda.run_all(
+                [feature],
+                compute_frameworks={PyArrowTable},
+                plugin_collector=plugin_collector,
+            )
 
 
 class TestIntegrationMultipleFeatures:

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
@@ -31,6 +31,11 @@ def _unit_percentile(value: object) -> float | None:
     return float(number)
 
 
+def _is_unit_interval_element(value: object) -> bool:
+    """Bare element predicate: one number in [0.0, 1.0], compared without float conversion so a huge int cannot overflow."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and 0.0 <= value <= 1.0
+
+
 class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """Base class for percentile operations that preserve row count.
 
@@ -78,7 +83,8 @@ class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         PERCENTILE: {
             "explanation": "Percentile value (float between 0.0 and 1.0)",
             DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.element_validator: _is_unit_interval_element,
             DefaultOptionKeys.match_guard: is_scalar_number,
         },
         DefaultOptionKeys.in_features: {

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
@@ -263,6 +263,48 @@ class TestConfigBasedExtraction:
         assert result == 1.0
 
 
+class TestRejectionReporting:
+    """A wrong-typed percentile is a reported strict-validation rejection, not a silent non-match."""
+
+    def test_wrong_typed_percentile_reports_a_reason(self) -> None:
+        options = Options(
+            context={
+                "percentile": "fifty",
+                "in_features": "value_int",
+                "partition_by": ["region"],
+            }
+        )
+        reason = PercentileFeatureGroup._strict_validation_rejection_reason("my_result", options)
+        assert reason is not None
+        assert "percentile" in reason
+
+    def test_out_of_range_percentile_reports_a_reason(self) -> None:
+        """An out-of-range percentile is a reported strict-validation rejection, not a silent non-match."""
+        for value in (50, 1.5):
+            options = Options(
+                context={
+                    "percentile": value,
+                    "in_features": "value_int",
+                    "partition_by": ["region"],
+                }
+            )
+            assert PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None) is False
+            reason = PercentileFeatureGroup._strict_validation_rejection_reason("my_result", options)
+            assert reason is not None
+            assert "percentile" in reason
+
+    def test_valid_percentile_reports_nothing(self) -> None:
+        options = Options(
+            context={
+                "percentile": 0.5,
+                "in_features": "value_int",
+                "partition_by": ["region"],
+            }
+        )
+        reason = PercentileFeatureGroup._strict_validation_rejection_reason("my_result", options)
+        assert reason is None
+
+
 class TestPercentileMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:
@@ -299,7 +341,8 @@ class TestPercentileMatchValidation(MatchValidationTestBase):
 
     @classmethod
     def options_reject_invalid_types(cls) -> bool:
-        return False
+        # percentile is strict with an element validator, so wrong-typed config values are rejected.
+        return True
 
     @classmethod
     def token_cases(cls) -> list[TokenCase]:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
@@ -10,8 +10,10 @@ Pattern: ``{col}__{op}_constant``
 Example: ``value_int__divide_constant`` with ``constant=2`` divides every
 non-null value in ``value_int`` by 2.
 
-The ``constant`` option carries ``strict_validation=False`` so that
-pattern-only matches (``{col}__{op}_constant``) succeed without it; the
+The ``constant`` option is strict with an element validator, so a
+wrong-typed value is reported as a rejection reason in the resolution
+error. A pattern match skips property validation, so
+``{col}__{op}_constant`` still matches without a constant; the
 missing-constant check then fires at compute time with a clear error.
 """
 
@@ -27,7 +29,12 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys
 
 from mloda.community.feature_groups.data_operations.row_preserving.arithmetic.base import ArithmeticFeatureGroupBase
-from mloda.community.feature_groups.data_operations.base import is_op_token, is_scalar_number, scalar_number_value
+from mloda.community.feature_groups.data_operations.base import (
+    is_number_element,
+    is_op_token,
+    is_scalar_number,
+    scalar_number_value,
+)
 
 ARITHMETIC_OPERATIONS: dict[str, str] = {
     "add": "Element-wise addition of a constant",
@@ -62,7 +69,8 @@ class ScalarArithmeticFeatureGroup(ArithmeticFeatureGroupBase):
         CONSTANT: {
             "explanation": "Numeric constant applied element-wise to the source column",
             DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.element_validator: is_number_element,
             DefaultOptionKeys.match_guard: is_scalar_number,
         },
     }

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -60,7 +60,7 @@ class TestPatternMatching:
         ],
     )
     def test_matches_all_operations(self, feature_name: str) -> None:
-        # CONSTANT has strict_validation=False, so missing-constant does not block match.
+        # A pattern match skips property validation, so a missing constant does not block the match.
         options = Options()
         result = ScalarArithmeticFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
@@ -171,6 +171,60 @@ class TestConstantExtraction:
         feature = Feature("value_int__add_constant", options=Options(context={"constant": "five"}))
         with pytest.raises(ValueError, match="int or float"):
             ScalarArithmeticFeatureGroup._extract_constant(feature)
+
+
+class TestRejectionReporting:
+    """A wrong-typed constant is a reported strict-validation rejection, not a silent non-match."""
+
+    def test_wrong_typed_constant_reports_a_reason(self) -> None:
+        options = Options(
+            context={
+                "arithmetic_op": "add",
+                "in_features": "value_int",
+                "constant": "five",
+            }
+        )
+        reason = ScalarArithmeticFeatureGroup._strict_validation_rejection_reason("my_result", options)
+        assert reason is not None
+        assert "constant" in reason
+
+    def test_valid_constant_reports_nothing(self) -> None:
+        options = Options(
+            context={
+                "arithmetic_op": "add",
+                "in_features": "value_int",
+                "constant": 5,
+            }
+        )
+        reason = ScalarArithmeticFeatureGroup._strict_validation_rejection_reason("my_result", options)
+        assert reason is None
+
+    def test_nested_singleton_constant_reports_a_reason(self) -> None:
+        """A nested singleton constant is a reported strict-validation rejection, not a silent non-match."""
+        for value in ([[5]], ([5],)):
+            options = Options(
+                context={
+                    "arithmetic_op": "add",
+                    "in_features": "value_int",
+                    "constant": value,
+                }
+            )
+            assert ScalarArithmeticFeatureGroup.match_feature_group_criteria("my_result", options, None) is False
+            reason = ScalarArithmeticFeatureGroup._strict_validation_rejection_reason("my_result", options)
+            assert reason is not None
+            assert "constant" in reason
+
+    def test_multi_element_constant_stays_a_silent_non_match(self) -> None:
+        # The arity guard, not strict validation, rejects a multi-element constant.
+        options = Options(
+            context={
+                "arithmetic_op": "add",
+                "in_features": "value_int",
+                "constant": [5, 10],
+            }
+        )
+        assert ScalarArithmeticFeatureGroup._strict_validation_rejection_reason("my_result", options) is None
+        assert ScalarArithmeticFeatureGroup.match_feature_group_criteria("my_result", options, None) is False
 
 
 class TestSingleColumnEnforcement:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_integration.py
@@ -291,3 +291,30 @@ class TestIntegrationOptionBasedConfig:
 
         assert add_found, "string-pattern add result not found"
         assert mul_found, "option-based multiply result not found"
+
+
+class TestMistypedConstantReported:
+    """A wrong-typed constant must surface as a reported validation failure, not a silent non-match."""
+
+    def test_mistyped_constant_reported_in_resolution_error(self) -> None:
+        plugin_collector = PluginCollector.enabled_feature_groups(
+            {PyArrowDataOpsTestDataCreator, PyArrowScalarArithmetic}
+        )
+
+        feature = Feature(
+            "my_result",
+            options=Options(
+                context={
+                    "arithmetic_op": "add",
+                    "in_features": "value_int",
+                    "constant": "five",
+                }
+            ),
+        )
+
+        with pytest.raises(ValueError, match=r"failed validation for 'constant'"):
+            mloda.run_all(
+                [feature],
+                compute_frameworks={PyArrowTable},
+                plugin_collector=plugin_collector,
+            )

--- a/mloda/community/feature_groups/data_operations/tests/test_prefix_pattern_collisions.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_prefix_pattern_collisions.py
@@ -56,11 +56,10 @@ DATA_OPERATIONS_ROOT = REPO_ROOT / "mloda" / "community" / "feature_groups" / "d
 _PREFIX_DEF_RE = re.compile(r"^\s*PREFIX_PATTERN\s*[:=]", re.MULTILINE)
 
 # Structural-only options: enough for families that require ``partition_by`` /
-# ``order_by`` to accept their string-based names, but deliberately free of any
-# operation-type key (``aggregation_type``, ``frame_type``, ...) so no family can
-# match via the config-based path. That keeps matching purely name-driven, which
-# is what this lint is about.
-PERMISSIVE_OPTIONS = Options(context={"partition_by": ["g"], "order_by": "t"})
+# ``order_by`` / ``time_column`` to accept their string-based names, but deliberately
+# free of any operation-type key (``aggregation_type``, ``frame_type``, ...) so no
+# family can match via the config-based path. Matching stays purely name-driven.
+PERMISSIVE_OPTIONS = Options(context={"partition_by": ["g"], "order_by": "t", "time_column": "t"})
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Closes #351. Closes #352.

## Required options are required at match time

ffill and ema require `order_by` and resample requires `time_column`, but none of the three declared it, so a name-pattern feature missing the option matched at discovery and raised inside `calculate_feature`. The three entries now carry a shared `always_required` required_when predicate, which the mixin enforces on the name path and the config path alike, so the feature is a non-match at discovery and resolution can move on. The compute-time raises stay as backstops for direct calls. The cross-family prefix-collision harness gained `time_column` as a structural key.

## Mistyped scalar options are reported, not silently dropped

A wrong-typed `constant` or `percentile` was rejected by its match_guard, a silent non-match that left "no feature groups found" with no reason. Both keys are now strict with a bare element validator, so a wrong-typed value, a nested singleton container, and an out-of-range percentile are reported as rejection reasons in the resolution error for config-style features, while the guard keeps rejecting multi-element containers. Element validators receive already-unpacked elements, so the new predicates do not unwrap again, and the percentile range check compares without float conversion so a huge int cannot overflow. Pattern-only matching is unaffected (a pattern match skips property validation); the outdated `strict_validation=False` rationale in the module docstring and the guides is rewritten, and the reporting claim is scoped to config-style features.

## Review pass

Two independent deep reviews ran on the diff. Accepted findings are in this PR: bare element predicates for the element slots, the range-aware percentile validator, doc scoping, a narrowed `pytest.raises`, and invariant phrasing on the config-path pin tests. Findings kept out of scope are filed as #378 (naming reasons for pattern-path guard rejections, required_when rejections, and the suppressed forwarding hint) and #379 (frame_aggregate declaring the same order_by rule by hand).

## Verification

`tox` green (4819 passed, 206 skipped; ruff format, ruff check, mypy --strict, bandit).