### PR TITLE
fix(data_operations): frame_aggregate order_by backstop and named arity rejections

### DIFF
--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -305,12 +305,14 @@ class RejectionReasonMixin(FeatureChainParserMixin):
                 continue
             if cls._guard_accepts(guard, value):
                 continue
-            # A genuinely multi-element container of individually accepted values fails on arity
-            # alone and stays a plain non-match; a nested singleton is a real guard rejection.
+            # Multi-element with every element accepted, where a flat list is also rejected, is an
+            # arity error, so the arity is named. A nested singleton or a container-type rejection
+            # falls through as a real guard rejection; the match verdict is a plain non-match either way.
             if (
                 isinstance(value, (list, tuple, set, frozenset))
                 and len(value) > 1
                 and all(cls._guard_accepts(guard, element) for element in value)
+                and not cls._guard_accepts(guard, list(value))
             ):
                 return f"option '{key}' accepts exactly one value, got {len(value)} elements: {_safe_repr(value)}"
             guard_name = getattr(guard, "__name__", repr(guard))

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -266,10 +266,9 @@ class RejectionReasonMixin(FeatureChainParserMixin):
                         f"For a chained name, the child receives only the context keys listed in "
                         f"propagate_context_keys"
                     )
-            rejected = cls._rejected_match_guard(options, property_mapping)
-            if rejected is not None:
-                key, value, guard_name = rejected
-                return f"match_guard '{guard_name}' for option '{key}' rejected value {_safe_repr(value)}"
+            guard_reason = cls._match_guard_rejection_reason(options, property_mapping)
+            if guard_reason is not None:
+                return guard_reason
         return None
 
     @classmethod
@@ -293,8 +292,8 @@ class RejectionReasonMixin(FeatureChainParserMixin):
         return None
 
     @classmethod
-    def _rejected_match_guard(cls, options: Options, property_mapping: dict[str, Any]) -> tuple[str, Any, str] | None:
-        """First (key, value, guard name) whose match_guard rejects a present value for more than arity."""
+    def _match_guard_rejection_reason(cls, options: Options, property_mapping: dict[str, Any]) -> str | None:
+        """Formatted reason for the first match_guard rejection of a present value, or None."""
         for key, mapping_entry in property_mapping.items():
             if not isinstance(mapping_entry, dict):
                 continue
@@ -306,15 +305,16 @@ class RejectionReasonMixin(FeatureChainParserMixin):
                 continue
             if cls._guard_accepts(guard, value):
                 continue
-            # Only a genuinely multi-element container of individually accepted values fails on
-            # arity alone, which stays a silent non-match; a nested singleton is a real rejection.
+            # A genuinely multi-element container of individually accepted values fails on arity
+            # alone and stays a plain non-match; a nested singleton is a real guard rejection.
             if (
                 isinstance(value, (list, tuple, set, frozenset))
                 and len(value) > 1
                 and all(cls._guard_accepts(guard, element) for element in value)
             ):
-                continue
-            return key, value, getattr(guard, "__name__", repr(guard))
+                return f"option '{key}' accepts exactly one value, got {len(value)} elements: {_safe_repr(value)}"
+            guard_name = getattr(guard, "__name__", repr(guard))
+            return f"match_guard '{guard_name}' for option '{key}' rejected value {_safe_repr(value)}"
         return None
 
     @staticmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -408,6 +408,11 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
         feature_name = feature.name
         parsed = cls._parse_frame_feature(feature_name)
 
+        # Compute-time backstop for direct calls; match time enforces presence declaratively.
+        order_by = option_value(feature.options, cls.ORDER_BY, column_ref_value)
+        if order_by is None:
+            raise ValueError("frame_aggregate requires an 'order_by' column in Options context.")
+
         if parsed is not None:
             return {
                 "source_col": parsed["source_col"],
@@ -416,7 +421,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
                 "frame_size": parsed["frame_size"],
                 "frame_unit": parsed["frame_unit"],
                 "partition_by": feature.options.get(cls.PARTITION_BY),
-                "order_by": option_value(feature.options, cls.ORDER_BY, column_ref_value),
+                "order_by": order_by,
             }
 
         source_features = cls._extract_source_features(feature)
@@ -427,7 +432,7 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
             "frame_size": option_value(feature.options, cls.FRAME_SIZE, positive_int_value),
             "frame_unit": _option_token(feature.options, cls.FRAME_UNIT),
             "partition_by": feature.options.get(cls.PARTITION_BY),
-            "order_by": option_value(feature.options, cls.ORDER_BY, column_ref_value),
+            "order_by": order_by,
         }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -639,6 +639,13 @@ class TestExtractParams:
         assert params["frame_type"] == "expanding"
         assert params["partition_by"] == ["region"]
 
+    def test_extract_from_name_without_order_by_raises(self) -> None:
+        """The order_by backstop sits above the name/config branch, so the name path hits it too."""
+        with pytest.raises(ValueError, match="order_by"):
+            FrameAggregateFeatureGroup._extract_params(
+                Feature("sales__sum_rolling_3", options=Options(context={"partition_by": ["region"]}))
+            )
+
 
 class TestReturnDataTypeRule:
     """return_data_type_rule should fix the output type only for deterministic ops.

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -721,7 +721,7 @@ class TestFrameAggregateMatchValidation(MatchValidationTestBase):
             TokenCase("frame_unit", "day", "week", context={"frame_type": "rolling"}),
             # order_by and frame_size are scalar too: one column, one positive int, so a
             # zero-sized frame and a bool stay out at every arity.
-            TokenCase("order_by", "timestamp", "region"),
+            TokenCase("order_by", "timestamp", "region", required=True),
             TokenCase("frame_size", 3, 5, invalid=(0, True)),
         ]
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -228,7 +228,7 @@ class TestRejectionReporting:
         assert reason is not None
         assert "'constant'" in reason
         assert "exactly one" in reason
-        assert "2" in reason
+        assert "got 2 elements" in reason
 
 
 class TestSingleColumnEnforcement:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -214,8 +214,8 @@ class TestRejectionReporting:
             assert reason is not None
             assert "constant" in reason
 
-    def test_multi_element_constant_stays_a_silent_non_match(self) -> None:
-        # The arity guard, not strict validation, rejects a multi-element constant.
+    def test_multi_element_constant_reports_an_arity_reason(self) -> None:
+        """A multi-element constant stays a non-match, but the reason names the arity."""
         options = Options(
             context={
                 "arithmetic_op": "add",
@@ -223,8 +223,12 @@ class TestRejectionReporting:
                 "constant": [5, 10],
             }
         )
-        assert ScalarArithmeticFeatureGroup._strict_validation_rejection_reason("my_result", options) is None
         assert ScalarArithmeticFeatureGroup.match_feature_group_criteria("my_result", options, None) is False
+        reason = ScalarArithmeticFeatureGroup._strict_validation_rejection_reason("my_result", options)
+        assert reason is not None
+        assert "'constant'" in reason
+        assert "exactly one" in reason
+        assert "2" in reason
 
 
 class TestSingleColumnEnforcement:

--- a/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
@@ -14,6 +14,9 @@ from mloda.community.feature_groups.data_operations.row_preserving.ffill.pyarrow
 from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.pandas_frame_aggregate import (
     PandasFrameAggregate,
 )
+from mloda.community.feature_groups.data_operations.row_preserving.point_arithmetic.pyarrow_point_arithmetic import (
+    PyArrowPointArithmetic,
+)
 from mloda.community.feature_groups.data_operations.row_preserving.scalar_arithmetic.pyarrow_scalar_arithmetic import (
     PyArrowScalarArithmetic,
 )
@@ -75,12 +78,21 @@ class TestMultiElementArityRejectionReported:
         assert reason is not None
         assert "'order_by'" in reason
         assert "exactly one" in reason
-        assert "2" in reason
+        assert "got 2 elements" in reason
 
     def test_single_element_order_by_reports_nothing(self) -> None:
         """A single-element container is an accepted singleton, so there is nothing to report."""
         options = Options(context={"in_features": "value_float", "order_by": ["ts"], "partition_by": ["region"]})
         assert PyArrowFfill._strict_validation_rejection_reason("my_result", options) is None
+
+    def test_guard_rejected_container_type_reports_the_guard_not_arity(self) -> None:
+        """A guard that rejects the container type itself must be named, not misreported as an arity failure."""
+        options = Options(context={"arithmetic_op": "add", "in_features": {("a",), ("b",)}})
+        reason = PyArrowPointArithmetic._strict_validation_rejection_reason("my_result", options)
+        assert reason is not None
+        assert "match_guard" in reason
+        assert "'in_features'" in reason
+        assert "exactly one" not in reason
 
 
 class TestMissingRequiredWhenReported:

--- a/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
@@ -62,6 +62,27 @@ class TestConfigPathGuardRejectionReported:
         assert PyArrowFfill._strict_validation_rejection_reason("some_unrelated_feature", options) is None
 
 
+class TestMultiElementArityRejectionReported:
+    """A multi-element container of individually accepted values must be named with an arity reason."""
+
+    def test_multi_element_order_by_reports_an_arity_reason(self) -> None:
+        """The verdict stays a non-match; only the reason is added."""
+        options = Options(
+            context={"in_features": "value_float", "order_by": ["ts", "region"], "partition_by": ["region"]}
+        )
+        assert PyArrowFfill.match_feature_group_criteria("my_result", options, None) is False
+        reason = PyArrowFfill._strict_validation_rejection_reason("my_result", options)
+        assert reason is not None
+        assert "'order_by'" in reason
+        assert "exactly one" in reason
+        assert "2" in reason
+
+    def test_single_element_order_by_reports_nothing(self) -> None:
+        """A single-element container is an accepted singleton, so there is nothing to report."""
+        options = Options(context={"in_features": "value_float", "order_by": ["ts"], "partition_by": ["region"]})
+        assert PyArrowFfill._strict_validation_rejection_reason("my_result", options) is None
+
+
 class TestMissingRequiredWhenReported:
     """A missing required_when key must be named, not left as a debug log."""
 


### PR DESCRIPTION
## Summary

- frame_aggregate now raises a ValueError naming order_by from _extract_params when the option is absent, mirroring the ffill and ema backstops. A direct calculate_feature call (or any future matcher regression) fails with a clear error instead of a bare KeyError from the backend internals. The shared-harness TokenCase for order_by declares required=True, and a dedicated test pins that the name path hits the backstop as well as the config path.
- The shared rejection-reason mixin now names a multi-element container of individually valid values for a scalar guard key with an arity-specific reason (for example: option 'order_by' accepts exactly one value, got 2 elements), instead of leaving it a silent non-match that ends in the generic no-feature-group error. The arity claim fires only when the guard also rejects the same elements re-presented as a flat list, so a guard that rejects the container type itself (point_arithmetic's ordered in_features) keeps the regular guard message naming the guard.
- Match verdicts are unchanged in both cases: the mixin only adds diagnostics, and a composite value stays a plain non-match that another candidate may accept.

Closes #383
Closes #382

## Testing

Full tox gate passes: pytest, ruff format, ruff check, mypy strict, and bandit.