### PR TITLE
fix(release): pace PyPI uploads to avoid 429 rate limiting

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,5 +133,31 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          # PyPI answers 429 above roughly 20 uploads per minute, and the released set is
+          # 24 packages, so a single batch `twine upload dist/*` trips the limit mid-way and
+          # leaves the release partially published. Upload one file at a time with a pause
+          # between them to stay under the limit.
+          PYPI_UPLOAD_DELAY_SECONDS: '5'
         # --skip-existing keeps a rerun after a partial upload from failing on files already on PyPI.
-        run: twine upload --non-interactive --skip-existing dist/*
+        run: |
+          shopt -s nullglob
+          dists=(dist/*)
+          if [ ${#dists[@]} -eq 0 ]; then
+            echo "::error ::No distributions found in dist/ to publish"
+            exit 1
+          fi
+
+          delay="${PYPI_UPLOAD_DELAY_SECONDS:-5}"
+          total=${#dists[@]}
+          index=0
+
+          for dist in "${dists[@]}"; do
+            index=$((index + 1))
+            echo "Uploading $index/$total: $(basename "$dist")"
+            twine upload --non-interactive --skip-existing "$dist"
+            if [ "$index" -lt "$total" ]; then
+              sleep "$delay"
+            fi
+          done
+
+          echo "Published $total distributions."


### PR DESCRIPTION
## Summary

The `Release` workflow's publish job uploaded all 24 released wheels in a single `twine upload dist/*`. PyPI rate limits uploads at roughly 20 per minute and answered `429 Too Many Requests` part way through the 0.4.1 release ([run 31087714734](https://github.com/mloda-ai/mloda-registry/actions/runs/31087714734)), leaving that release partially published.

This uploads one distribution at a time with a pause between them.

## Changes

- `.github/workflows/release.yaml`: the `Publish to PyPI` step now loops over `dist/*`, uploading each wheel individually and sleeping `PYPI_UPLOAD_DELAY_SECONDS` (step-level env, default `5`) between uploads.
- Fails with a `::error ::` if `dist/` is empty, matching the defensive style of the neighbouring `Build packages` step.
- `--skip-existing` is kept, so a re-dispatch after a partial upload still works.

24 packages at 5s adds roughly 2 minutes to a job that currently runs under 2 minutes. The delay is an env var so it can be tuned without rewriting the loop.

## Verification

- The workflow parses as YAML and the step exposes the expected env keys.
- The extracted `run:` block was executed against a stub `twine` in a temp dir: the happy path uploads all files in order and exits 0, a failing upload aborts immediately with exit 1 (default `bash -e`), and an empty `dist/` emits the error and exits 1.
- Not verified: a real release run.

## Note

0.4.1 is still partially published on PyPI. That needs a separate follow-up: either upload the missing wheels manually or let the next release carry them.