### PR TITLE
fix(packaging): exclude real .egg-info dirs from package discovery

### DIFF
--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -126,7 +126,11 @@ def discover_packages(pkg_path: str, exclude_paths: list[str] | None = None) -> 
     """
     packages: list[str] = []
     base_path = Path(pkg_path)
-    exclude_dirs = {"build", "dist", ".tox", ".venv", "__pycache__", ".egg-info", "tests"}
+    # Directories matched by exact name.
+    exclude_dirs = {"build", "dist", ".tox", ".venv", "__pycache__", "tests"}
+    # Directories matched by suffix, since real egg-info dirs are named
+    # "<package>.egg-info" and never match an exact "in pkg_dir.parts" check.
+    exclude_suffixes = (".egg-info",)
     exclude_paths = exclude_paths or []
 
     if not base_path.exists():
@@ -136,8 +140,11 @@ def discover_packages(pkg_path: str, exclude_paths: list[str] | None = None) -> 
     for init_file in base_path.rglob("__init__.py"):
         pkg_dir = init_file.parent
         pkg_dir_str = str(pkg_dir)
-        # Skip excluded directories
+        # Skip excluded directories (exact match)
         if any(excluded in pkg_dir.parts for excluded in exclude_dirs):
+            continue
+        # Skip excluded directories (suffix match, e.g. "<pkg>.egg-info")
+        if any(part.endswith(suffix) for part in pkg_dir.parts for suffix in exclude_suffixes):
             continue
         # Skip paths that are configured as separate packages
         if any(pkg_dir_str == excl or pkg_dir_str.startswith(excl + "/") for excl in exclude_paths):

--- a/tests/test_end2end/test_generate_pyproject_guards.py
+++ b/tests/test_end2end/test_generate_pyproject_guards.py
@@ -140,3 +140,31 @@ def test_meta_package_without_py_typed_still_generates() -> None:
 
     assert "packages = []" in content, content
     assert "package-data" not in content, content
+
+
+def test_discover_packages_excludes_real_egg_info_dirs(tmp_path: Path) -> None:
+    """A planted ``<package>.egg-info/__init__.py`` must not be discovered as a package.
+
+    ``discover_packages`` excluded directories via an exact-part match
+    against the literal string ``".egg-info"``. Real egg-info directories are
+    named ``<package>.egg-info`` (e.g. ``foo.egg-info``), so the exact
+    comparison never matched and the entry was dead: a synthetic
+    ``foo.egg-info`` package directory got discovered like any other package.
+    """
+    pkg_root = tmp_path / "mloda" / "demo"
+    real_pkg = pkg_root / "widgets"
+    real_pkg.mkdir(parents=True)
+    (real_pkg / "__init__.py").write_text("")
+
+    egg_info_pkg = pkg_root / "widgets.egg-info"
+    egg_info_pkg.mkdir(parents=True)
+    (egg_info_pkg / "__init__.py").write_text("")
+
+    discovered = gen.discover_packages(str(pkg_root))
+
+    assert any(pkg.endswith("widgets") and "egg-info" not in pkg for pkg in discovered), (
+        f"expected the real widgets package to be discovered, got: {discovered}"
+    )
+    assert not any("egg-info" in pkg for pkg in discovered), (
+        f"a synthetic '.egg-info' package leaked into discovery: {discovered}"
+    )


### PR DESCRIPTION
`discover_packages` excluded directories via an exact-part match against the literal string `.egg-info`. Real egg-info directories are named `<package>.egg-info` (e.g. `foo.egg-info`), so the exact comparison never matched — the exclusion entry was dead code. A synthetic `<pkg>.egg-info` directory containing an `__init__.py` would get discovered and shipped as a real package.

Fixed by matching `.egg-info` as a suffix on each path part, in addition to the existing exact-match set. Added a regression test that plants a synthetic `<pkg>.egg-info/__init__.py` alongside a real package and asserts only the real package is discovered.

Verified locally: the new test passes against the fix.