### PR TITLE
fix(tests): skip build artifact directories in filesystem-walking tests

### DIFF
--- a/mloda/community/feature_groups/data_operations/tests/test_framework_support_matrix.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_framework_support_matrix.py
@@ -21,6 +21,15 @@ DATA_OPERATIONS_ROOT = REPO_ROOT / "mloda" / "community" / "feature_groups" / "d
 BEGIN_MARKER = "<!-- BEGIN GENERATED: framework-support-matrix -->"
 END_MARKER = "<!-- END GENERATED: framework-support-matrix -->"
 
+#: Build artifact directory names skipped by tree walks; scripts/generate_pyproject.py excludes these too.
+ARTIFACT_DIR_PARTS = frozenset({"build", "dist", ".tox", ".venv", "__pycache__"})
+
+
+def is_artifact_path(rel_path: Path) -> bool:
+    """True when any part of *rel_path* is a build artifact directory (or an ``*.egg-info``)."""
+    return any(part in ARTIFACT_DIR_PARTS or part.endswith(".egg-info") for part in rel_path.parts)
+
+
 #: Doc column order: (framework key, doc column label).
 FRAMEWORKS: list[tuple[str, str]] = [
     ("pyarrow", "PyArrow"),
@@ -161,18 +170,20 @@ def splice_into_doc(doc_text: str, generated: str) -> str:
     return doc_text[:begin] + generated.rstrip("\n") + trailing
 
 
-def discover_operation_dirs_on_disk() -> set[str]:
+def discover_operation_dirs_on_disk(root: Path = DATA_OPERATIONS_ROOT) -> set[str]:
     """Operation directory names that carry per-framework twin test modules.
 
     A directory counts when its ``tests`` subpackage contains at least one
     ``test_<framework>.py`` file. Guards against a new data operation landing
-    on disk without a catalog entry.
+    on disk without a catalog entry. Build artifact copies are skipped.
     """
     ops: set[str] = set()
-    if not DATA_OPERATIONS_ROOT.exists():
+    if not root.exists():
         return ops
-    for tests_dir in DATA_OPERATIONS_ROOT.rglob("tests"):
+    for tests_dir in root.rglob("tests"):
         if not tests_dir.is_dir():
+            continue
+        if is_artifact_path(tests_dir.relative_to(root)):
             continue
         if not any((tests_dir / f"test_{fw_key}.py").exists() for fw_key, _label in FRAMEWORKS):
             continue
@@ -204,8 +215,30 @@ def test_operations_list_covers_every_data_operation_on_disk() -> None:
         f"OPERATIONS does not match DataOperationsCatalog.list() names: "
         f"missing={sorted(catalog_names - set(OPERATIONS))} extra={sorted(set(OPERATIONS) - catalog_names)}"
     )
-    uncovered = sorted(discover_operation_dirs_on_disk() - catalog_names)
+    on_disk = discover_operation_dirs_on_disk()
+    uncovered = sorted(on_disk - catalog_names)
     assert uncovered == [], (
         "DataOperationsCatalog is missing entries for these data-operation directories "
         "(each has test_<framework>.py twin files):\n  " + "\n  ".join(uncovered)
     )
+    unbacked = sorted(catalog_names - on_disk)
+    assert unbacked == [], (
+        "These DataOperationsCatalog entries have no twin test directories on disk (an over-broad "
+        "build-artifact skip in discover_operation_dirs_on_disk would hide them):\n  " + "\n  ".join(unbacked)
+    )
+
+
+def test_discover_operation_dirs_on_disk_counts_planted_operation(tmp_path: Path) -> None:
+    """A planted <op>/tests/test_<framework>.py twin file counts its operation directory."""
+    twin = tmp_path / "my_op" / "tests" / "test_pandas.py"
+    twin.parent.mkdir(parents=True)
+    twin.write_text("")
+    assert discover_operation_dirs_on_disk(root=tmp_path) == {"my_op"}
+
+
+def test_discover_operation_dirs_on_disk_skips_build_artifact_dirs(tmp_path: Path) -> None:
+    """A twin-file tree under build/lib is not counted as an operation directory."""
+    copy = tmp_path / "build" / "lib" / "my_op" / "tests" / "test_pandas.py"
+    copy.parent.mkdir(parents=True)
+    copy.write_text("")
+    assert discover_operation_dirs_on_disk(root=tmp_path) == set()

--- a/mloda/community/feature_groups/data_operations/tests/test_prefix_pattern_collisions.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_prefix_pattern_collisions.py
@@ -45,7 +45,10 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
 
+import pytest
+
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.community.feature_groups.data_operations.tests.test_framework_support_matrix import is_artifact_path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -238,18 +241,24 @@ def find_collisions(
     return collisions
 
 
-def discover_uncovered_families() -> list[str]:
-    """Dotted module paths of ``data_operations`` ``base.py`` files that define a
-    ``PREFIX_PATTERN`` but are absent from :data:`FAMILIES`."""
-    covered = {spec.module for spec in FAMILIES}
-    missing: list[str] = []
-    for base_py in DATA_OPERATIONS_ROOT.rglob("base.py"):
+def discover_family_base_modules(root: Path = DATA_OPERATIONS_ROOT, repo_root: Path = REPO_ROOT) -> set[str]:
+    """Dotted modules of every non-artifact ``base.py`` under *root* that defines a ``PREFIX_PATTERN``."""
+    modules: set[str] = set()
+    for base_py in root.rglob("base.py"):
+        rel = base_py.relative_to(repo_root)
+        if is_artifact_path(rel):
+            continue
         if not _PREFIX_DEF_RE.search(base_py.read_text()):
             continue
-        module = ".".join(base_py.relative_to(REPO_ROOT).with_suffix("").parts)
-        if module not in covered:
-            missing.append(module)
-    return sorted(missing)
+        modules.add(".".join(rel.with_suffix("").parts))
+    return modules
+
+
+def discover_uncovered_families(root: Path = DATA_OPERATIONS_ROOT, repo_root: Path = REPO_ROOT) -> list[str]:
+    """Dotted module paths of ``data_operations`` ``base.py`` files that define a
+    ``PREFIX_PATTERN`` but are absent from :data:`FAMILIES`. Build artifact copies are skipped."""
+    covered = {spec.module for spec in FAMILIES}
+    return sorted(discover_family_base_modules(root, repo_root) - covered)
 
 
 def _format_collision(collision: Collision) -> str:
@@ -539,6 +548,14 @@ def test_every_family_is_covered() -> None:
     )
 
 
+def test_every_family_module_is_discovered_on_disk() -> None:
+    missing = sorted({spec.module for spec in FAMILIES} - discover_family_base_modules())
+    assert missing == [], (
+        "These FAMILIES modules were not discovered on disk; an over-broad build-artifact skip "
+        "(is_artifact_path) would hide real family modules like this:\n  " + "\n  ".join(missing)
+    )
+
+
 # --- negative tests: prove the detectors actually fire ------------------------
 
 
@@ -578,3 +595,26 @@ def test_find_pattern_overlaps_detects_planted_overlap() -> None:
     overlaps = find_pattern_overlaps(patterns, specs)
     assert ("alpha", "col__op_zz", "beta") in overlaps
     assert all(owner != other for owner, _name, other in overlaps)
+
+
+def test_discover_uncovered_families_reports_planted_family(tmp_path: Path) -> None:
+    """A planted base.py defining a PREFIX_PATTERN under root is reported by its dotted path."""
+    base_py = tmp_path / "pkg" / "some_family" / "base.py"
+    base_py.parent.mkdir(parents=True)
+    base_py.write_text("PREFIX_PATTERN = r'__op$'\n")
+    uncovered = discover_uncovered_families(root=tmp_path / "pkg", repo_root=tmp_path)
+    assert uncovered == ["pkg.some_family.base"]
+
+
+@pytest.mark.parametrize("artifact_part", ["build", "dist", "something.egg-info", ".tox", ".venv"])
+def test_discover_uncovered_families_skips_build_artifact_dirs(tmp_path: Path, artifact_part: str) -> None:
+    """A base.py copy under a build artifact directory is not reported alongside the real module."""
+    body = "PREFIX_PATTERN = r'__op$'\n"
+    real = tmp_path / "pkg" / "some_family" / "base.py"
+    real.parent.mkdir(parents=True)
+    real.write_text(body)
+    copy = tmp_path / "pkg" / "some_family" / artifact_part / "lib" / "pkg" / "some_family" / "base.py"
+    copy.parent.mkdir(parents=True)
+    copy.write_text(body)
+    uncovered = discover_uncovered_families(root=tmp_path / "pkg", repo_root=tmp_path)
+    assert uncovered == ["pkg.some_family.base"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ namespaces = true
 [tool.pytest.ini_options]
 testpaths = ["tests", "mloda/**/tests"]
 pythonpath = ["."]
-addopts = "--import-mode=importlib"
+addopts = "--import-mode=importlib --ignore-glob=*/build/* --ignore-glob=*/dist/*"
 filterwarnings = [
     "error:The behavior of DataFrame concatenation with empty or all-NA entries:FutureWarning",
     "error:Mean of empty slice:RuntimeWarning",

--- a/tests/test_end2end/test_no_hashabledict_credentials.py
+++ b/tests/test_end2end/test_no_hashabledict_credentials.py
@@ -18,7 +18,7 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-_SKIP_DIRS = {"__pycache__", "site-packages", "node_modules"}
+_SKIP_DIRS = {"__pycache__", "site-packages", "node_modules", "build", "dist"}
 _MARKERS = ("credentials", "DataAccessCollection", "BaseInputData")
 
 
@@ -47,7 +47,7 @@ def find_hashabledict_credential_usages(root: Path) -> list[str]:
     hits: list[str] = []
     for path in list(root.rglob("*.py")) + list(root.rglob("*.md")):
         rel = path.relative_to(root)
-        if any(part.startswith(".") or part in _SKIP_DIRS for part in rel.parts):
+        if any(part.startswith(".") or part in _SKIP_DIRS or part.endswith(".egg-info") for part in rel.parts):
             continue
         if path.name == "test_no_hashabledict_credentials.py":
             continue
@@ -137,6 +137,14 @@ def test_md_prose_credential_hashabledict_not_flagged(tmp_path: Path) -> None:
     """A HashableDict + credentials mention only in .md prose (no fenced block) is not flagged."""
     body = "Previously you passed a HashableDict as credentials; now use Credential.\n"
     _write(tmp_path / "guide.md", body)
+    assert find_hashabledict_credential_usages(tmp_path) == []
+
+
+def test_build_artifact_dirs_not_scanned(tmp_path: Path) -> None:
+    """A flaggable file under a build artifact directory is not scanned."""
+    _write(tmp_path / "build" / "lib" / "m.py", "credentials=[HashableDict({'host': 'h'})]\n")
+    _write(tmp_path / "dist" / "m.py", "credentials=[HashableDict({'host': 'h'})]\n")
+    _write(tmp_path / "pkg.egg-info" / "m.py", "credentials=[HashableDict({'host': 'h'})]\n")
     assert find_hashabledict_credential_usages(tmp_path) == []
 
 

--- a/tests/test_end2end/test_no_named_form_string_credentials.py
+++ b/tests/test_end2end/test_no_named_form_string_credentials.py
@@ -21,7 +21,7 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-_SKIP_DIRS = {"__pycache__", "site-packages", "node_modules"}
+_SKIP_DIRS = {"__pycache__", "site-packages", "node_modules", "build", "dist"}
 
 # A credentials mapping opened right after a marker: ``credentials={`` or
 # ``add_credentials({``. The captured ``{`` opens the mapping at depth 1; a
@@ -108,7 +108,7 @@ def find_named_form_string_credential_usages(root: Path) -> list[str]:
     hits: list[str] = []
     for path in list(root.rglob("*.py")) + list(root.rglob("*.md")):
         rel = path.relative_to(root)
-        if any(part.startswith(".") or part in _SKIP_DIRS for part in rel.parts):
+        if any(part.startswith(".") or part in _SKIP_DIRS or part.endswith(".egg-info") for part in rel.parts):
             continue
         if path.name == "test_no_named_form_string_credentials.py":
             continue
@@ -217,6 +217,14 @@ def test_md_prose_named_form_string_not_flagged(tmp_path: Path) -> None:
     """A named-form string credential mention only in .md prose (no fenced block) is not flagged."""
     body = "Previously credentials={'prod': 'dsn-string'} was allowed; now use a nested mapping.\n"
     _write(tmp_path / "guide.md", body)
+    assert find_named_form_string_credential_usages(tmp_path) == []
+
+
+def test_build_artifact_dirs_not_scanned(tmp_path: Path) -> None:
+    """A flaggable file under a build artifact directory is not scanned."""
+    _write(tmp_path / "build" / "lib" / "m.py", "credentials={'prod': 'dsn-string'}\n")
+    _write(tmp_path / "dist" / "m.py", "credentials={'prod': 'dsn-string'}\n")
+    _write(tmp_path / "pkg.egg-info" / "m.py", "credentials={'prod': 'dsn-string'}\n")
     assert find_named_form_string_credential_usages(tmp_path) == []
 
 


### PR DESCRIPTION
## Summary

Running a local `uv build` leaves a gitignored `build/lib/...` source copy inside the package directory. The family-coverage walker reported that copy as a missing `FAMILIES` entry, so `tox` failed spuriously right after a build. Other tree walks shared the gap.

## Changes

- `discover_uncovered_families()` and `discover_operation_dirs_on_disk()` skip the same artifact directories `scripts/generate_pyproject.py` excludes (`build`, `dist`, `.tox`, `.venv`, `__pycache__`, `*.egg-info`), via a shared `is_artifact_path` predicate, and take an explicit root so tmp-tree tests can exercise them.
- The credential scan twins under `tests/test_end2end/` skip `build`, `dist` and `*.egg-info` as well.
- pytest ignores `*/build/*` and `*/dist/*` at collection: the `testpaths` glob `mloda/**/tests` expands artifact copies into direct args, which bypasses the default `norecursedirs`, so a tests-bearing artifact copy would otherwise be collected as phantom tests.
- The real-tree guardrails now assert coverage in both directions (every catalog operation has twin test dirs on disk, every registered family module is found by the walk), so an over-broad artifact skip fails loudly instead of passing vacuously.

## Verification

- Reproduced the failure on main with `uv build --package mloda-community-aggregation`, confirmed the suite stays green with the artifacts present after the fix, and that a planted tests-bearing `build/lib` copy is no longer collected.
- Full `tox` gate green: 4851 passed, ruff format, ruff check, mypy --strict, bandit.

Fixes #348.