### PR TITLE
refactor(data_operations): declare frame_aggregate order_by via required_when

### DIFF
--- a/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
+++ b/docs/guides/data-operation-patterns/08-scalar-and-frame-aggregate.md
@@ -146,7 +146,7 @@ All frame-aggregate variants accept:
 
 ### Config-based frame features
 
-A frame feature built from Options instead of a name declares its window explicitly, and PROPERTY_MAPPING is what enforces it: `aggregation_type`, `frame_type` and `in_features` are always required, `frame_size` (a positive integer) is required for `rolling` and `time`, and `frame_unit` is required for `time` and must be one of the units above. Name-based features carry all of that in the name, so they need only `partition_by` and `order_by`.
+A frame feature built from Options instead of a name declares its window explicitly, and PROPERTY_MAPPING is what enforces it: `aggregation_type`, `frame_type` and `in_features` are always required, `order_by` is always required on both the name and config paths, `frame_size` (a positive integer) is required for `rolling` and `time`, and `frame_unit` is required for `time` and must be one of the units above. Name-based features carry all of that in the name, so they need only `partition_by` and `order_by`.
 
 ---
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -212,6 +212,9 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
 
+    #: Keys a frame name supplies via _parse_frame_feature; exempt from required_when on the name path.
+    _NAME_SUPPLIED_KEYS: tuple[str, ...] = (FRAME_TYPE, FRAME_SIZE, FRAME_UNIT)
+
     PROPERTY_MAPPING = {
         AGGREGATION_TYPE: {
             "explanation": "Aggregation applied over the frame",
@@ -332,9 +335,9 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
         property_mapping: dict[str, Any] | None,
         options: Options,
     ) -> bool:
-        # A frame name carries its own size and unit; order_by stays required on every path.
+        # A frame name carries its own type, size and unit; order_by stays required on every path.
         if property_mapping is not None and cls._parse_frame_feature(str(feature_name)) is not None:
-            property_mapping = {k: v for k, v in property_mapping.items() if k not in (cls.FRAME_SIZE, cls.FRAME_UNIT)}
+            property_mapping = {k: v for k, v in property_mapping.items() if k not in cls._NAME_SUPPLIED_KEYS}
         return super()._validate_required_when(result, feature_name, prefix_patterns, property_mapping, options)
 
     @classmethod
@@ -346,8 +349,8 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
     ) -> bool:
         """Extend the declaration-driven mixin match with per-subclass capability and shape checks.
 
-        PROPERTY_MAPPING owns the value spaces (agg type, frame type, frame unit, frame size) and the
-        presence rules; only what a shared class-level declaration cannot express lives here.
+        PROPERTY_MAPPING owns the value spaces; order_by is declared always-required, frame_size and
+        frame_unit stay config-path only (the name supplies them), and partition_by presence is hand-enforced below.
         """
         if not super().match_feature_group_criteria(feature_name, options, _data_access_collection):
             return False

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -18,6 +18,7 @@ from mloda.community.feature_groups.data_operations.base import (
     FRAME_TYPE as _FRAME_TYPE_KEY,
     FRAME_UNIT as _FRAME_UNIT_KEY,
     RejectionReasonMixin,
+    always_required,
     column_ref_value,
     is_column_ref,
     is_in_features_value,
@@ -262,6 +263,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.match_guard: is_column_ref,
+            DefaultOptionKeys.required_when: always_required,
         },
         MASK_KEY: {
             "explanation": "Conditional mask: (column, operator, value) tuple or list of tuples",
@@ -330,9 +332,9 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
         property_mapping: dict[str, Any] | None,
         options: Options,
     ) -> bool:
-        # A frame name carries its own size and unit, so the conditional requirements are config-path only.
-        if cls._parse_frame_feature(str(feature_name)) is not None:
-            return True
+        # A frame name carries its own size and unit; order_by stays required on every path.
+        if property_mapping is not None and cls._parse_frame_feature(str(feature_name)) is not None:
+            property_mapping = {k: v for k, v in property_mapping.items() if k not in (cls.FRAME_SIZE, cls.FRAME_UNIT)}
         return super()._validate_required_when(result, feature_name, prefix_patterns, property_mapping, options)
 
     @classmethod
@@ -344,9 +346,8 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
     ) -> bool:
         """Extend the declaration-driven mixin match with per-subclass capability and shape checks.
 
-        PROPERTY_MAPPING owns the value spaces (agg type, frame type, frame unit, frame size)
-        and the config-path presence rules; only what a shared class-level declaration cannot
-        express lives here.
+        PROPERTY_MAPPING owns the value spaces (agg type, frame type, frame unit, frame size) and the
+        presence rules; only what a shared class-level declaration cannot express lives here.
         """
         if not super().match_feature_group_criteria(feature_name, options, _data_access_collection):
             return False
@@ -363,9 +364,6 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
         if not isinstance(partition_by, (list, tuple)):
             return False
         if not all(isinstance(item, str) for item in partition_by):
-            return False
-
-        if not is_column_ref(options.get(cls.ORDER_BY)):
             return False
 
         return True

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -7,9 +7,11 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import DefaultOptionKeys
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
 
+from mloda.community.feature_groups.data_operations.base import always_required
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.base import (
     FrameAggregateFeatureGroup,
     _AGGREGATION_TYPES,
@@ -145,11 +147,20 @@ class TestPatternMatching:
         result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
         assert result is False
 
-    def test_rejects_cumulative_no_order_by(self) -> None:
-        """order_by is required on every path, unsized cumulative frames included."""
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            "sales__sum_rolling_3",
+            "sales__avg_7_day_window",
+            "sales__cumsum",
+            "sales__expanding_avg",
+        ],
+    )
+    def test_rejects_no_order_by_every_shape(self, feature_name: str) -> None:
+        """order_by is required on every name shape, unsized cumulative and expanding frames included."""
         options = Options(context={"partition_by": ["region"]})
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__cumsum", options, None)
-        assert result is False
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(feature_name, options, None)
+        assert result is False, f"Name path should require order_by: {feature_name}"
 
     def test_rejects_wrong_typed_order_by(self) -> None:
         """order_by must be a column reference, not any scalar."""
@@ -448,7 +459,7 @@ class TestNameBasedFrameTypeInOptions:
         assert result is True
 
     def test_rolling_name_with_stray_time_frame_type_option(self) -> None:
-        """A stray time frame_type option on a rolling name must not demand frame_size or frame_unit."""
+        """A time frame_type option contradicting a rolling name must not trigger config-path size/unit rules."""
         options = Options(context={"frame_type": "time", "partition_by": ["region"], "order_by": "timestamp"})
         result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
         assert result is True
@@ -460,6 +471,44 @@ class TestNameBasedFrameTypeInOptions:
         options.inherit_from(consumer)
         result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
         assert result is True
+
+
+class TestNameSuppliedFrameTypeRequiredWhen:
+    """The name supplies frame_type just like frame_size and frame_unit, so a required_when on it
+    must not fire on the name path; the config path, which has no name to supply it, still enforces it.
+    """
+
+    @staticmethod
+    def _frame_type_required() -> type[FrameAggregateFeatureGroup]:
+        class _FrameTypeRequired(FrameAggregateFeatureGroup):
+            PROPERTY_MAPPING = {
+                **FrameAggregateFeatureGroup.PROPERTY_MAPPING,
+                FrameAggregateFeatureGroup.FRAME_TYPE: {
+                    **FrameAggregateFeatureGroup.PROPERTY_MAPPING[FrameAggregateFeatureGroup.FRAME_TYPE],
+                    DefaultOptionKeys.required_when: always_required,
+                },
+            }
+
+        return _FrameTypeRequired
+
+    def test_name_path_not_rejected_by_frame_type_required_when(self) -> None:
+        """A rolling name carries its frame type, so an always-on frame_type requirement must not reject it."""
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        result = self._frame_type_required().match_feature_group_criteria("sales__sum_rolling_3", options, None)
+        assert result is True
+
+    def test_config_path_still_enforces_frame_type(self) -> None:
+        """Control: a config feature without frame_type stays a non-match."""
+        options = Options(
+            context={
+                "aggregation_type": "sum",
+                "in_features": "sales",
+                "partition_by": ["region"],
+                "order_by": "timestamp",
+            }
+        )
+        result = self._frame_type_required().match_feature_group_criteria("my_result", options, None)
+        assert result is False
 
 
 class TestHostileInFeatures:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -145,6 +145,18 @@ class TestPatternMatching:
         result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
         assert result is False
 
+    def test_rejects_cumulative_no_order_by(self) -> None:
+        """order_by is required on every path, unsized cumulative frames included."""
+        options = Options(context={"partition_by": ["region"]})
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__cumsum", options, None)
+        assert result is False
+
+    def test_rejects_wrong_typed_order_by(self) -> None:
+        """order_by must be a column reference, not any scalar."""
+        options = Options(context={"partition_by": ["region"], "order_by": 123})
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
+        assert result is False
+
     def test_rejects_invalid_agg_type(self) -> None:
         options = self._base_options()
         result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__unknown_rolling_3", options, None)
@@ -219,6 +231,19 @@ class TestConfigBasedMatching:
                 "aggregation_type": "sum",
                 "partition_by": ["region"],
                 "order_by": "timestamp",
+            }
+        )
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
+        assert result is False
+
+    def test_config_rejects_missing_order_by(self) -> None:
+        options = Options(
+            context={
+                "aggregation_type": "sum",
+                "frame_type": "rolling",
+                "frame_size": 3,
+                "in_features": "sales",
+                "partition_by": ["region"],
             }
         )
         result = FrameAggregateFeatureGroup.match_feature_group_criteria("my_result", options, None)
@@ -420,6 +445,12 @@ class TestNameBasedFrameTypeInOptions:
     def test_time_window_name_with_frame_type_option(self) -> None:
         options = Options(context={"frame_type": "time", "partition_by": ["region"], "order_by": "timestamp"})
         result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__avg_7_day_window", options, None)
+        assert result is True
+
+    def test_rolling_name_with_stray_time_frame_type_option(self) -> None:
+        """A stray time frame_type option on a rolling name must not demand frame_size or frame_unit."""
+        options = Options(context={"frame_type": "time", "partition_by": ["region"], "order_by": "timestamp"})
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
         assert result is True
 
     def test_rolling_name_with_propagated_frame_type(self) -> None:


### PR DESCRIPTION
## Summary

`FrameAggregateFeatureGroup` enforced "order_by required on every path" with a hand-written check inside `match_feature_group_criteria`, while ffill, ema, and resample declare the same rule with the shared `always_required` required_when predicate. One rule, two mechanisms. The ORDER_BY mapping entry now declares `required_when: always_required` (the existing `match_guard: is_column_ref` keeps the value check) and the manual line is gone.

Closes #379.

## The name-path caveat

frame_aggregate overrides `_validate_required_when` to skip conditional requirements for name-parsed features, since size and unit come from the name. A blanket skip would also have disabled the new always-required order_by. The override now strips only the keys the name itself supplies, derived from a `_NAME_SUPPLIED_KEYS` constant (frame_type, frame_size, frame_unit), and delegates the rest, so order_by still fires on all four name shapes. A subclass test pins that a future `required_when` on any name-supplied key cannot reject name-parsed features.

## Behavior preservation

Existing match tests are unchanged and green. New pins bracket the refactor: config path without order_by, wrong-typed order_by on the name path, missing order_by across all four name shapes, and a stray time frame_type option on a rolling name. An independent review ran a 32,000-case old-vs-new differential over name shapes, creation paths, option placements, and hostile values with zero behavioral divergence.

## Review

Two independent deep reviews (Claude Opus and codex). Codex: clean pass. Opus: no critical or major findings; accepted and fixed the incomplete name-path exemption list and two wording gaps (docstring, guide 08). Deferred with reasons: a compute-time backstop for direct calls with missing order_by (pre-existing gap, filed separately) and micro-optimizing the name-path match cost (dominant cost sits in core's effective-options build).

## Testing

`tox` green: 4828 passed, 206 skipped; ruff format, ruff check, mypy --strict, bandit all clean.
