### PR TITLE
impr(data_operations): name guard and required_when rejections in resolution errors

### DIFF
--- a/docs/guides/data-operation-patterns/12-ffill-by-time.md
+++ b/docs/guides/data-operation-patterns/12-ffill-by-time.md
@@ -60,7 +60,7 @@ Ordering ties matter only when two rows in a partition share an `order_by` value
 
 ## Chained names
 
-A chained name writes the child inline: `price__ffill__ema_10` builds `price__ffill` as its own input feature. Context options stay local, so the child never receives `order_by` or `partition_by` and fails resolution, with the missing key named in the error. List the keys in `propagate_context_keys` to send them down the chain (group options propagate too, but they affect feature hashing and splitting).
+A chained name writes the child inline: `price__ffill__ema_10` builds `price__ffill` as its own input feature. Context options stay local, so the child receives neither `order_by` nor `partition_by`: the missing `order_by` fails resolution with the key named in the error, while a missing `partition_by` silently computes the child unpartitioned and changes the result. List the keys in `propagate_context_keys` to send them down the chain (group options propagate too, but they affect feature hashing and splitting).
 
 ```python
 Feature(

--- a/docs/guides/data-operation-patterns/12-ffill-by-time.md
+++ b/docs/guides/data-operation-patterns/12-ffill-by-time.md
@@ -58,6 +58,24 @@ Ordering ties matter only when two rows in a partition share an `order_by` value
 
 ---
 
+## Chained names
+
+A chained name writes the child inline: `price__ffill__ema_10` builds `price__ffill` as its own input feature. Context options stay local, so the child never receives `order_by` or `partition_by` and fails resolution, with the missing key named in the error. List the keys in `propagate_context_keys` to send them down the chain (group options propagate too, but they affect feature hashing and splitting).
+
+```python
+Feature(
+    "price__ffill__ema_10",
+    Options(
+        context={"order_by": "ts", "partition_by": ["symbol"]},
+        propagate_context_keys=frozenset({"order_by", "partition_by"}),
+    ),
+)
+```
+
+See [Context Propagation](../feature-group-patterns/11-options.md#context-propagation).
+
+---
+
 ## Related
 
 - [Row-preserving contract](02-row-preserving-contract.md) - Output row count and order must match input.

--- a/docs/guides/data-operation-patterns/13-ema.md
+++ b/docs/guides/data-operation-patterns/13-ema.md
@@ -75,7 +75,7 @@ result = mloda.run_all(features, compute_frameworks={"PandasDataFrame"})
 
 ## Chained names
 
-A chained name writes the child inline: `price__ema_10__ema_5` builds `price__ema_10` as its own input feature. Context options stay local, so the child never receives `order_by` or `partition_by` and fails resolution, with the missing key named in the error. List the keys in `propagate_context_keys` to send them down the chain (group options propagate too, but they affect feature hashing and splitting).
+A chained name writes the child inline: `price__ema_10__ema_5` builds `price__ema_10` as its own input feature. Context options stay local, so the child receives neither `order_by` nor `partition_by`: the missing `order_by` fails resolution with the key named in the error, while a missing `partition_by` silently computes the child unpartitioned and changes the result. List the keys in `propagate_context_keys` to send them down the chain (group options propagate too, but they affect feature hashing and splitting).
 
 ```python
 Feature(

--- a/docs/guides/data-operation-patterns/13-ema.md
+++ b/docs/guides/data-operation-patterns/13-ema.md
@@ -73,6 +73,24 @@ result = mloda.run_all(features, compute_frameworks={"PandasDataFrame"})
 
 ---
 
+## Chained names
+
+A chained name writes the child inline: `price__ema_10__ema_5` builds `price__ema_10` as its own input feature. Context options stay local, so the child never receives `order_by` or `partition_by` and fails resolution, with the missing key named in the error. List the keys in `propagate_context_keys` to send them down the chain (group options propagate too, but they affect feature hashing and splitting).
+
+```python
+Feature(
+    "price__ema_10__ema_5",
+    Options(
+        context={"order_by": "ts", "partition_by": ["symbol"]},
+        propagate_context_keys=frozenset({"order_by", "partition_by"}),
+    ),
+)
+```
+
+See [Context Propagation](../feature-group-patterns/11-options.md#context-propagation).
+
+---
+
 ## Related
 
 - [Row-preserving contract](02-row-preserving-contract.md) - Output row count and order must match input.

--- a/docs/guides/data-operation-patterns/14-resample.md
+++ b/docs/guides/data-operation-patterns/14-resample.md
@@ -80,6 +80,24 @@ The result has one row per occupied hour per symbol, not one row per input event
 
 ---
 
+## Chained names
+
+A chained name writes the child inline: `value__resample_1_hour_mean__resample_1_day_max` builds `value__resample_1_hour_mean` as its own input feature. Context options stay local, so the child never receives `time_column` and fails resolution, with the missing key named in the error. List the key in `propagate_context_keys` to send it down the chain (group options propagate too, but they affect feature hashing and splitting).
+
+```python
+Feature(
+    "value__resample_1_hour_mean__resample_1_day_max",
+    Options(
+        context={"time_column": "ts"},
+        propagate_context_keys=frozenset({"time_column"}),
+    ),
+)
+```
+
+See [Context Propagation](../feature-group-patterns/11-options.md#context-propagation).
+
+---
+
 ## Related
 
 - [Time bucketization](11-time-bucketization.md) - The row-preserving floor that resample reuses for bucket alignment.

--- a/docs/guides/feature-group-patterns/03-chained-features.md
+++ b/docs/guides/feature-group-patterns/03-chained-features.md
@@ -99,7 +99,7 @@ PROPERTY_MAPPING supports additional capabilities that reduce boilerplate in `ma
 
 - **`allowed_values`**: The kwarg that declares a key's accepted value space; `strict=True` (the builder kwarg that sets the `strict_validation` field) makes membership enforced, and the spec validates itself at construction. See [Options: PROPERTY_MAPPING value space](11-options.md#property_mapping-value-space) and [Options: Builder `property_spec`](11-options.md#builder-property_spec).
 - **`required_when`**: Declare options that are only required under certain conditions via a predicate callable.
-- **`match_guard`**: Check the raw option value with a callable (e.g., that it is a list of strings). Does not require `strict_validation`; a falsy return is a non-match, not an error.
+- **`match_guard`**: Check the raw option value with a callable (e.g., that it is a list of strings). Does not require `strict_validation`; a falsy return is a non-match, not an error, with no reason reported unless the feature group extends the rejection-reason hook, as the data operation families do.
 - **`element_validator`**: Validate each parsed element when `strict_validation` is enabled (e.g., that it is a positive integer). A falsy return raises `ValueError`, which the mixin turns into a non-match plus a rejection reason in the resolution error.
 
 See [Feature Matching: Key Differences](14-feature-matching.md#key-differences-from-element_validator) for the comparison table and examples, and [PROPERTY_MAPPING Configuration](https://mloda-ai.github.io/mloda/in_depth/property-mapping/) for the precedence and lifecycle rules.

--- a/docs/guides/feature-group-patterns/11-options.md
+++ b/docs/guides/feature-group-patterns/11-options.md
@@ -115,7 +115,7 @@ A spec validates itself when it is built, so a `strict=True` `default` outside t
 When using `PROPERTY_MAPPING` with `FeatureChainParserMixin`, you can declare validation rules and conditional requirements directly on option entries:
 
 - **`element_validator`**: Validate each parsed element with a callable (requires `strict=True`). A falsy return raises `ValueError`, which the mixin turns into a non-match plus a rejection reason in the resolution error.
-- **`match_guard`**: Check the raw option value with a callable (no `strict_validation` needed). Useful for composite types like lists or dicts. A falsy return is a plain non-match, with no reason reported.
+- **`match_guard`**: Check the raw option value with a callable (no `strict_validation` needed). Useful for composite types like lists or dicts. A falsy return is a plain non-match, with no reason reported unless the feature group extends the rejection-reason hook, as the data operation families do.
 - **`required_when`**: Make an option conditionally required based on a predicate callable.
 
 For `element_validator` and membership, the spec declares the arity: `list`, `tuple`, `set` and `frozenset` unpack element-wise and identically, a `str` stays a scalar, and a `dict` is one composite value. `match_guard` still sees the raw value with its original container type.

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -252,7 +252,7 @@ Use `element_validator` to validate option values with a callable instead of che
 
 When an element validator is present, it **replaces** the `allowed_values` membership check rather than adding to it. It receives each parsed element and must return `True` if valid.
 
-A falsy return raises `ValueError`, but the mixin catches it and returns `False`, so both mechanisms end in a non-match and another candidate can still take the feature. The difference is diagnostics: if nothing matches, an `element_validator` rejection is listed as a reason in the end user's "No feature groups found" error, while a `match_guard` rejection leaves only a debug log unless the feature group extends the rejection-reason hook, as the data operation families do.
+A falsy return raises `ValueError`, but the mixin catches it and returns `False`, so both mechanisms end in a non-match and another candidate can still take the feature. The difference is diagnostics: if nothing matches, an `element_validator` rejection is listed as a reason in the end user's "No feature groups found" error, while a `match_guard` rejection leaves only a debug log unless the feature group extends the rejection-reason hook, as the data operation families do (via `RejectionReasonMixin` in `mloda/community/feature_groups/data_operations/base.py`).
 
 ```python
 from mloda.provider import property_spec

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -252,7 +252,7 @@ Use `element_validator` to validate option values with a callable instead of che
 
 When an element validator is present, it **replaces** the `allowed_values` membership check rather than adding to it. It receives each parsed element and must return `True` if valid.
 
-A falsy return raises `ValueError`, but the mixin catches it and returns `False`, so both mechanisms end in a non-match and another candidate can still take the feature. The difference is diagnostics: if nothing matches, an `element_validator` rejection is listed as a reason in the end user's "No feature groups found" error, while a `match_guard` rejection leaves only a debug log.
+A falsy return raises `ValueError`, but the mixin catches it and returns `False`, so both mechanisms end in a non-match and another candidate can still take the feature. The difference is diagnostics: if nothing matches, an `element_validator` rejection is listed as a reason in the end user's "No feature groups found" error, while a `match_guard` rejection leaves only a debug log unless the feature group extends the rejection-reason hook, as the data operation families do.
 
 ```python
 from mloda.provider import property_spec

--- a/mloda/community/feature_groups/data_operations/aggregation_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation_base.py
@@ -20,11 +20,10 @@ from __future__ import annotations
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import op_token_value
+from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, op_token_value
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 
 AGGREGATION_TYPES: dict[str, str] = {
@@ -48,7 +47,7 @@ AGGREGATION_TYPES: dict[str, str] = {
 }
 
 
-class AggregationFeatureGroupBase(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGroup):
+class AggregationFeatureGroupBase(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup):
     AGGREGATION_TYPE = "aggregation_type"
 
     #: Canonical aggregation-type table. Subclasses override to advertise their

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import reprlib
 from collections.abc import Callable
 from enum import Enum
 from typing import Any, TypeVar
@@ -226,6 +227,14 @@ def is_parametric_suffix(suffix: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _safe_repr(value: Any) -> str:
+    """A capped repr that never raises: a hostile __repr__ falls back to the type name."""
+    try:
+        return reprlib.repr(value)
+    except Exception:
+        return f"<unreprable {type(value).__name__}>"
+
+
 class RejectionReasonMixin(FeatureChainParserMixin):
     """Names guard and required_when rejections that core's rejection-reason hook leaves silent."""
 
@@ -238,25 +247,29 @@ class RejectionReasonMixin(FeatureChainParserMixin):
         if property_mapping is None:
             return None
         prefix_patterns = cls._get_prefix_patterns()
-        # Only name a missing required_when key for a candidate that would otherwise match.
-        # Guard rejections need no such gate: they fire only on values that are present.
+        # Both checks only fire for a candidate that would otherwise match; a non-candidate
+        # carrying a stray mistyped option stays silent.
         try:
             matched = FeatureChainParser.match_configuration_feature_chain_parser(
                 feature_name, options, property_mapping=property_mapping, prefix_patterns=prefix_patterns
             )
         except ValueError:
             matched = False
-        if matched and not cls._validate_required_when(True, feature_name, prefix_patterns, property_mapping, options):
-            key = cls._missing_required_when_key(feature_name, prefix_patterns, property_mapping, options)
-            if key is not None:
-                return (
-                    f"required option '{key}' was not provided; context options do not propagate to "
-                    f"chained input features unless listed in propagate_context_keys"
-                )
-        rejected = cls._rejected_match_guard(options, property_mapping)
-        if rejected is not None:
-            key, value, guard_name = rejected
-            return f"match_guard '{guard_name}' for option '{key}' rejected value {value!r}"
+        if matched:
+            # Whether a key is missing goes through cls._validate_required_when so subclass overrides
+            # (frame_aggregate's name-path carve-out) win; only the key lookup mirrors the base loop.
+            if not cls._validate_required_when(True, feature_name, prefix_patterns, property_mapping, options):
+                key = cls._missing_required_when_key(feature_name, prefix_patterns, property_mapping, options)
+                if key is not None:
+                    return (
+                        f"required option '{key}' was not provided; provide it in Options(context=...). "
+                        f"For a chained name, the child receives only the context keys listed in "
+                        f"propagate_context_keys"
+                    )
+            rejected = cls._rejected_match_guard(options, property_mapping)
+            if rejected is not None:
+                key, value, guard_name = rejected
+                return f"match_guard '{guard_name}' for option '{key}' rejected value {_safe_repr(value)}"
         return None
 
     @classmethod
@@ -293,10 +306,12 @@ class RejectionReasonMixin(FeatureChainParserMixin):
                 continue
             if cls._guard_accepts(guard, value):
                 continue
-            # A multi-element container of individually accepted values fails only on arity,
-            # which stays a silent non-match.
-            if isinstance(value, (list, tuple, set, frozenset)) and all(
-                cls._guard_accepts(guard, element) for element in value
+            # Only a genuinely multi-element container of individually accepted values fails on
+            # arity alone, which stays a silent non-match; a nested singleton is a real rejection.
+            if (
+                isinstance(value, (list, tuple, set, frozenset))
+                and len(value) > 1
+                and all(cls._guard_accepts(guard, element) for element in value)
             ):
                 continue
             return key, value, getattr(guard, "__name__", repr(guard))

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -7,6 +7,10 @@ from collections.abc import Callable
 from enum import Enum
 from typing import Any, TypeVar
 
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 
 T = TypeVar("T")
@@ -215,3 +219,93 @@ _PARAMETRIC_SUFFIX_PATTERN = re.compile(r"[1-9][0-9]*")
 def is_parametric_suffix(suffix: str) -> bool:
     """True for the ASCII positive-integer suffix of a parametric operation token (e.g. the 4 in ntile_4)."""
     return _PARAMETRIC_SUFFIX_PATTERN.fullmatch(suffix) is not None
+
+
+# ---------------------------------------------------------------------------
+# Shared rejection-reason reporting
+# ---------------------------------------------------------------------------
+
+
+class RejectionReasonMixin(FeatureChainParserMixin):
+    """Names guard and required_when rejections that core's rejection-reason hook leaves silent."""
+
+    @classmethod
+    def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
+        reason = super()._strict_validation_rejection_reason(feature_name, options)
+        if reason is not None:
+            return reason
+        property_mapping = cls._get_property_mapping()
+        if property_mapping is None:
+            return None
+        prefix_patterns = cls._get_prefix_patterns()
+        # Only name a missing required_when key for a candidate that would otherwise match.
+        # Guard rejections need no such gate: they fire only on values that are present.
+        try:
+            matched = FeatureChainParser.match_configuration_feature_chain_parser(
+                feature_name, options, property_mapping=property_mapping, prefix_patterns=prefix_patterns
+            )
+        except ValueError:
+            matched = False
+        if matched and not cls._validate_required_when(True, feature_name, prefix_patterns, property_mapping, options):
+            key = cls._missing_required_when_key(feature_name, prefix_patterns, property_mapping, options)
+            if key is not None:
+                return (
+                    f"required option '{key}' was not provided; context options do not propagate to "
+                    f"chained input features unless listed in propagate_context_keys"
+                )
+        rejected = cls._rejected_match_guard(options, property_mapping)
+        if rejected is not None:
+            key, value, guard_name = rejected
+            return f"match_guard '{guard_name}' for option '{key}' rejected value {value!r}"
+        return None
+
+    @classmethod
+    def _missing_required_when_key(
+        cls,
+        feature_name: str | FeatureName,
+        prefix_patterns: list[str],
+        property_mapping: dict[str, Any],
+        options: Options,
+    ) -> str | None:
+        """First key whose required_when predicate fires while the effective options leave it unset."""
+        effective_options = cls._build_effective_options(str(feature_name), prefix_patterns, property_mapping, options)
+        for key, mapping_entry in property_mapping.items():
+            if not isinstance(mapping_entry, dict):
+                continue
+            predicate = mapping_entry.get(DefaultOptionKeys.required_when)
+            if predicate is None or not callable(predicate):
+                continue
+            if predicate(effective_options) and effective_options.get(key) is None:
+                return key
+        return None
+
+    @classmethod
+    def _rejected_match_guard(cls, options: Options, property_mapping: dict[str, Any]) -> tuple[str, Any, str] | None:
+        """First (key, value, guard name) whose match_guard rejects a present value for more than arity."""
+        for key, mapping_entry in property_mapping.items():
+            if not isinstance(mapping_entry, dict):
+                continue
+            guard = mapping_entry.get(DefaultOptionKeys.match_guard)
+            if guard is None:
+                continue
+            value = options.get(key)
+            if value is None:
+                continue
+            if cls._guard_accepts(guard, value):
+                continue
+            # A multi-element container of individually accepted values fails only on arity,
+            # which stays a silent non-match.
+            if isinstance(value, (list, tuple, set, frozenset)) and all(
+                cls._guard_accepts(guard, element) for element in value
+            ):
+                continue
+            return key, value, getattr(guard, "__name__", repr(guard))
+        return None
+
+    @staticmethod
+    def _guard_accepts(guard: Callable[[Any], Any], value: Any) -> bool:
+        """Run one guard, treating a raised TypeError/ValueError/AttributeError as rejection."""
+        try:
+            return bool(guard(value))
+        except (TypeError, ValueError, AttributeError):
+            return False

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -40,13 +40,13 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.base import (
+    RejectionReasonMixin,
     always_required,
     column_ref_value,
     is_column_ref,
@@ -118,7 +118,7 @@ def _is_valid_resample_op(value: object) -> bool:
     return True
 
 
-class ResampleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for resample operations that CHANGE the row count.
 
     Subclasses must implement ``_compute_resample`` (the backend-specific

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_integration.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from typing import Any
 
 import pyarrow as pa
+import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.data_creator.pyarrow import PyArrowDataOpsTestDataCreator
@@ -90,6 +91,24 @@ class TestResampleIntegration:
 
         col = table.column(name).to_pylist()
         assert sorted(col) == _COUNT_SORTED
+
+
+class TestChainedNameDropsContext:
+    """A chained resample name drops context keys on the child; the error must name time_column."""
+
+    def test_chained_child_missing_time_column_named_in_resolution_error(self) -> None:
+        plugin_collector = PluginCollector.enabled_feature_groups({PyArrowDataOpsTestDataCreator, PyArrowResample})
+        feature = Feature(
+            "value_float__resample_1_hour_mean__resample_2_hour_sum",
+            options=Options(context={"time_column": "timestamp"}),
+        )
+
+        with pytest.raises(ValueError, match=r"required option 'time_column'"):
+            mloda.run_all(
+                [feature],
+                compute_frameworks={PyArrowTable},
+                plugin_collector=plugin_collector,
+            )
 
 
 class TestResampleMatchFeatureGroupCriteria:

--- a/mloda/community/feature_groups/data_operations/row_preserving/arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/arithmetic/base.py
@@ -22,10 +22,9 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.provider import FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import op_token_value
+from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, op_token_value
 
 ARITHMETIC_OP_NAMES: frozenset[str] = frozenset({"add", "subtract", "multiply", "divide"})
 
@@ -33,7 +32,7 @@ ARITHMETIC_OP_NAMES: frozenset[str] = frozenset({"add", "subtract", "multiply", 
 SQL_ARITHMETIC_OPS: dict[str, str] = {"add": "+", "subtract": "-", "multiply": "*", "divide": "/"}
 
 
-class ArithmeticFeatureGroupBase(FeatureChainParserMixin, FeatureGroup):
+class ArithmeticFeatureGroupBase(RejectionReasonMixin, FeatureGroup):
     ARITHMETIC_OP = "arithmetic_op"
 
     #: Operation label used in the numeric-source rejection message.

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -7,12 +7,12 @@ from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 from mloda.community.feature_groups.data_operations.base import (
+    RejectionReasonMixin,
     is_op_token,
     is_positive_int,
     op_token_value,
@@ -25,7 +25,7 @@ BINNING_OPS = {
 }
 
 
-class BinningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup):
     PREFIX_PATTERN = r".*__(bin|qbin)_[1-9]\d*$"
 
     MIN_IN_FEATURES = 1

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
@@ -7,12 +7,11 @@ from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
-from mloda.community.feature_groups.data_operations.base import is_op_token, op_token_value
+from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, is_op_token, op_token_value
 
 DATETIME_OPS = {
     "year": "Extract year from datetime",
@@ -27,7 +26,7 @@ DATETIME_OPS = {
 }
 
 
-class DateTimeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class DateTimeFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for element-wise datetime extraction operations.
 
     Extracts scalar integer components from datetime columns. The output

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
@@ -44,16 +44,20 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import always_required, column_ref_value, is_column_ref
+from mloda.community.feature_groups.data_operations.base import (
+    RejectionReasonMixin,
+    always_required,
+    column_ref_value,
+    is_column_ref,
+)
 
 
-class EmaFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class EmaFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for exponential-moving-average operations that preserve row count."""
 
     PREFIX_PATTERN = r".*__ema_\d+$"

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
@@ -35,16 +35,20 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import always_required, column_ref_value, is_column_ref
+from mloda.community.feature_groups.data_operations.base import (
+    RejectionReasonMixin,
+    always_required,
+    column_ref_value,
+    is_column_ref,
+)
 
 
-class FfillFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class FfillFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for forward-fill-by-time operations that preserve row count.
 
     ffill is a single-op operation (no op/unit matrix). All backends support it

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_integration.py
@@ -129,22 +129,7 @@ class TestFfillRequiredOrderBy:
         assert not PyArrowFfill.match_feature_group_criteria("my_result", options, None)
 
     def test_missing_order_by_rejected_at_discovery(self) -> None:
-        """Engine level: missing order_by fails resolution with core's generic no-feature-group error, not compute."""
-        plugin_collector = PluginCollector.enabled_feature_groups({PyArrowDataOpsTestDataCreator, PyArrowFfill})
-        feature = Feature(
-            "value_float__ffill",
-            options=Options(context={"partition_by": ["region"]}),
-        )
-
-        with pytest.raises(ValueError, match=r"(?i)no feature group"):
-            mloda.run_all(
-                [feature],
-                compute_frameworks={PyArrowTable},
-                plugin_collector=plugin_collector,
-            )
-
-    def test_missing_order_by_resolution_error_names_order_by(self) -> None:
-        """Engine level: the resolution error names the missing order_by."""
+        """Engine level: missing order_by fails resolution, and the error names order_by, not compute."""
         plugin_collector = PluginCollector.enabled_feature_groups({PyArrowDataOpsTestDataCreator, PyArrowFfill})
         feature = Feature(
             "value_float__ffill",

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/tests/test_integration.py
@@ -143,6 +143,21 @@ class TestFfillRequiredOrderBy:
                 plugin_collector=plugin_collector,
             )
 
+    def test_missing_order_by_resolution_error_names_order_by(self) -> None:
+        """Engine level: the resolution error names the missing order_by."""
+        plugin_collector = PluginCollector.enabled_feature_groups({PyArrowDataOpsTestDataCreator, PyArrowFfill})
+        feature = Feature(
+            "value_float__ffill",
+            options=Options(context={"partition_by": ["region"]}),
+        )
+
+        with pytest.raises(ValueError, match=r"required option 'order_by'"):
+            mloda.run_all(
+                [feature],
+                compute_frameworks={PyArrowTable},
+                plugin_collector=plugin_collector,
+            )
+
 
 class TestIntegrationMultipleFeatures:
     """Run multiple ffill features in a single ``run_all`` call."""

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
@@ -18,6 +17,7 @@ from mloda.community.feature_groups.data_operations.base import (
     FRAME_SIZE as _FRAME_SIZE_KEY,
     FRAME_TYPE as _FRAME_TYPE_KEY,
     FRAME_UNIT as _FRAME_UNIT_KEY,
+    RejectionReasonMixin,
     column_ref_value,
     is_column_ref,
     is_in_features_value,
@@ -119,7 +119,7 @@ def _parse_frame_feature_cached(feature_name: str) -> dict[str, Any] | None:
     return None
 
 
-class FrameAggregateFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGroup):
+class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup):
     """Base class for frame aggregate operations that preserve row count.
 
     Frame aggregation computes an aggregate over a sliding or expanding window

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -7,11 +7,11 @@ from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.base import (
+    RejectionReasonMixin,
     column_ref_value,
     is_column_ref,
     is_in_features_value,
@@ -45,7 +45,7 @@ def _is_supported_offset_type(value: object) -> bool:
     return False
 
 
-class OffsetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for offset operations that preserve row count.
 
     Offset operations access values at a fixed offset from the current row

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
@@ -6,13 +6,16 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import is_scalar_number, scalar_number_value
+from mloda.community.feature_groups.data_operations.base import (
+    RejectionReasonMixin,
+    is_scalar_number,
+    scalar_number_value,
+)
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
 
 
@@ -36,7 +39,7 @@ def _is_unit_interval_element(value: object) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool) and 0.0 <= value <= 1.0
 
 
-class PercentileFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for percentile operations that preserve row count.
 
     Computes a percentile over a partitioned group using PERCENTILE_CONT

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -7,13 +7,13 @@ from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 from mloda.community.feature_groups.data_operations.base import (
+    RejectionReasonMixin,
     column_ref_value,
     is_column_ref,
     is_in_features_value,
@@ -49,7 +49,7 @@ def _is_supported_rank_type(value: object) -> bool:
     return False
 
 
-class RankFeatureGroup(SubtypeCapabilityHook, FeatureChainParserMixin, FeatureGroup):
+class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup):
     """Base class for rank operations that preserve row count.
 
     Rank operations assign a rank or position to each row within a

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_integration.py
@@ -318,3 +318,21 @@ class TestMistypedConstantReported:
                 compute_frameworks={PyArrowTable},
                 plugin_collector=plugin_collector,
             )
+
+
+class TestMistypedPatternConstantReported:
+    """A wrong-typed constant on a pattern name must surface as a reported guard rejection."""
+
+    def test_pattern_path_mistyped_constant_reported_in_resolution_error(self) -> None:
+        plugin_collector = PluginCollector.enabled_feature_groups(
+            {PyArrowDataOpsTestDataCreator, PyArrowScalarArithmetic}
+        )
+
+        feature = Feature("value_int__add_constant", options=Options(context={"constant": "five"}))
+
+        with pytest.raises(ValueError, match=r"match_guard.*'constant'"):
+            mloda.run_all(
+                [feature],
+                compute_frameworks={PyArrowTable},
+                plugin_collector=plugin_collector,
+            )

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
@@ -48,13 +48,12 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import column_ref_value, is_column_ref
+from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, column_ref_value, is_column_ref
 
 # Supported sessionization units mapped to their length in seconds. The four
 # keys also define the units accepted by the feature-name regex.
@@ -104,7 +103,7 @@ def _sessionize_threshold_seconds(n: int, unit: str) -> int:
     return n * SESSIONIZATION_UNITS[unit]
 
 
-class SessionizationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class SessionizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for gap-threshold sessionization operations that preserve row count."""
 
     PREFIX_PATTERN = r".*__sessionize_\d+_(?:minute|hour|day|week)$"

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
@@ -39,13 +39,12 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import is_op_token, op_token_value
+from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, is_op_token, op_token_value
 
 TIME_BUCKETIZATION_OPS: dict[str, str] = {
     "floor": "Round timestamp down to the start of the enclosing bucket",
@@ -108,7 +107,7 @@ def _parse_bucket_op(token: str) -> tuple[str, int, str]:
     return op, n, unit
 
 
-class TimeBucketizationFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class TimeBucketizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for element-wise timestamp bucketization.
 
     Subclasses must implement ``_compute_bucket`` (the backend-specific

--- a/mloda/community/feature_groups/data_operations/string/base.py
+++ b/mloda/community/feature_groups/data_operations/string/base.py
@@ -7,10 +7,9 @@ from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.provider import DefaultOptionKeys, FeatureGroup
-from mloda.community.feature_groups.data_operations.base import is_op_token, op_token_value
+from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, is_op_token, op_token_value
 
 STRING_OPS = {
     "upper": "Convert string to uppercase",
@@ -21,7 +20,7 @@ STRING_OPS = {
 }
 
 
-class StringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class StringFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for element-wise string operations that preserve row count.
 
     String operations transform a single string column element by element.

--- a/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
@@ -1,0 +1,66 @@
+"""Rejection reasons surfaced by ``_strict_validation_rejection_reason``.
+
+Core's hook names element-validator rejections on the config path only; a pattern-path
+match_guard rejection and a missing required_when key both end in the generic
+no-feature-groups error with nothing named. These tests pin the reasons the mixin adds.
+"""
+
+from __future__ import annotations
+
+from mloda.core.abstract_plugins.components.options import Options
+
+from mloda.community.feature_groups.data_operations.row_preserving.ffill.pyarrow_ffill import PyArrowFfill
+from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.pandas_frame_aggregate import (
+    PandasFrameAggregate,
+)
+from mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.pyarrow_scalar_arithmetic import (
+    PyArrowScalarArithmetic,
+)
+
+
+class TestPatternPathGuardRejectionReported:
+    """A pattern-path match_guard rejection must be named, not a silent non-match."""
+
+    def test_mistyped_constant_reports_a_reason(self) -> None:
+        options = Options(context={"constant": "five"})
+        reason = PyArrowScalarArithmetic._strict_validation_rejection_reason("value_int__add_constant", options)
+        assert reason is not None
+        assert "match_guard" in reason
+        assert "'constant'" in reason
+        assert "'five'" in reason
+
+    def test_valid_constant_reports_nothing(self) -> None:
+        options = Options(context={"constant": 5})
+        assert PyArrowScalarArithmetic._strict_validation_rejection_reason("value_int__add_constant", options) is None
+
+    def test_unrelated_candidate_reports_nothing(self) -> None:
+        assert PyArrowScalarArithmetic._strict_validation_rejection_reason("some_unrelated_feature", Options()) is None
+
+
+class TestMissingRequiredWhenReported:
+    """A missing required_when key must be named, not left as a debug log."""
+
+    def test_missing_order_by_reports_a_reason(self) -> None:
+        reason = PyArrowFfill._strict_validation_rejection_reason("value_float__ffill", Options())
+        assert reason is not None
+        assert "required option 'order_by'" in reason
+        assert "propagate_context_keys" in reason
+
+    def test_present_order_by_reports_nothing(self) -> None:
+        options = Options(context={"order_by": "ts"})
+        assert PyArrowFfill._strict_validation_rejection_reason("value_float__ffill", options) is None
+
+    def test_config_path_guard_rejection_reports_a_reason(self) -> None:
+        options = Options(context={"in_features": "value_float", "order_by": 123})
+        reason = PyArrowFfill._strict_validation_rejection_reason("my_result", options)
+        assert reason is not None
+        assert "match_guard" in reason
+        assert "'order_by'" in reason
+
+
+class TestFrameAggregateNamePathReportsNothing:
+    """frame_aggregate parses size and unit from the name, so its name path has nothing to report."""
+
+    def test_rolling_name_with_required_context_reports_nothing(self) -> None:
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        assert PandasFrameAggregate._strict_validation_rejection_reason("sales__sum_rolling_3", options) is None

--- a/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
@@ -2,7 +2,8 @@
 
 Core's hook names element-validator rejections on the config path only; a pattern-path
 match_guard rejection and a missing required_when key both end in the generic
-no-feature-groups error with nothing named. These tests pin the reasons the mixin adds.
+no-feature-groups error with nothing named. These tests pin the reasons the mixin adds,
+and that non-candidates stay silent while reporting itself never raises.
 """
 
 from __future__ import annotations
@@ -29,12 +30,36 @@ class TestPatternPathGuardRejectionReported:
         assert "'constant'" in reason
         assert "'five'" in reason
 
+    def test_nested_singleton_constant_reports_a_reason(self) -> None:
+        """A double-wrapped scalar is guard-rejected; the arity carve-out must not swallow it."""
+        options = Options(context={"constant": [[5]]})
+        reason = PyArrowScalarArithmetic._strict_validation_rejection_reason("value_int__add_constant", options)
+        assert reason is not None
+        assert "'constant'" in reason
+
     def test_valid_constant_reports_nothing(self) -> None:
         options = Options(context={"constant": 5})
         assert PyArrowScalarArithmetic._strict_validation_rejection_reason("value_int__add_constant", options) is None
 
     def test_unrelated_candidate_reports_nothing(self) -> None:
         assert PyArrowScalarArithmetic._strict_validation_rejection_reason("some_unrelated_feature", Options()) is None
+
+
+class TestConfigPathGuardRejectionReported:
+    """A config-path match_guard rejection must be named; a non-candidate must stay silent."""
+
+    def test_mistyped_order_by_reports_a_reason(self) -> None:
+        """With partition_by present the guard on order_by is the only failure, so it gets named."""
+        options = Options(context={"in_features": "value_float", "order_by": 123, "partition_by": ["region"]})
+        reason = PyArrowFfill._strict_validation_rejection_reason("my_result", options)
+        assert reason is not None
+        assert "match_guard" in reason
+        assert "'order_by'" in reason
+
+    def test_non_candidate_with_guard_rejected_value_reports_nothing(self) -> None:
+        """No pattern name and no in_features: ffill was never a candidate, so nothing is reported."""
+        options = Options(context={"order_by": 123})
+        assert PyArrowFfill._strict_validation_rejection_reason("some_unrelated_feature", options) is None
 
 
 class TestMissingRequiredWhenReported:
@@ -50,17 +75,28 @@ class TestMissingRequiredWhenReported:
         options = Options(context={"order_by": "ts"})
         assert PyArrowFfill._strict_validation_rejection_reason("value_float__ffill", options) is None
 
-    def test_config_path_guard_rejection_reports_a_reason(self) -> None:
-        options = Options(context={"in_features": "value_float", "order_by": 123})
-        reason = PyArrowFfill._strict_validation_rejection_reason("my_result", options)
+
+class TestRejectionReasonHookNeverRaises:
+    """The hook is diagnostics only: a hostile value repr must not escape as an exception."""
+
+    def test_unreprable_guard_rejected_value_still_reports_a_reason(self) -> None:
+        class ExplodingRepr:
+            """Value whose repr raises, so reporting must survive the formatting failure."""
+
+            def __repr__(self) -> str:
+                raise RuntimeError("repr exploded")
+
+        options = Options(context={"order_by": ExplodingRepr()})
+        reason = PyArrowFfill._strict_validation_rejection_reason("value_float__ffill", options)
         assert reason is not None
-        assert "match_guard" in reason
         assert "'order_by'" in reason
 
 
 class TestFrameAggregateNamePathReportsNothing:
     """frame_aggregate parses size and unit from the name, so its name path has nothing to report."""
 
-    def test_rolling_name_with_required_context_reports_nothing(self) -> None:
-        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+    def test_rolling_name_skips_option_driven_required_when(self) -> None:
+        """The name supplies size and unit, so a frame_type option cannot demand them: the match holds silently."""
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp", "frame_type": "time"})
+        assert PandasFrameAggregate.match_feature_group_criteria("sales__sum_rolling_3", options)
         assert PandasFrameAggregate._strict_validation_rejection_reason("sales__sum_rolling_3", options) is None


### PR DESCRIPTION
## Summary

Discovery-time rejections in the data operation families now name their reason in the resolution error instead of ending in a bare "no feature groups found":

- A pattern-path wrong-typed scalar (e.g. `value_int__add_constant` with `constant="five"`) names the guard, the key, and the rejected value. Core's rejection-reason hook returns None once a name matches `PREFIX_PATTERN`, so element-validator reporting only covered config-style names.
- A missing `required_when` key (e.g. `order_by` on ffill, `time_column` on resample) names the key and how to provide it, instead of leaving only a debug log. This also covers chained names, where the child fails resolution because context options do not propagate.

Closes #378.

## Implementation

A shared `RejectionReasonMixin` in `mloda/community/feature_groups/data_operations/base.py` extends `_strict_validation_rejection_reason`: after core's hook, it checks a missing `required_when` key and a `match_guard` rejection of a present value, both gated on the candidate otherwise matching so unrelated feature groups stay silent. Whether a key is missing goes through `cls._validate_required_when`, so subclass overrides (frame_aggregate's name path) are respected. All data operation family bases adopt the mixin.

Hardening from review: a multi-element container of individually valid values stays a plain arity non-match while a nested singleton is named, and reason formatting uses a capped safe repr so a hostile `__repr__` cannot escape the hook.

## Docs

The ffill, ema, and resample guides document why chained names drop context options and the `propagate_context_keys` escape hatch, including the caveat that an unpropagated `partition_by` silently computes the child unpartitioned. The options, matching, and chained-features guides note the extended reporting.

## Review

Two independent deep reviews (Claude Opus and codex). Accepted and fixed: gating guard reasons on candidacy, a unit test that pinned a false attribution, the nested-singleton carve-out, the raising-repr hazard, the required_when message wording, and doc consistency. Rejected: reporting multi-element arity failures (contradicts the pinned silent-non-match arity contract; filed as a follow-up), and deduplicating the per-op guide sections (guides are deliberately self-contained).

## Testing

`tox` green: 4831 passed, 206 skipped; ruff format, ruff check, mypy --strict, bandit all clean.
