### PR TITLE
fix(security): pass anchored -x globs to the bandit gate instead of its bare defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ When a compute framework backend cannot natively support an input or operation, 
 
 ## Project Practices
 
-`tox` is the gate. It runs `pytest -n {env:PYTEST_WORKERS:2}` (default 2 workers, no timeout), then `ruff format --check --line-length 120 .`, `ruff check .`, `mypy --strict --ignore-missing-imports .`, and `bandit -c pyproject.toml -r -q .`. All of these must pass before a PR is mergeable.
+`tox` is the gate. It runs `pytest -n {env:PYTEST_WORKERS:2}` (default 2 workers, no timeout), then `ruff format --check --line-length 120 .`, `ruff check .`, `mypy --strict --ignore-missing-imports .`, and `bandit -c pyproject.toml -r -q` with an explicit `-x` list of anchored globs replacing bandit's built-in default excludes (see `tox.ini`). All of these must pass before a PR is mergeable.
 
 - **Python**: supported range is `>=3.10`; tox envs cover `python310`, `python311`, `python312`, `python313`, `python314`.
 - **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007` (extend-selected in `pyproject.toml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ When a compute framework backend cannot natively support an input or operation, 
 
 ## Project Practices
 
-`tox` is the gate. It runs `pytest -n {env:PYTEST_WORKERS:2}` (default 2 workers, no timeout), then `ruff format --check --line-length 120 .`, `ruff check .`, `mypy --strict --ignore-missing-imports .`, and `bandit -c pyproject.toml -r -q .`. All of these must pass before a PR is mergeable.
+`tox` is the gate. It runs `pytest -n {env:PYTEST_WORKERS:2}` (default 2 workers, no timeout), then `ruff format --check --line-length 120 .`, `ruff check .`, `mypy --strict --ignore-missing-imports .`, and `bandit -c pyproject.toml -r -q` with an explicit `-x` list of anchored globs replacing bandit's built-in default excludes (see `tox.ini`). All of these must pass before a PR is mergeable.
 
 - **Python**: supported range is `>=3.10`; tox envs cover `python310`, `python311`, `python312`, `python313`, `python314`.
 - **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007` (extend-selected in `pyproject.toml`).

--- a/tests/test_end2end/test_bandit_exclusions.py
+++ b/tests/test_end2end/test_bandit_exclusions.py
@@ -1,10 +1,13 @@
-"""The bandit gate (``bandit -c pyproject.toml -r -q .``) must scan scripts/verify_builds.py and
-scripts/verify_build_floor.py. Bandit applies each [tool.bandit] exclude_dirs entry both as an
-fnmatch glob and as a plain substring of the full path, so a bare entry like "build" silently drops
-every path containing that substring while genuine artifact directories must stay excluded."""
+"""The bandit gate in tox.ini must scan scripts/verify_builds.py and scripts/verify_build_floor.py.
+Bandit applies each exclusion entry both as an fnmatch glob and as a plain substring of the full
+path, so a bare entry like "build" silently drops every path containing that substring, while genuine
+artifact directories must stay excluded. The gate therefore passes an explicit -x glob list: without
+one, bandit appends its built-in defaults (.svn, CVS, .eggs, ...) bare."""
 
 from __future__ import annotations
 
+import configparser
+import shlex
 import sys
 from pathlib import Path
 from typing import Any
@@ -21,9 +24,7 @@ from bandit.core import manager as b_manager
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
-
-# bandit/cli/main.py passes this -x/--exclude default into discover_files on top of exclude_dirs.
-_CLI_DEFAULT_EXCLUDES = ",".join(b_constants.EXCLUDE)
+_TOX_INI = _REPO_ROOT / "tox.ini"
 
 # The real-world artifact the "build" entry exists for: setuptools mirrors sources into build/lib.
 _NESTED_BUILD_ARTIFACT = (
@@ -45,12 +46,55 @@ _ARTIFACT_PATHS = [
     "attribution/report.py",
 ]
 
+# One synthetic lookalike per bandit built-in default: the name occurs only as a substring of a
+# path component, never as a component itself.
+_DEFAULT_NAME_LOOKALIKES = {
+    ".svn": "mloda/pkg.svnx/module.py",
+    "CVS": "mloda/tools/CVS_reader.py",
+    ".bzr": "mloda/pkg.bzrx/module.py",
+    ".hg": "mloda/pkg.hgx/module.py",
+    ".git": ".github/scripts/module.py",
+    "__pycache__": "mloda/__pycache__x/module.py",
+    ".tox": "mloda/pkg.toxic/module.py",
+    ".eggs": "mloda/data.eggs_reader/module.py",
+    "*.egg": "mloda/pkg.egg_helper/module.py",
+}
+
+# Genuine default-named artifact directories the gate excludes must keep out of the scan.
+_DEFAULT_NAMED_ARTIFACT_PATHS = [
+    ".git/hooks/update.py",
+    "mloda/.svn/text-base/module.py",
+    "CVS/module.py",
+    "mloda/CVS/module.py",
+    "mloda/.hg/store/module.py",
+    "mloda/.bzr/checkout/module.py",
+    ".eggs/pytest_runner-6.0.0/setup.py",
+    "mloda/pkg/foo.egg/module.py",
+]
+
+
+def _gate_cli_excludes() -> str:
+    """The comma-separated -x exclusion list the tox.ini bandit gate passes."""
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.read(_TOX_INI)
+    for line in parser["testenv"]["commands"].splitlines():
+        tokens = shlex.split(line)
+        if not tokens or tokens[0] != "bandit":
+            continue
+        if "-x" in tokens[:-1]:
+            return tokens[tokens.index("-x") + 1]
+        pytest.fail(
+            "the tox.ini bandit gate passes no explicit -x, so bandit appends its built-in default "
+            "excludes bare and drops any path merely containing one as a substring"
+        )
+    pytest.fail("no bandit command found in tox.ini [testenv] commands")
+
 
 def _discover(targets: list[str], config_file: Path | None) -> Any:
     """BanditManager after file discovery, wired exactly like the CLI gate."""
     conf = b_config.BanditConfig(config_file=str(config_file)) if config_file else b_config.BanditConfig()
     mgr = b_manager.BanditManager(conf, "file")
-    mgr.discover_files(targets, True, _CLI_DEFAULT_EXCLUDES)
+    mgr.discover_files(targets, True, _gate_cli_excludes())
     return mgr
 
 
@@ -125,3 +169,35 @@ def test_build_output_exclusion_comes_from_the_pyproject_config(monkeypatch: pyt
         f"{target} is already excluded without the pyproject config; this guard no longer proves the "
         "config carries the build-output exclusion"
     )
+
+
+def test_effective_exclusions_are_globs_not_bare_substrings() -> None:
+    """Every effective exclusion entry must contain a "*" so bandit's substring branch stays inert."""
+    entries = _configured_exclude_dirs() + _gate_cli_excludes().split(",")
+    bare = [entry for entry in entries if "*" not in entry]
+    assert not bare, f"bare exclusion entries substring-match every path containing them: {bare}"
+
+
+def test_paths_merely_containing_a_default_name_stay_scanned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A path containing a bandit default name only as a substring must still be scanned."""
+    monkeypatch.chdir(_REPO_ROOT)
+    assert set(_DEFAULT_NAME_LOOKALIKES) == set(b_constants.EXCLUDE), (
+        "bandit's built-in default exclude list changed; update _DEFAULT_NAME_LOOKALIKES and mirror "
+        "the new name as anchored globs in the tox.ini bandit -x list"
+    )
+    targets = [form for path in _DEFAULT_NAME_LOOKALIKES.values() for form in (path, "./" + path)]
+    mgr = _discover(targets, _PYPROJECT)
+    dropped = set(targets) & set(mgr.excluded_files)
+    assert not dropped, f"paths merely containing a default name were dropped from the scan: {sorted(dropped)}"
+    missing = {"./" + target for target in targets} - set(mgr.files_list)
+    assert not missing, f"lookalike paths never landed in the scan list: {sorted(missing)}"
+
+
+def test_default_named_artifact_paths_stay_excluded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Genuine VCS and egg artifact directories must stay out of the scan under the gate excludes."""
+    monkeypatch.chdir(_REPO_ROOT)
+    targets = [form for path in _DEFAULT_NAMED_ARTIFACT_PATHS for form in (path, "./" + path)]
+    mgr = _discover(targets, _PYPROJECT)
+    for path in targets:
+        assert path in mgr.excluded_files, f"{path} is a default-named artifact path and must stay excluded"
+    assert not mgr.files_list, f"default-named artifact paths leaked into the scan: {mgr.files_list}"

--- a/tox.ini
+++ b/tox.ini
@@ -26,12 +26,13 @@ passenv =
 allowlist_externals = sh, bandit
 setenv =
     USE_TOX_LOCK = {env:USE_TOX_LOCK:}
+# The explicit bandit -x replaces the bare built-in defaults, which substring-match every path containing them.
 commands =
     sh -c "if [ -n \"$USE_TOX_LOCK\" ]; then flock /shared/tox.lock pytest -n {env:PYTEST_WORKERS:2}; else pytest -n {env:PYTEST_WORKERS:2}; fi"
     ruff format --check --line-length 120 .
     ruff check .
     mypy --strict --ignore-missing-imports .
-    bandit -c pyproject.toml -r -q .
+    bandit -c pyproject.toml -r -q -x .svn/*,*/.svn/*,CVS/*,*/CVS/*,.bzr/*,*/.bzr/*,.hg/*,*/.hg/*,.git/*,*/.git/*,__pycache__/*,*/__pycache__/*,.tox/*,*/.tox/*,.eggs/*,*/.eggs/*,*.egg,*.egg/* .
 
 [testenv:testing]
 description = Run only mloda-testing tests


### PR DESCRIPTION
## Summary

Without an explicit `-x`, bandit appends its built-in default excludes (.svn, CVS, .bzr, .hg, .git, __pycache__, .tox, .eggs, *.egg) to the exclusion set, and any entry that is not an existing directory stays a plain string that excludes every path containing it as a substring. A source path merely containing such a name (.github contains .git, data.eggs_reader contains .eggs) would be silently dropped from the scan. The gate line now passes a component-anchored glob translation of the defaults, so no bare substring entry remains, and the exclusion tests parse the `-x` list from tox.ini so they always exercise the real gate: lookalike paths must stay scanned, genuine default-named artifact directories must stay excluded, and no effective exclusion entry may lack a glob metacharacter. File discovery over the full repo tree is unchanged by the new list.

## Related issue

Closes #388

## Type of change

- [x] Bug fix (`fix:`)

## Checklist

- [x] `uv run tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`)
- [x] Tests added or updated for the change
- [x] Documentation updated where relevant
- [x] `pyproject.toml` not edited by hand (regenerated from `config/` via `scripts/generate_pyproject.py` if dependencies changed)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)