### PR TITLE
fix(security): anchor bandit exclude globs so the verify build scripts are scanned

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,19 +73,33 @@ module = ["pyarrow.compute", "pyarrow.compute.*"]
 follow_imports = "skip"
 
 [tool.bandit]
+# Anchored globs, not bare names: bandit also substring-matches plain entries against the full path.
 exclude_dirs = [
-    "venv",
-    ".venv",
-    "migrations",
-    "__pycache__",
-    "build",
-    "dist",
-    ".devcontainer",
-    ".tox",
-    ".vscode",
-    "attribution",
+    "venv/*",
+    "*/venv/*",
+    ".venv/*",
+    "*/.venv/*",
+    "migrations/*",
+    "*/migrations/*",
+    "__pycache__/*",
+    "*/__pycache__/*",
+    "build/*",
+    "*/build/*",
+    "dist/*",
+    "*/dist/*",
+    ".devcontainer/*",
+    "*/.devcontainer/*",
+    ".tox/*",
+    "*/.tox/*",
+    ".vscode/*",
+    "*/.vscode/*",
+    "attribution/*",
+    "*/attribution/*",
     "*.egg-info",
-    "site-packages"
+    "*.egg-info/*",
+    "*/*.egg-info/*",
+    "site-packages/*",
+    "*/site-packages/*"
 ]
 skips = [
     "B101", # Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.

--- a/scripts/verify_build_floor.py
+++ b/scripts/verify_build_floor.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
+import subprocess  # nosec
 import sys
 import tempfile
 from pathlib import Path
@@ -69,7 +69,7 @@ def create_floor_env(venv: Path, floor: str) -> str | None:
         ["uv", "pip", "install", "--python", str(venv_python(venv)), f"setuptools=={floor}"],
     ]
     for command in commands:
-        result = subprocess.run(command, capture_output=True, text=True)
+        result = subprocess.run(command, capture_output=True, text=True)  # nosec
         if result.returncode != 0:
             return f"{' '.join(command)} failed:\n{result.stderr[-500:]}"
     return None
@@ -78,7 +78,7 @@ def create_floor_env(venv: Path, floor: str) -> str | None:
 def build_wheel_with(python: Path, pkg_dir: Path, out_dir: Path) -> subprocess.CompletedProcess[str]:
     """Build one package by calling the backend directly, so only the setuptools in ``python`` is used."""
     code = f"from setuptools import build_meta; build_meta.build_wheel({str(out_dir)!r})"
-    return subprocess.run([str(python), "-c", code], cwd=pkg_dir, capture_output=True, text=True)
+    return subprocess.run([str(python), "-c", code], cwd=pkg_dir, capture_output=True, text=True)  # nosec
 
 
 def main() -> int:

--- a/scripts/verify_builds.py
+++ b/scripts/verify_builds.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import configparser
 import re
 import shutil
-import subprocess
+import subprocess  # nosec
 import sys
 import tempfile
 import zipfile
@@ -340,7 +340,7 @@ def main() -> int:
 
         for pkg_name, _ in PACKAGES:
             print(f"\nBuilding {pkg_name}...")
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603 B607
                 ["uv", "build", "--package", pkg_name, "--out-dir", tmpdir, "--wheel", "--no-build-isolation"],
                 capture_output=True,
                 text=True,

--- a/tests/test_end2end/test_bandit_exclusions.py
+++ b/tests/test_end2end/test_bandit_exclusions.py
@@ -1,0 +1,127 @@
+"""The bandit gate (``bandit -c pyproject.toml -r -q .``) must scan scripts/verify_builds.py and
+scripts/verify_build_floor.py. Bandit applies each [tool.bandit] exclude_dirs entry both as an
+fnmatch glob and as a plain substring of the full path, so a bare entry like "build" silently drops
+every path containing that substring while genuine artifact directories must stay excluded."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+import pytest
+from bandit.core import config as b_config
+from bandit.core import constants as b_constants
+from bandit.core import manager as b_manager
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+# bandit/cli/main.py passes this -x/--exclude default into discover_files on top of exclude_dirs.
+_CLI_DEFAULT_EXCLUDES = ",".join(b_constants.EXCLUDE)
+
+# The real-world artifact the "build" entry exists for: setuptools mirrors sources into build/lib.
+_NESTED_BUILD_ARTIFACT = (
+    "mloda/community/feature_groups/data_operations/aggregation/build/lib/"
+    "mloda/community/feature_groups/data_operations/aggregation/base.py"
+)
+
+# Artifact paths the gate must keep excluding, in both bare and walk-style ("./") forms.
+_ARTIFACT_PATHS = [
+    _NESTED_BUILD_ARTIFACT,
+    "./" + _NESTED_BUILD_ARTIFACT,
+    "dist/mloda_registry-0.1.0/pkg/module.py",
+    ".venv/lib/python3.12/site-packages/module.py",
+    "__pycache__/module.py",
+    "pkg/dep.egg-info",
+    "migrations/0001_initial.py",
+    "./.devcontainer/setup.py",
+    ".vscode/settings.json",
+    "attribution/report.py",
+]
+
+
+def _discover(targets: list[str], config_file: Path | None) -> Any:
+    """BanditManager after file discovery, wired exactly like the CLI gate."""
+    conf = b_config.BanditConfig(config_file=str(config_file)) if config_file else b_config.BanditConfig()
+    mgr = b_manager.BanditManager(conf, "file")
+    mgr.discover_files(targets, True, _CLI_DEFAULT_EXCLUDES)
+    return mgr
+
+
+def _configured_exclude_dirs() -> list[str]:
+    """The [tool.bandit] exclude_dirs entries declared in the repo pyproject.toml."""
+    entries: list[str] = tomllib.loads(_PYPROJECT.read_text())["tool"]["bandit"]["exclude_dirs"]
+    return entries
+
+
+def test_gate_scans_the_verify_build_scripts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The two verify scripts must be discovered, not swallowed by a substring exclude."""
+    monkeypatch.chdir(_REPO_ROOT)
+    mgr = _discover(["scripts"], _PYPROJECT)
+    expected = {"scripts/verify_builds.py", "scripts/verify_build_floor.py"}
+    missing = expected - set(mgr.files_list)
+    dropped = [path for path in mgr.excluded_files if path.endswith(".py")]
+    assert not missing, (
+        f"the bandit gate never scans {sorted(missing)}: an exclude_dirs entry matches them as a plain "
+        f"substring of the path (excluded .py files: {dropped})"
+    )
+
+
+def test_gate_scans_the_verify_build_scripts_in_walk_form(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gate walks from ".", so the scripts surface as "./"-prefixed paths and must stay included."""
+    monkeypatch.chdir(_REPO_ROOT)
+    targets = ["./scripts/verify_builds.py", "./scripts/verify_build_floor.py"]
+    mgr = _discover(targets, _PYPROJECT)
+    dropped = set(targets) & set(mgr.excluded_files)
+    assert not dropped, f'an exclude_dirs entry matches the "./"-prefixed form the gate produces: {sorted(dropped)}'
+    # bandit re-anchors explicit file targets under "." before adding them to files_list.
+    missing = {"./" + target for target in targets} - set(mgr.files_list)
+    assert not missing, (
+        f"the verify scripts never landed in the scan list: {sorted(missing)} (files_list: {mgr.files_list})"
+    )
+
+
+def test_artifact_paths_stay_excluded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Build, dist, venv, pycache, and egg-info artifacts must stay out of the scan."""
+    monkeypatch.chdir(_REPO_ROOT)
+    mgr = _discover(list(_ARTIFACT_PATHS), _PYPROJECT)
+    for path in _ARTIFACT_PATHS:
+        assert path in mgr.excluded_files, f"{path} is an artifact path and must stay excluded from the gate"
+    assert not mgr.files_list, f"artifact paths leaked into the scan: {mgr.files_list}"
+
+
+def test_every_configured_exclude_entry_excludes_a_representative(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each exclude_dirs entry keeps rejecting a path derived from it."""
+    monkeypatch.chdir(_REPO_ROOT)
+    entries = _configured_exclude_dirs()
+    assert entries, "[tool.bandit] exclude_dirs vanished from pyproject.toml"
+
+    representatives = {
+        entry: entry.replace("*", "sample") if "*" in entry else f"{entry}/artifact.py" for entry in entries
+    }
+    mgr = _discover(list(representatives.values()), _PYPROJECT)
+    for entry, representative in representatives.items():
+        assert representative in mgr.excluded_files, (
+            f"exclude_dirs entry {entry!r} no longer excludes {representative!r}"
+        )
+
+
+def test_build_output_exclusion_comes_from_the_pyproject_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bandit defaults alone do not exclude build outputs; pyproject.toml must carry that entry."""
+    monkeypatch.chdir(_REPO_ROOT)
+    target = "mloda/x/build/lib/y.py"
+
+    with_config = _discover([target], _PYPROJECT)
+    assert target in with_config.excluded_files, f"{target} must be excluded by the pyproject bandit config"
+
+    without_config = _discover([target], None)
+    assert "./" + target in without_config.files_list, (
+        f"{target} is already excluded without the pyproject config; this guard no longer proves the "
+        "config carries the build-output exclusion"
+    )


### PR DESCRIPTION
## Summary

bandit applies plain `exclude_dirs` entries both as fnmatch globs and as substring matches against the full path. The bare entry `"build"` therefore silently excluded `scripts/verify_builds.py` and `scripts/verify_build_floor.py` from the `bandit -c pyproject.toml -r -q .` gate: they showed as scanned with 0 lines.

## Changes

- Every `[tool.bandit] exclude_dirs` entry is now a component-anchored glob in bare and nested forms (`build/*` plus `*/build/*`, and so on). Glob entries contain `*`, so bandit's substring branch can never match a source file name, while real artifact directories stay excluded in every path form the gate produces (`./`-prefixed walk paths, bare targets, nested trees).
- `scripts/verify_builds.py` and `scripts/verify_build_floor.py` are now scanned; their fixed-argv `subprocess` lines carry `nosec` markers matching `scripts/verify_floor_installs.py`, scoped to the exact checks where two fire on one line.
- New `tests/test_end2end/test_bandit_exclusions.py` drives bandit's own config and discovery in-process: the gate must scan the verify build scripts (in both path forms), genuine artifact paths must stay excluded (explicit representatives for every configured entry), and the build-output exclusion must come from the pyproject config rather than bandit defaults.

## Verification

- Copying `scripts/verify_builds.py` to a name without `build` in it previously surfaced B404/B603 immediately; the originals now report the same findings without the copy step (silenced with scoped nosec after triage).
- Full `tox` gate green: 4845 passed, ruff format, ruff check, mypy --strict, bandit exit 0.

Fixes #375.