### PR TITLE
chore(release): add twine --verbose and raise the PyPI upload delay to 10s

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,12 +133,13 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          # PyPI answers 429 above roughly 20 uploads per minute, and the released set is
-          # 24 packages, so a single batch `twine upload dist/*` trips the limit mid-way and
-          # leaves the release partially published. Upload one file at a time with a pause
-          # between them to stay under the limit.
-          PYPI_UPLOAD_DELAY_SECONDS: '5'
+          # PyPI answered 429 part way through the 0.4.1 release, leaving it partially
+          # published. Which limiter fires is still unconfirmed, so upload one file at a
+          # time with a pause between them rather than one batch `twine upload dist/*`.
+          PYPI_UPLOAD_DELAY_SECONDS: '10'
         # --skip-existing keeps a rerun after a partial upload from failing on files already on PyPI.
+        # --verbose so a 429 prints the response body and the RateLimit / RateLimit-Policy
+        # headers; without it twine reports a bare "Too Many Requests" that names no policy.
         run: |
           shopt -s nullglob
           dists=(dist/*)
@@ -147,14 +148,14 @@ jobs:
             exit 1
           fi
 
-          delay="${PYPI_UPLOAD_DELAY_SECONDS:-5}"
+          delay="${PYPI_UPLOAD_DELAY_SECONDS:-10}"
           total=${#dists[@]}
           index=0
 
           for dist in "${dists[@]}"; do
             index=$((index + 1))
             echo "Uploading $index/$total: $(basename "$dist")"
-            twine upload --non-interactive --skip-existing "$dist"
+            twine upload --non-interactive --skip-existing --verbose "$dist"
             if [ "$index" -lt "$total" ]; then
               sleep "$delay"
             fi


### PR DESCRIPTION
## Summary

Follow-up to #397. The 0.4.1 publish job hit `429 Too Many Requests` again with the 5s pacing in place, so the pacing alone is not sufficient, and we still do not know which limiter is rejecting us.

Two small changes to the `Publish to PyPI` step:

- **`--verbose` on the twine call.** Plain `twine upload` swallows the response body, so the failure log reads only `HTTPError: 429 Too Many Requests` with no indication of the policy. With `--verbose`, twine prints the response body and the `RateLimit` / `RateLimit-Policy` headers, which name the policy and the remaining budget. Twine's own message ("Retry with the --verbose option for more details") is asking for exactly this.
- **`PYPI_UPLOAD_DELAY_SECONDS` 5 to 10.** Adds roughly 2 more minutes to the job.

The stale comment claiming a "20 uploads per minute" limit is replaced, since that was not verified and the 5s pacing did not prevent the failure.

## Context on what we know

The two failures both landed on `mloda-community-time-bucketization`, the only package in the released set that does not yet exist on PyPI. 19 uploads to existing projects succeeded in the same job that was then rejected on the first project creation.

PyPI's project-create limiters (`warehouse/config.py`, `warehouse/packaging/services.py:420-487`) are 20/hour per user and 40/hour per IP, and are only consulted when a project must be created. Checking first-upload timestamps, we created only 4 new projects today, well under the user quota. The per-IP limit is shared with everyone else publishing from GitHub-hosted runners, which would explain a rejection on our first creation, but that is inference. This PR is what turns it into a fact on the next failure.

## Verification

- Workflow parses as YAML; the step exposes `PYPI_UPLOAD_DELAY_SECONDS: '10'`.
- The extracted `run:` block was run against a stub `twine` in a temp dir: the happy path passes `--verbose` through and exits 0, the default delay is honoured (2 files took 10.0s), a failing upload aborts with exit 1, and an empty `dist/` errors out.
- Not verified: a real release run.