### PR TITLE
fix(packaging): derive the tox verify lists from the configured package set

### DIFF
--- a/scripts/verify_extras.py
+++ b/scripts/verify_extras.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Install each internal extra and prove it gates exactly its members' imports.
+
+Internal extras are the non-dev extras of published packages whose members are configured package
+keys. ``{published_children}`` expands as the generator does; the shared default extras from
+config/shared.toml declare only ``dev``, which is skipped, so they are never merged here.
+
+Run: python scripts/verify_extras.py <version>
+Exit code: 1 if any member imports without its extra or fails to import with it, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import subprocess  # nosec
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The dev extra is tooling, never shipped code.
+DEV_EXTRA = "dev"
+
+
+def _load_sibling(name: str) -> ModuleType:
+    """Load a sibling scripts/ module by file path, so an arbitrary cwd cannot break the import."""
+    path = Path(__file__).resolve().parent / f"{name}.py"
+    if not path.exists():
+        raise ImportError(f"{path} is missing; {Path(__file__).name} derives its checks from it")
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def internal_extra_members(packages: dict[str, dict[str, Any]]) -> list[tuple[str, str, list[str]]]:
+    """(package, extra, members) per non-dev extra of a published package with configured members, in config order."""
+    expand: Callable[[dict[str, Any], dict[str, dict[str, Any]]], dict[str, list[str]]] = _load_sibling(
+        "generate_pyproject"
+    ).expand_published_children
+    entries: list[tuple[str, str, list[str]]] = []
+    for pkg_name, pkg_config in packages.items():
+        if pkg_config.get("published") is not True:
+            continue
+        expanded = expand(pkg_config, packages)
+        for extra, deps in expanded.items():
+            if extra == DEV_EXTRA:
+                continue
+            members = [dep for dep in deps if dep in packages]
+            if members:
+                entries.append((pkg_name, extra, members))
+    return entries
+
+
+def _install_and_probe(
+    specifier: str,
+    owner_modules: tuple[str, ...],
+    expect_import: bool,
+    member_modules: dict[str, str],
+    tmpdir: str,
+) -> list[str]:
+    """Install one specifier into a fresh venv, probe the owner's surface, then check every member."""
+    from verify_build_floor import venv_python
+
+    venv = Path(tmpdir) / "venv"
+    setup = [
+        ["uv", "venv", "--python", sys.executable, str(venv)],
+        ["uv", "pip", "install", "--python", str(venv_python(venv)), specifier],
+    ]
+    for command in setup:
+        # cwd is the temp dir, so the checkout cannot shadow the installed packages.
+        result = subprocess.run(command, capture_output=True, text=True, cwd=tmpdir)  # nosec
+        if result.returncode != 0:
+            return [f"{specifier}: {' '.join(command)} failed:\n{result.stderr[-500:]}"]
+
+    errors: list[str] = []
+    # The owning package itself must import with and without its extra.
+    for module in owner_modules:
+        command = [str(venv_python(venv)), "-c", f"import {module}"]
+        result = subprocess.run(command, capture_output=True, text=True, cwd=tmpdir)  # nosec
+        if result.returncode != 0:
+            errors.append(f"{specifier}: import {module} failed:\n{result.stderr[-500:]}")
+        else:
+            print(f"  ✓ base package OK: {module}")
+    for member, module in member_modules.items():
+        command = [str(venv_python(venv)), "-c", f"import {module}"]
+        result = subprocess.run(command, capture_output=True, text=True, cwd=tmpdir)  # nosec
+        if expect_import:
+            if result.returncode == 0:
+                print(f"  ✓ {member}: imports")
+            else:
+                errors.append(f"{specifier}: import {module} failed:\n{result.stderr[-500:]}")
+        elif result.returncode == 0:
+            errors.append(f"{specifier}: {member} ({module}) imports without the extra")
+        elif "ModuleNotFoundError" in result.stderr and f"'{module}'" in result.stderr:
+            # Only a ModuleNotFoundError naming the member proves the extra gates it; anything
+            # else (a broken parent, a SyntaxError, a crashed interpreter) is a real failure.
+            print(f"  ✓ {member}: correctly not installed")
+        else:
+            errors.append(
+                f"{specifier}: import {module} failed, but not with ModuleNotFoundError for "
+                f"{module}:\n{result.stderr[-500:]}"
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify each internal extra gates exactly its members' imports")
+    parser.add_argument("version", nargs="?", default="", help="Released version to install every package at")
+    args = parser.parse_args()
+
+    # tox renders an empty argument when MLODA_REGISTRY_VERSION is unset.
+    if not args.version.strip():
+        parser.error("version must not be empty (is MLODA_REGISTRY_VERSION set?)")
+
+    # The reused published_packages helper resolves the config relative to cwd.
+    os.chdir(REPO_ROOT)
+    from published_packages import load_packages_config
+
+    packages = load_packages_config()
+    entries = internal_extra_members(packages)
+
+    # An empty set would silently verify nothing.
+    if not entries:
+        print("❌ config/packages.toml declares no internal extras")
+        return 1
+
+    # The single derivation point for import surfaces lives in verify_published_imports.
+    surface: Callable[[str], tuple[str, ...]] = _load_sibling("verify_published_imports").import_surface
+
+    errors: list[str] = []
+    for package, extra, members in entries:
+        owner_modules = surface(str(packages[package]["path"]))
+        member_modules = {member: str(packages[member]["path"]).replace("/", ".") for member in members}
+        bare = (f"{package}=={args.version}", False)
+        gated = (f"{package}[{extra}]=={args.version}", True)
+        for specifier, expect_import in (bare, gated):
+            print(f"\nInstalling {specifier}...")
+            with tempfile.TemporaryDirectory() as tmpdir:
+                errors.extend(_install_and_probe(specifier, owner_modules, expect_import, member_modules, tmpdir))
+
+    if errors:
+        print("\n❌ Errors:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"\n✅ every internal extra gates exactly its members at {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_independent_installs.py
+++ b/scripts/verify_independent_installs.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Install each top-level distribution into its own venv and probe its full import surface.
+
+A nested package is covered through its parent's install, so only the published top of the
+configured layout installs independently. The bundle wheels ship all nested code, so each probe
+covers every configured package nested under the distribution's path: a payload-less wheel fails.
+
+Run: python scripts/verify_independent_installs.py <version>
+Exit code: 1 if any distribution fails to install or import on its own, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import subprocess  # nosec
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_sibling(name: str) -> ModuleType:
+    """Load a sibling scripts/ module by file path, so an arbitrary cwd cannot break the import."""
+    path = Path(__file__).resolve().parent / f"{name}.py"
+    if not path.exists():
+        raise ImportError(f"{path} is missing; {Path(__file__).name} derives its checks from it")
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def top_level_distributions(packages: dict[str, dict[str, Any]]) -> list[str]:
+    """Published packages whose path sits under no other configured package's path, in config order."""
+    # The trailing slash keeps the prefix check segment-aware: mloda/test never covers mloda/testing.
+    prefixes = [str(pkg_config["path"]).rstrip("/") + "/" for pkg_config in packages.values()]
+    return [
+        name
+        for name, pkg_config in packages.items()
+        if pkg_config.get("published") is True
+        # The package's own path is normalized too, so a trailing-slash path cannot self-exclude.
+        and not any(str(pkg_config["path"]).rstrip("/").startswith(prefix) for prefix in prefixes)
+    ]
+
+
+def probe_modules(name: str, packages: dict[str, dict[str, Any]]) -> list[str]:
+    """The distribution's own import surface plus every nested configured package's, in config order."""
+    # The single derivation point for import surfaces lives in verify_published_imports.
+    surface: Callable[[str], tuple[str, ...]] = _load_sibling("verify_published_imports").import_surface
+    path = str(packages[name]["path"]).rstrip("/")
+    modules = list(surface(path))
+    prefix = path + "/"
+    for pkg_config in packages.values():
+        nested = str(pkg_config["path"]).rstrip("/")
+        if nested.startswith(prefix):
+            modules.extend(surface(nested))
+    return modules
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Install each top-level distribution into its own venv")
+    parser.add_argument("version", nargs="?", default="", help="Released version to install every distribution at")
+    args = parser.parse_args()
+
+    # tox renders an empty argument when MLODA_REGISTRY_VERSION is unset.
+    if not args.version.strip():
+        parser.error("version must not be empty (is MLODA_REGISTRY_VERSION set?)")
+
+    # The reused published_packages helper resolves the config relative to cwd.
+    os.chdir(REPO_ROOT)
+    from published_packages import load_packages_config
+    from verify_build_floor import venv_python
+
+    packages = load_packages_config()
+    names = top_level_distributions(packages)
+
+    # An empty set would silently verify nothing.
+    if not names:
+        print("❌ config/packages.toml declares no published top-level packages")
+        return 1
+
+    errors: list[str] = []
+    for name in names:
+        modules = probe_modules(name, packages)
+        print(f"\nInstalling {name}=={args.version} independently...")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv = Path(tmpdir) / "venv"
+            # One import statement per probed module: the distribution's own surface plus its nested ones.
+            imports = "\n".join(f"import {module}" for module in modules)
+            commands = [
+                ["uv", "venv", "--python", sys.executable, str(venv)],
+                ["uv", "pip", "install", "--python", str(venv_python(venv)), f"{name}=={args.version}"],
+                [str(venv_python(venv)), "-c", imports],
+            ]
+            for command in commands:
+                # cwd is the temp dir, so the checkout cannot shadow the installed packages.
+                result = subprocess.run(command, capture_output=True, text=True, cwd=tmpdir)  # nosec
+                if result.returncode != 0:
+                    errors.append(f"{name}: {' '.join(command)} failed:\n{result.stderr[-500:]}")
+                    break
+            else:
+                print(f"  ✓ import surface loads ({len(modules)} modules)")
+
+    if errors:
+        print("\n❌ Errors:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"\n✅ every top-level distribution installs and its import surface loads independently at {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_published_imports.py
+++ b/scripts/verify_published_imports.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Smoke-import every configured package inside the venv holding the released set.
+
+Every configured package ships in some wheel, so every import surface (the dotted root plus its
+base module when the checkout ships a base.py) gets probed.
+
+Run: python scripts/verify_published_imports.py <venv-python>
+Exit code: 1 if any module fails to import, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess  # nosec
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def import_surface(path: str) -> tuple[str, ...]:
+    """The dotted package root, plus its base module when <path>/base.py exists in the checkout."""
+    root = path.replace("/", ".")
+    # Most leaf __init__.py files are empty and the cross-package imports live in the leaf's base
+    # module, so importing only the root is vacuous. Resolve against the checkout, never the cwd.
+    if (REPO_ROOT / path / "base.py").exists():
+        return (root, f"{root}.base")
+    return (root,)
+
+
+def import_modules(packages: dict[str, dict[str, Any]]) -> list[str]:
+    """The import surface of every configured package, in config order (roots plus base modules)."""
+    modules: list[str] = []
+    for pkg_config in packages.values():
+        modules.extend(import_surface(str(pkg_config["path"])))
+    return modules
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Smoke-import every configured package inside a venv")
+    parser.add_argument("venv_python", nargs="?", default="", help="Interpreter of the venv holding the released set")
+    args = parser.parse_args()
+
+    # tox renders an empty argument when the interpolated value is unset.
+    if not args.venv_python.strip():
+        parser.error("venv_python must not be empty")
+
+    # Anchor to the invocation cwd before the chdir below; abspath keeps the venv symlink unresolved.
+    interpreter = os.path.abspath(args.venv_python)
+
+    # The reused published_packages helper resolves the config relative to cwd.
+    os.chdir(REPO_ROOT)
+    from published_packages import load_packages_config
+
+    modules = import_modules(load_packages_config())
+
+    # An empty set would silently verify nothing.
+    if not modules:
+        print("❌ config/packages.toml declares no packages")
+        return 1
+
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for module in modules:
+            command = [interpreter, "-c", f"import {module}"]
+            # cwd is the temp dir, so the checkout cannot shadow the installed packages.
+            result = subprocess.run(command, capture_output=True, text=True, cwd=tmpdir)  # nosec
+            if result.returncode != 0:
+                errors.append(f"import {module} failed:\n{result.stderr[-500:]}")
+                continue
+            print(f"  ✓ {module} OK")
+
+    if errors:
+        print("\n❌ Errors:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"\n✅ the full import surface ({len(modules)} modules) imports from the installed released set")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_end2end/test_published_set_single_source.py
+++ b/tests/test_end2end/test_published_set_single_source.py
@@ -35,6 +35,9 @@ _SHARED_CONFIG = _REPO_ROOT / "config" / "shared.toml"
 _PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
 _GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
 _PUBLISHED_SCRIPT = _REPO_ROOT / "scripts" / "published_packages.py"
+_IMPORTS_SCRIPT = _REPO_ROOT / "scripts" / "verify_published_imports.py"
+_INDEPENDENT_SCRIPT = _REPO_ROOT / "scripts" / "verify_independent_installs.py"
+_EXTRAS_SCRIPT = _REPO_ROOT / "scripts" / "verify_extras.py"
 _RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yaml"
 _TOX_INI = _REPO_ROOT / "tox.ini"
 
@@ -97,7 +100,27 @@ _TOX_PUBLISHED_ENVS = ["verify-published", "security"]
 # The tox env that import-checks every installed distribution.
 _VERIFY_PUBLISHED_ENV = "verify-published"
 
+# The tox env that installs each top-level distribution into its own venv.
+_INDEPENDENT_ENV = "verify-published-independent"
+
+# The tox env that installs internal extras and import-checks their members.
+_EXTRAS_ENV = "verify-extras"
+
+# Every tox env that installs distributions by name; none may hand-type them.
+_TOX_DERIVED_SET_ENVS = [*_TOX_PUBLISHED_ENVS, _INDEPENDENT_ENV, _EXTRAS_ENV]
+
 _SCRIPT_INVOCATION = "scripts/published_packages.py"
+
+_IMPORTS_INVOCATION = "scripts/verify_published_imports.py"
+_INDEPENDENT_INVOCATION = "scripts/verify_independent_installs.py"
+_EXTRAS_INVOCATION = "scripts/verify_extras.py"
+
+# Each PyPI-verifying env with the config-derived script that carries its checks.
+_TOX_VERIFY_SCRIPTS = [
+    (_VERIFY_PUBLISHED_ENV, _IMPORTS_INVOCATION),
+    (_INDEPENDENT_ENV, _INDEPENDENT_INVOCATION),
+    (_EXTRAS_ENV, _EXTRAS_INVOCATION),
+]
 
 _BUILD_STEP = "Build packages"
 
@@ -133,6 +156,12 @@ def _dotted_path(pkg_name: str) -> str:
     return path.replace("/", ".")
 
 
+def _expected_surface(path: str) -> list[str]:
+    """The import surface of a package path: the dotted root plus base when the checkout ships base.py."""
+    dotted = path.replace("/", ".")
+    return [dotted, f"{dotted}.base"] if (_REPO_ROOT / path / "base.py").exists() else [dotted]
+
+
 def _published_children() -> list[str]:
     """Published packages nested under the data-operations path, in config order."""
     packages = _packages()
@@ -155,6 +184,50 @@ def _published_packages_fn() -> Callable[[dict[str, dict[str, Any]]], list[str]]
     )
     assert callable(reader), "published_packages.published_packages must be a callable"
     return reader
+
+
+def _script_fn(path: Path, attr: str, purpose: str) -> Callable[..., Any]:
+    """A callable exposed by a config-derived verify script."""
+    assert path.exists(), f"{path} is missing; it must {purpose}"
+    fn: Callable[..., Any] | None = getattr(load_script(path.stem, path), attr, None)
+    assert callable(fn), f"{path.name} must expose a callable {attr}"
+    return fn
+
+
+def _import_modules(packages: dict[str, dict[str, Any]]) -> list[str]:
+    """The smoke-import list verify_published_imports derives from a config."""
+    modules: list[str] = _script_fn(
+        _IMPORTS_SCRIPT, "import_modules", "derive one smoke import per configured package from config/packages.toml"
+    )(packages)
+    return modules
+
+
+def _top_level_distributions(packages: dict[str, dict[str, Any]]) -> list[str]:
+    """The independently installed distributions verify_independent_installs derives from a config."""
+    names: list[str] = _script_fn(
+        _INDEPENDENT_SCRIPT,
+        "top_level_distributions",
+        "derive the independently installed distributions from config/packages.toml",
+    )(packages)
+    return names
+
+
+def _probe_modules(name: str, packages: dict[str, dict[str, Any]]) -> list[str]:
+    """The modules verify_independent_installs probes after installing one distribution on its own."""
+    modules: list[str] = _script_fn(
+        _INDEPENDENT_SCRIPT,
+        "probe_modules",
+        "derive the import surface each independent install probes from config/packages.toml",
+    )(name, packages)
+    return modules
+
+
+def _internal_extra_entries(packages: dict[str, dict[str, Any]]) -> list[tuple[str, str, list[str]]]:
+    """The (package, extra, members) entries verify_extras derives from a config, normalized to tuples."""
+    entries = _script_fn(
+        _EXTRAS_SCRIPT, "internal_extra_members", "derive the internal extras to verify from config/packages.toml"
+    )(packages)
+    return [(package, extra, list(members)) for package, extra, members in entries]
 
 
 def _cli(monkeypatch: pytest.MonkeyPatch, cwd: Path, argv: list[str]) -> Callable[[], int]:
@@ -384,13 +457,13 @@ def test_release_workflow_builds_from_the_published_script() -> None:
     )
 
 
-@pytest.mark.parametrize("env_name", _TOX_PUBLISHED_ENVS)
+@pytest.mark.parametrize("env_name", _TOX_DERIVED_SET_ENVS)
 def test_tox_env_names_no_distribution_itself(env_name: str) -> None:
-    """tox must not re-type the released set to install it, pinned or unpinned."""
+    """tox must not re-type any distribution name; every installed set is derived from the config."""
     names = sorted(set(_DISTRIBUTION_NAME_RE.findall(_tox_block(env_name))))
     assert names == [], (
         f"tox.ini [testenv:{env_name}] names {len(names)} distribution(s) by hand, starting with "
-        f"{names[:3]}; build the list from 'python {_SCRIPT_INVOCATION} --pin ...' instead."
+        f"{names[:3]}; derive the list from config/packages.toml through a scripts/ helper instead."
     )
 
 
@@ -398,9 +471,197 @@ def test_tox_env_names_no_distribution_itself(env_name: str) -> None:
 def test_verify_published_imports_every_published_distribution(pkg_name: str) -> None:
     """Installing the released set proves nothing about importing it, so every distribution needs a smoke import."""
     dotted = _dotted_path(pkg_name)
-    assert dotted in _tox_block(_VERIFY_PUBLISHED_ENV), (
-        f"tox.ini [testenv:{_VERIFY_PUBLISHED_ENV}] never imports {dotted}, so {pkg_name} is installed "
-        "from PyPI and never import-checked; add a smoke import line for it."
+    assert dotted in _import_modules(_packages()), (
+        f"verify_published_imports.import_modules() never yields {dotted}, so {pkg_name} is installed "
+        "from PyPI and never import-checked."
+    )
+
+
+@pytest.mark.parametrize("pkg_name", _BUNDLE_ONLY)
+def test_verify_published_imports_every_bundle_only_package(pkg_name: str) -> None:
+    """Bundle-only code has no wheel of its own, so its smoke import is what proves the bundles carry it."""
+    dotted = _dotted_path(pkg_name)
+    assert dotted in _import_modules(_packages()), (
+        f"verify_published_imports.import_modules() never yields {dotted}, so nothing proves the bundle "
+        f"wheels carry the {pkg_name} code."
+    )
+
+
+def test_import_modules_covers_every_configured_package_in_config_order() -> None:
+    """Every configured package ships in some wheel, so its whole import surface gets a smoke import."""
+    packages = _packages()
+    expected = [module for cfg in packages.values() for module in _expected_surface(cfg["path"])]
+    modules = _import_modules(packages)
+    assert modules == expected, (
+        f"import_modules() returned {modules!r}, expected the import surface (root plus base module "
+        f"where <path>/base.py exists) of every configured package in config order {expected!r}"
+    )
+
+
+@pytest.mark.parametrize(("env_name", "script"), _TOX_VERIFY_SCRIPTS)
+def test_tox_verify_env_runs_its_config_derived_script(env_name: str, script: str) -> None:
+    """Each PyPI-verifying env invokes the config-reading script with an argument, not in a comment."""
+    invocation = re.compile(rf"^[^\n;#]*{re.escape(script)}\s+\S", re.MULTILINE)
+    assert invocation.search(_tox_block(env_name)) is not None, (
+        f"tox.ini [testenv:{env_name}] does not invoke {script} with an argument on a non-comment "
+        "line, so its checks are a hand-written copy of the configured package set."
+    )
+
+
+def test_top_level_distributions_are_the_bundles() -> None:
+    """On the real config only the bundle distributions sit at the top of the package layout."""
+    names = _top_level_distributions(_packages())
+    assert names == _BUNDLES, (
+        f"top_level_distributions() returned {names!r}, expected the bundle distributions in config order {_BUNDLES!r}"
+    )
+
+
+def test_top_level_distributions_follows_the_config() -> None:
+    """A new top-level package joins the independent installs without any hand-edited list."""
+    packages = deepcopy(_packages())
+    packages["mloda-extras"] = {"description": "sandbox", "path": "mloda/extras", "published": True}
+
+    names = _top_level_distributions(packages)
+
+    assert names == [*_BUNDLES, "mloda-extras"], (
+        f"top_level_distributions() returned {names!r}; a configured package whose path sits under no "
+        "other configured package's path must be installed independently."
+    )
+
+
+def test_top_level_distributions_never_includes_a_nested_package() -> None:
+    """A nested package is covered through its parent's install, never as an independent top-level one."""
+    packages: dict[str, dict[str, Any]] = {
+        "mloda-registry": {"description": "sandbox", "path": "mloda/registry", "published": True},
+        "mloda-registry-child": {"description": "sandbox", "path": "mloda/registry/child", "published": True},
+    }
+
+    names = _top_level_distributions(packages)
+
+    assert names == ["mloda-registry"], (
+        f"top_level_distributions() returned {names!r}; a package whose path sits under another "
+        "configured package's path is never an independent top-level install."
+    )
+
+
+def test_top_level_distributions_excludes_an_unpublished_top_level_package() -> None:
+    """Only the released set installs from PyPI, so an unpublished top-level package has no wheel to probe."""
+    packages: dict[str, dict[str, Any]] = {
+        "mloda-registry": {"description": "sandbox", "path": "mloda/registry", "published": True},
+        "mloda-sandbox": {"description": "sandbox", "path": "mloda/sandbox"},
+    }
+
+    names = _top_level_distributions(packages)
+
+    assert names == ["mloda-registry"], (
+        f"top_level_distributions() returned {names!r}; a top-level package without 'published = true' "
+        "ships no wheel, so it can never be installed independently."
+    )
+
+
+def test_top_level_distributions_keeps_a_trailing_slash_path() -> None:
+    """A trailing-slash path equals its own prefix string, so it must not exclude itself."""
+    packages: dict[str, dict[str, Any]] = {
+        "mloda-registry": {"description": "sandbox", "path": "mloda/registry/", "published": True},
+    }
+
+    names = _top_level_distributions(packages)
+
+    assert names == ["mloda-registry"], (
+        f"top_level_distributions() returned {names!r}; a package path with a trailing slash starts "
+        "with its own prefix, so the comparison must normalize the path before checking."
+    )
+
+
+def test_every_unpublished_package_is_nested_under_an_entry_point_bundle() -> None:
+    """import_modules() probes every configured package in the released venv; an unpublished package
+    only reaches that venv inside a bundle wheel, so none may sit outside every bundle path."""
+    packages = _packages()
+    bundle_prefixes = [cfg["path"] + "/" for cfg in packages.values() if cfg.get("entry_point_bundle") is True]
+    stranded = [
+        name
+        for name, cfg in packages.items()
+        if not cfg.get("published") and not any(cfg["path"].startswith(prefix) for prefix in bundle_prefixes)
+    ]
+    assert stranded == [], (
+        f"configured packages {stranded} are neither published nor nested under a package flagged "
+        "'entry_point_bundle = true'; no wheel ships their code, so the verify-published smoke "
+        "imports would fail for them."
+    )
+
+
+@pytest.mark.parametrize("bundle", _ENTRY_POINT_BUNDLES)
+def test_probe_modules_covers_every_surface_nested_under_a_bundle(bundle: str) -> None:
+    """The bundle wheels ship all nested code, so a payload-less bundle wheel must fail the probe."""
+    packages = _packages()
+    prefix = packages[bundle]["path"] + "/"
+    nested = [name for name, cfg in packages.items() if cfg["path"].startswith(prefix)]
+    assert nested, f"fixture assumption: {bundle} has configured packages nested under {prefix}"
+    expected = [module for name in [bundle, *nested] for module in _expected_surface(packages[name]["path"])]
+
+    modules = _probe_modules(bundle, packages)
+
+    assert modules == expected, (
+        f"probe_modules({bundle!r}) returned {modules!r}, expected its own import surface plus every "
+        f"nested configured package's surface in config order {expected!r}"
+    )
+
+
+def test_probe_modules_for_a_top_level_leaf_is_its_own_surface() -> None:
+    """A distribution with nothing nested under its path probes exactly its own import surface."""
+    packages = _packages()
+
+    modules = _probe_modules("mloda-registry", packages)
+
+    expected = _expected_surface(packages["mloda-registry"]["path"])
+    assert modules == expected, (
+        f"probe_modules('mloda-registry') returned {modules!r}, expected only its own import surface {expected!r}"
+    )
+
+
+def test_internal_extra_members_yields_exactly_the_internal_extras() -> None:
+    """The extras that pull in configured packages are the only ones verify-extras must exercise."""
+    entries = _internal_extra_entries(_packages())
+    expected = [
+        (_COMMUNITY_EXAMPLE, "all", ["mloda-community-example-a", _EXAMPLE_B]),
+        (_DATA_OPERATIONS, "all", _published_children()),
+    ]
+    assert entries == expected, f"internal_extra_members() yielded {entries!r}, expected exactly {expected!r}"
+
+
+def test_internal_extra_members_always_skips_the_dev_extra() -> None:
+    """The dev extra is tooling, never shipped code, so it is skipped even when it names a configured package."""
+    packages: dict[str, dict[str, Any]] = {
+        "mloda-registry": {
+            "description": "sandbox",
+            "path": "mloda/registry",
+            "published": True,
+            "optional_dependencies": {"dev": ["mloda-testing"], "all": ["mloda-testing"]},
+        },
+        "mloda-testing": {"description": "sandbox", "path": "mloda/testing", "published": True},
+    }
+
+    entries = _internal_extra_entries(packages)
+
+    assert entries == [("mloda-registry", "all", ["mloda-testing"])], (
+        f"internal_extra_members() yielded {entries!r}; the dev extra must never be verified, even when "
+        "it lists a configured package."
+    )
+
+
+def test_internal_extra_members_drops_external_names() -> None:
+    """External extras (pyarrow, pandas, ...) resolve on PyPI anyway; only internal members need the check."""
+    packages = _packages()
+    entries = _internal_extra_entries(packages)
+    stray = sorted({member for _, _, members in entries for member in members if member not in packages})
+    assert stray == [], (
+        f"internal_extra_members() yielded external names {stray} as members; only configured package "
+        "names can be import-checked through their dotted paths."
+    )
+    named = sorted({package for package, _, _ in entries})
+    assert "mloda-community-aggregation" not in named, (
+        "internal_extra_members() yielded mloda-community-aggregation, whose non-dev extras list only "
+        "external names; a package with no internal members has nothing to verify."
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -114,39 +114,12 @@ skip_install = true
 # tomli: nothing else here provides it, and Python 3.10 has no tomllib.
 deps =
     tomli
-allowlist_externals = sh, uv, rm
+allowlist_externals = sh
 commands =
     sh -c 'uv cache clean'
     sh -c 'rm -rf /tmp/mloda-verify && uv venv /tmp/mloda-verify'
     sh -c 'VIRTUAL_ENV=/tmp/mloda-verify uv pip install $(python scripts/published_packages.py --pin {env:MLODA_REGISTRY_VERSION})'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.registry import discover, search; print(\"mloda.registry OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.testing import FeatureGroupTestBase; print(\"mloda.testing OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.community.feature_groups.example import CommunityExampleFeatureGroup; print(\"mloda.community.example OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.community.feature_groups.example.example_a import ExampleAFeatureGroup; print(\"mloda.community.example_a OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.enterprise.feature_groups.example import EnterpriseExampleFeatureGroup; print(\"mloda.enterprise.example OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.community.compute_frameworks.example import CommunityExampleComputeFramework; print(\"mloda.community.compute_frameworks.example OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.community.extenders.example import CommunityExampleExtender; print(\"mloda.community.extenders.example OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.enterprise.compute_frameworks.example import EnterpriseExampleComputeFramework; print(\"mloda.enterprise.compute_frameworks.example OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "from mloda.enterprise.extenders.example import EnterpriseExampleExtender; print(\"mloda.enterprise.extenders.example OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations; print(\"mloda.community.data_operations OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.aggregation; print(\"mloda.community.aggregation OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.rank; print(\"mloda.community.rank OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.offset; print(\"mloda.community.offset OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.window_aggregation; print(\"mloda.community.window_aggregation OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate; print(\"mloda.community.frame_aggregate OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate; print(\"mloda.community.scalar_aggregate OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic; print(\"mloda.community.scalar_arithmetic OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.point_arithmetic; print(\"mloda.community.point_arithmetic OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.datetime; print(\"mloda.community.datetime OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.string; print(\"mloda.community.string OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.binning; print(\"mloda.community.binning OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.percentile; print(\"mloda.community.percentile OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.time_bucketization; print(\"mloda.community.time_bucketization OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.ffill; print(\"mloda.community.ffill OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.ema; print(\"mloda.community.ema OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_preserving.sessionization; print(\"mloda.community.sessionization OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify/bin/python -c "import mloda.community.feature_groups.data_operations.row_changing.resample; print(\"mloda.community.resample OK\")"'
-    sh -c 'echo "=== All packages verified ==="'
+    python scripts/verify_published_imports.py /tmp/mloda-verify/bin/python
 
 [testenv:verify-floor-installs]
 description = Verify each package's import surface loads with its internal dependency pinned to the declared floor
@@ -171,49 +144,25 @@ commands =
 
 [testenv:verify-extras]
 description = Verify optional dependencies install correctly
-# Needs skip_install, which the lock runner ignores.
+# Needs deps and skip_install, which the lock runner ignores.
 runner = uv-venv-runner
 skip_install = true
-allowlist_externals = sh, uv, rm
+# tomli: nothing else here provides it, and Python 3.10 has no tomllib.
+deps =
+    tomli
 commands =
-    ; Test mloda-community-example base package (without extras)
-    sh -c 'rm -rf /tmp/mloda-verify-base && uv venv /tmp/mloda-verify-base'
-    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify-base uv pip install mloda-community-example=={env:MLODA_REGISTRY_VERSION}'
-    sh -c 'cd /tmp && /tmp/mloda-verify-base/bin/python -c "from mloda.community.feature_groups.example import CommunityExampleFeatureGroup; print(\"base package OK\")"'
-    ; Verify example_a is NOT installed with base (requires [all] extra)
-    sh -c 'cd /tmp && /tmp/mloda-verify-base/bin/python -c "from mloda.community.feature_groups.example.example_a import ExampleAFeatureGroup" 2>/dev/null && { echo "ERROR: example_a should NOT be installed with base"; exit 1; } || echo "example_a correctly NOT installed with base"'
-    ; Test mloda-community-example[all] installs example_a and example_b
-    sh -c 'rm -rf /tmp/mloda-verify-all && uv venv /tmp/mloda-verify-all'
-    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify-all uv pip install "mloda-community-example[all]=={env:MLODA_REGISTRY_VERSION}"'
-    sh -c 'cd /tmp && /tmp/mloda-verify-all/bin/python -c "from mloda.community.feature_groups.example import CommunityExampleFeatureGroup; print(\"base with [all] OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify-all/bin/python -c "from mloda.community.feature_groups.example.example_a import ExampleAFeatureGroup; print(\"example_a with [all] OK\")"'
-    sh -c 'cd /tmp && /tmp/mloda-verify-all/bin/python -c "from mloda.community.feature_groups.example.example_b import ExampleBFeatureGroup; print(\"example_b with [all] OK\")"'
-    sh -c 'echo "=== Optional dependencies verified ==="'
+    python scripts/verify_extras.py {env:MLODA_REGISTRY_VERSION}
 
 [testenv:verify-published-independent]
 description = Verify each package installs and imports independently
-# Needs skip_install, which the lock runner ignores.
+# Needs deps and skip_install, which the lock runner ignores.
 runner = uv-venv-runner
 skip_install = true
-allowlist_externals = sh, uv, rm
+# tomli: nothing else here provides it, and Python 3.10 has no tomllib.
+deps =
+    tomli
 commands =
-    ; Test mloda-registry independently
-    sh -c 'rm -rf /tmp/mloda-verify-registry && uv venv /tmp/mloda-verify-registry'
-    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify-registry uv pip install mloda-registry=={env:MLODA_REGISTRY_VERSION}'
-    sh -c 'cd /tmp && /tmp/mloda-verify-registry/bin/python -c "from mloda.registry import discover, search; print(\"mloda-registry independent OK\")"'
-    ; Test mloda-testing independently
-    sh -c 'rm -rf /tmp/mloda-verify-testing && uv venv /tmp/mloda-verify-testing'
-    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify-testing uv pip install mloda-testing=={env:MLODA_REGISTRY_VERSION}'
-    sh -c 'cd /tmp && /tmp/mloda-verify-testing/bin/python -c "from mloda.testing import FeatureGroupTestBase; print(\"mloda-testing independent OK\")"'
-    ; Test mloda-community independently (without enterprise)
-    sh -c 'rm -rf /tmp/mloda-verify-community && uv venv /tmp/mloda-verify-community'
-    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify-community uv pip install mloda-community=={env:MLODA_REGISTRY_VERSION}'
-    sh -c 'cd /tmp && /tmp/mloda-verify-community/bin/python -c "from mloda.community.feature_groups.example import CommunityExampleFeatureGroup; print(\"mloda-community independent OK\")"'
-    ; Test mloda-enterprise independently (without community)
-    sh -c 'rm -rf /tmp/mloda-verify-enterprise && uv venv /tmp/mloda-verify-enterprise'
-    sh -c 'VIRTUAL_ENV=/tmp/mloda-verify-enterprise uv pip install mloda-enterprise=={env:MLODA_REGISTRY_VERSION}'
-    sh -c 'cd /tmp && /tmp/mloda-verify-enterprise/bin/python -c "from mloda.enterprise.feature_groups.example import EnterpriseExampleFeatureGroup; print(\"mloda-enterprise independent OK\")"'
-    sh -c 'echo "=== All packages verified independently ==="'
+    python scripts/verify_independent_installs.py {env:MLODA_REGISTRY_VERSION}
 
 [testenv:security]
 description = CVE scanning of published packages


### PR DESCRIPTION
## Summary

Three tox blocks re-typed the released set by hand: the `verify-published` import smoke lines, the four bundle names in `verify-published-independent`, and `mloda-community-example` in `verify-extras`. A new package could ship without ever being verified, and the bundle set was frozen at four names. Adding a package to the released set now requires no tox.ini edit.

## Changes

- `scripts/verify_published_imports.py`: probes the import surface (dotted root, plus the base module when the package ships one) of every configured package through the verify venv's interpreter. This covers all published distributions and the bundle-only packages, and extends the old hand-written coverage (which missed `example_b` and probed several near-empty roots instead of their base modules).
- `scripts/verify_independent_installs.py`: derives the top-level published distributions from path nesting, installs each alone, and imports its surface plus the surfaces of every configured package nested under it, so a payload-less bundle wheel fails instead of passing on a namespace import.
- `scripts/verify_extras.py`: for every published package whose non-dev extras carry in-repo members ({published_children} expanded exactly as the generator does), verifies the bare install does not carry the members (a member only counts as absent on a ModuleNotFoundError naming it), verifies the [extra] install imports them, and probes the owner package in both venvs.
- The three tox envs shrink to one script call each; guard tests forbid hand-written distribution names in all four PyPI-installing envs, require each env to invoke its script on a live line, and pin the derivations against synthetic configs (unpublished top-level exclusion, trailing-slash paths, dev-extra skip, external-name filtering, and the invariant that every unpublished package sits under an entry-point bundle).

## Verification

- Full tox gate green: 4864 passed, ruff format, ruff check, mypy --strict, bandit.
- End-to-end against the released 0.4.0 wheels: `verify-published-independent` passes with the strong probes (42 modules proven for the community bundle); the import verifier loads all 49 surface modules from the four bundle wheels; the extras verifier passes both community-example venvs and the data-operations bare venv, failing only on `[all]==0.4.0` because the frozen 0.4.0 metadata references distributions first published by the next release.

Fixes #373.