### PR TITLE
test: collapse sibling test bodies into parametrized cases

### DIFF
--- a/docs/guides/data-operation-patterns/10-adding-new-operation.md
+++ b/docs/guides/data-operation-patterns/10-adding-new-operation.md
@@ -98,6 +98,7 @@ File: `mloda/testing/feature_groups/data_operations/{category}/{your_op}/{your_o
 
 ```python
 from typing import Any
+import pytest
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.community.feature_groups.data_operations.{category}.{your_op}.pyarrow_{your_op} import (
     PyArrowYourOp,
@@ -113,16 +114,21 @@ class YourOpTestBase(DataOpsTestBase):
     def supported_ops(cls) -> set[str]:
         return {"op_a", "op_b"}
 
-    def test_op_a_basic(self) -> None:
-        self._skip_if_unsupported("op_a")
-        self._compare_with_reference("value_int__op_a")
-
-    def test_op_b_partitioned(self) -> None:
-        self._skip_if_unsupported("op_b")
-        self._compare_with_reference("value_int__op_b", partition_by=["region"])
+    @pytest.mark.parametrize(
+        ("op", "partition_by"),
+        [
+            pytest.param("op_a", None, id="op_a"),
+            pytest.param("op_b", ["region"], id="op_b"),
+        ],
+    )
+    def test_cross_framework(self, op: str, partition_by: list[str] | None) -> None:
+        self._skip_if_unsupported(op)
+        self._compare_with_reference(f"value_int__{op}", partition_by=partition_by)
 ```
 
-The test methods call `_compare_with_reference`, which runs both the implementation under test and PyArrow and asserts they match. Every framework's concrete test class will inherit these methods.
+The test method calls `_compare_with_reference`, which runs both the implementation under test and PyArrow and asserts they match. Every framework's concrete test class inherits it.
+
+One parametrized method per family, not one method per op: the explicit ids name the failing case (`test_cross_framework[op_b]`), and calling `_skip_if_unsupported` inside the body keeps the skip per case, so an unsupported op skips alone.
 
 ---
 

--- a/docs/guides/data-operation-patterns/known-divergences.md
+++ b/docs/guides/data-operation-patterns/known-divergences.md
@@ -38,7 +38,7 @@ mitigation_location:
 - mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/polars_lazy_scalar_aggregate.py
 - mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/polars_lazy_window_aggregation.py
 regression_test:
-- mloda/testing/feature_groups/data_operations/aggregation/aggregation.py::AggregationTestBase::test_null_policy_skip_all_null_column
+- mloda/testing/feature_groups/data_operations/aggregation/aggregation.py::AggregationTestBase::test_all_null_column_per_group
 -->
 
 - **Operations**: `aggregation`, `scalar_aggregate`, `window_aggregation`.
@@ -47,7 +47,7 @@ regression_test:
 - **Native Polars behavior**: `pl.col(...).sum()` returns `0` for the same input.
 - **Mitigation kind**: Implementation fix.
 - **How**: The Polars implementation wraps the `sum` expression with `pl.when(count > 0).then(sum).otherwise(None)`, so an all-null group maps back to `null`.
-- **Regression signal**: The canonical 12-row fixture has a `score` column that is all-null. `test_null_policy_skip_all_null_column` in `mloda/testing/feature_groups/data_operations/aggregation/aggregation.py` asserts `score__sum_agg` is all-null per region, and fails if this correction is removed.
+- **Regression signal**: The canonical 12-row fixture has a `score` column that is all-null. `test_all_null_column_per_group[sum]` in `mloda/testing/feature_groups/data_operations/aggregation/aggregation.py` asserts `score__sum_agg` is all-null per region, and fails if this correction is removed.
 
 ### Polars `rank()` returns null for null inputs
 
@@ -82,8 +82,8 @@ mitigation_location:
 - mloda/community/feature_groups/data_operations/polars_mode_helpers.py
 - mloda/community/feature_groups/data_operations/pandas_helpers.py
 regression_test:
-- mloda/testing/feature_groups/data_operations/aggregation/aggregation.py::AggregationTestBase::test_cross_framework_mode
-- mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py::WindowAggregationTestBase::test_cross_framework_mode
+- mloda/testing/feature_groups/data_operations/aggregation/aggregation.py::AggregationTestBase::test_cross_framework_agg
+- mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py::WindowAggregationTestBase::test_cross_framework
 -->
 
 - **Operations**: `aggregation` (`mode` agg type), `window_aggregation` (`mode` agg type).
@@ -92,7 +92,7 @@ regression_test:
 - **Native framework behavior**: Polars' `.mode()` and Pandas' `.mode()` break ties differently (sorted order / multiple returned values / unspecified).
 - **Mitigation kind**: Implementation fix.
 - **How**: Both frameworks explicitly rank candidate values by `(count desc, first_occurrence_index asc)` and take the head. The Polars Lazy implementation stays inside the lazy / vectorised path: it adds per-`(partition, value)` count and first-index columns via `.over()`, then uses `sort_by([cnt, first_idx], descending=[True, False], maintain_order=True).first()` (no Python callback). On Pandas this is a single vectorized groupby over `(partition_by, value)` that aggregates count and first-occurrence index, avoiding a per-group Python reducer.
-- **Regression signal**: The canonical fixture has values that tie; mode tests compare against the PyArrow reference via `_compare_with_reference`.
+- **Regression signal**: The canonical fixture has values that tie; `test_cross_framework_agg[mode]` and `test_cross_framework[mode]` compare against the PyArrow reference via `_compare_with_reference`.
 
 ### SQLite divide-by-zero returns NULL instead of IEEE-754 inf/nan
 
@@ -124,9 +124,7 @@ condition: UPPER/LOWER are ASCII-only and REVERSE has no native function
 mitigation_location:
 - mloda/community/feature_groups/data_operations/string/sqlite_string.py
 regression_test:
-- mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py::TestSqliteUnsupportedOps::test_upper_does_not_match
-- mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py::TestSqliteUnsupportedOps::test_lower_does_not_match
-- mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py::TestSqliteUnsupportedOps::test_reverse_does_not_match
+- mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py::TestSqliteUnsupportedOps::test_unsupported_op_does_not_match
 -->
 
 - **Operations**: `string` (`upper`, `lower`, `reverse`).
@@ -135,7 +133,7 @@ regression_test:
 - **Native SQLite behavior**: `UPPER('héllo')` returns `'HéLLO'`. `REVERSE` is not implemented.
 - **Mitigation kind**: Excluded op.
 - **How**: `SqliteStringOps._validate_string_match` returns `True` only for `trim` and `length`. Requesting `name__upper`, `name__lower`, or `name__reverse` with `compute_frameworks={"SqliteRelation"}` refuses to match at resolution time. The test class mirrors the decision through `supported_ops()`.
-- **Regression signal**: `test_sqlite.py` inherits the unicode expected values (row 10 = `"héllo"` / `"HÉLLO"` / `"oll\u00e9h"`) and `supported_ops()` restricts the test suite to `{"trim", "length"}`. Adding an op without also enabling a Unicode-safe expression is caught immediately by cross-framework comparison.
+- **Regression signal**: `test_unsupported_op_does_not_match[upper|lower|reverse]` pins the refusal, and `test_sqlite.py` inherits the unicode expected values (row 10 = `"héllo"` / `"HÉLLO"` / `"oll\u00e9h"`) and `supported_ops()` restricts the test suite to `{"trim", "length"}`. Adding an op without also enabling a Unicode-safe expression is caught immediately by cross-framework comparison.
 - **Related**: Resolved from #146 via #147.
 
 ### Float accumulation order across SQL engines vs. columnar reductions
@@ -218,7 +216,7 @@ condition: SQLite has no percentile implementation and no native reverse
 mitigation_location:
 - mloda/community/feature_groups/data_operations/string/sqlite_string.py
 regression_test:
-- mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py::TestSqliteUnsupportedOps::test_reverse_does_not_match
+- mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py::TestSqliteUnsupportedOps::test_unsupported_op_does_not_match
 - mloda/community/feature_groups/data_operations/tests/test_framework_support_matrix.py::test_framework_support_matrix_is_in_sync
 -->
 

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
@@ -86,54 +86,37 @@ class TestPatternMatching:
         result = AggregationFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_rejects_unimplemented_dynamic_type(self) -> None:
-        """Unimplemented dynamic types like percentile_75 should not match."""
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            # percentile_75 parses as a dynamic type but has no implementation.
+            pytest.param("value_int__percentile_75_agg", id="unimplemented_dynamic_type"),
+            pytest.param("value_int__avg_window", id="wrong_suffix"),
+            pytest.param("value_int__avg", id="no_suffix"),
+            pytest.param("avg_agg", id="no_source_column"),
+            pytest.param("value_int__unknown_agg", id="invalid_operation"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options(context={"partition_by": ["region"]})
-        result = AggregationFeatureGroup.match_feature_group_criteria("value_int__percentile_75_agg", options, None)
-        assert result is False
-
-    def test_no_match_wrong_suffix(self) -> None:
-        """Feature with wrong suffix (window instead of agg) should not match."""
-        options = Options(context={"partition_by": ["region"]})
-        result = AggregationFeatureGroup.match_feature_group_criteria("value_int__avg_window", options, None)
-        assert result is False
-
-    def test_no_match_no_suffix(self) -> None:
-        """Feature without _agg suffix should not match."""
-        options = Options(context={"partition_by": ["region"]})
-        result = AggregationFeatureGroup.match_feature_group_criteria("value_int__avg", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        """Feature with no source column (just operation_agg) should not match."""
-        options = Options(context={"partition_by": ["region"]})
-        result = AggregationFeatureGroup.match_feature_group_criteria("avg_agg", options, None)
-        assert result is False
-
-    def test_no_match_invalid_operation(self) -> None:
-        """Feature with an unknown/invalid operation should not match."""
-        options = Options(context={"partition_by": ["region"]})
-        result = AggregationFeatureGroup.match_feature_group_criteria("value_int__unknown_agg", options, None)
+        result = AggregationFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
 
 class TestPatternParsing:
     """Tests for extracting operation and source column from feature names."""
 
-    def test_parse_avg_operation(self) -> None:
-        """Parsing value_int__avg_agg should yield operation=avg."""
-        operation = AggregationFeatureGroup.get_aggregation_type("value_int__avg_agg")
-        assert operation == "avg"
-
-    def test_parse_sum_operation(self) -> None:
-        """Parsing my_col__sum_agg should yield operation=sum."""
-        operation = AggregationFeatureGroup.get_aggregation_type("my_col__sum_agg")
-        assert operation == "sum"
-
-    def test_parse_percentile_operation(self) -> None:
-        """Parsing value_int__percentile_75_agg should yield operation=percentile_75."""
-        operation = AggregationFeatureGroup.get_aggregation_type("value_int__percentile_75_agg")
-        assert operation == "percentile_75"
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("value_int__avg_agg", "avg", id="avg"),
+            pytest.param("my_col__sum_agg", "sum", id="sum"),
+            pytest.param("value_int__percentile_75_agg", "percentile_75", id="percentile"),
+        ],
+    )
+    def test_parse_operation(self, feature_name: str, expected: str) -> None:
+        operation = AggregationFeatureGroup.get_aggregation_type(feature_name)
+        assert operation == expected
 
     def test_parse_source_feature_from_avg(self) -> None:
         """Source feature should be extracted correctly from value_int__avg_agg."""

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -51,19 +51,17 @@ class TestPatternMatching:
         result = BinningFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_no_match_wrong_suffix(self) -> None:
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("value_int__bucket_3", id="wrong_suffix"),
+            pytest.param("value_int__bin", id="no_number"),
+            pytest.param("bin_3", id="no_source_column"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options()
-        result = BinningFeatureGroup.match_feature_group_criteria("value_int__bucket_3", options, None)
-        assert result is False
-
-    def test_no_match_no_number(self) -> None:
-        options = Options()
-        result = BinningFeatureGroup.match_feature_group_criteria("value_int__bin", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        options = Options()
-        result = BinningFeatureGroup.match_feature_group_criteria("bin_3", options, None)
+        result = BinningFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
     @pytest.mark.parametrize(

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/tests/test_base.py
@@ -53,19 +53,17 @@ class TestPatternMatching:
         result = DateTimeFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_no_match_wrong_suffix(self) -> None:
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("timestamp__weekday", id="wrong_suffix"),
+            pytest.param("timestamp", id="no_suffix"),
+            pytest.param("year", id="no_source_column"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options()
-        result = DateTimeFeatureGroup.match_feature_group_criteria("timestamp__weekday", options, None)
-        assert result is False
-
-    def test_no_match_no_suffix(self) -> None:
-        options = Options()
-        result = DateTimeFeatureGroup.match_feature_group_criteria("timestamp", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        options = Options()
-        result = DateTimeFeatureGroup.match_feature_group_criteria("year", options, None)
+        result = DateTimeFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -59,35 +59,21 @@ class TestPatternParsing:
         result = FrameAggregateFeatureGroup._parse_frame_feature("plain_feature")
         assert result is None
 
-    def test_rolling_large_window(self) -> None:
-        result = FrameAggregateFeatureGroup._parse_frame_feature("value__max_rolling_100")
+    @pytest.mark.parametrize(
+        ("feature_name", "expected_fields"),
+        [
+            pytest.param("value__max_rolling_100", {"frame_size": 100, "agg_type": "max"}, id="rolling_large_window"),
+            pytest.param("temp__min_24_hour_window", {"frame_unit": "hour", "frame_size": 24}, id="time_window_hour"),
+            pytest.param("price__cummin", {"agg_type": "min", "frame_type": "cumulative"}, id="cummin"),
+            pytest.param("price__cummax", {"agg_type": "max", "frame_type": "cumulative"}, id="cummax"),
+            pytest.param("price__cumcount", {"agg_type": "count", "frame_type": "cumulative"}, id="cumcount"),
+        ],
+    )
+    def test_parse_frame_fields(self, feature_name: str, expected_fields: dict[str, Any]) -> None:
+        result = FrameAggregateFeatureGroup._parse_frame_feature(feature_name)
         assert result is not None
-        assert result["frame_size"] == 100
-        assert result["agg_type"] == "max"
-
-    def test_time_window_hour(self) -> None:
-        result = FrameAggregateFeatureGroup._parse_frame_feature("temp__min_24_hour_window")
-        assert result is not None
-        assert result["frame_unit"] == "hour"
-        assert result["frame_size"] == 24
-
-    def test_cummin(self) -> None:
-        result = FrameAggregateFeatureGroup._parse_frame_feature("price__cummin")
-        assert result is not None
-        assert result["agg_type"] == "min"
-        assert result["frame_type"] == "cumulative"
-
-    def test_cummax(self) -> None:
-        result = FrameAggregateFeatureGroup._parse_frame_feature("price__cummax")
-        assert result is not None
-        assert result["agg_type"] == "max"
-        assert result["frame_type"] == "cumulative"
-
-    def test_cumcount(self) -> None:
-        result = FrameAggregateFeatureGroup._parse_frame_feature("price__cumcount")
-        assert result is not None
-        assert result["agg_type"] == "count"
-        assert result["frame_type"] == "cumulative"
+        for field, expected in expected_fields.items():
+            assert result[field] == expected, f"{feature_name}: {field}"
 
 
 class TestParseFrameFeatureMemoization:
@@ -117,25 +103,24 @@ class TestPatternMatching:
     def _base_options(self) -> Options:
         return Options(context={"partition_by": ["region"], "order_by": "timestamp"})
 
-    def test_matches_rolling_string(self) -> None:
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("sales__sum_rolling_3", True, id="rolling_string"),
+            pytest.param("sales__avg_7_day_window", True, id="time_window_string"),
+            pytest.param("sales__cumsum", True, id="cumulative_string"),
+            pytest.param("sales__expanding_avg", True, id="expanding_string"),
+            # cumavg is a valid cumulative operation (cumulative and expanding are aliases).
+            pytest.param("sales__cumavg", True, id="cumavg"),
+            pytest.param("sales__unknown_rolling_3", False, id="invalid_agg_type"),
+            pytest.param("sales__avg_7_banana_window", False, id="invalid_time_unit"),
+            pytest.param("plain_feature", False, id="plain_feature_without_config"),
+        ],
+    )
+    def test_match_by_name(self, feature_name: str, expected: bool) -> None:
         options = self._base_options()
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
-        assert result is True
-
-    def test_matches_time_window_string(self) -> None:
-        options = self._base_options()
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__avg_7_day_window", options, None)
-        assert result is True
-
-    def test_matches_cumulative_string(self) -> None:
-        options = self._base_options()
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__cumsum", options, None)
-        assert result is True
-
-    def test_matches_expanding_string(self) -> None:
-        options = self._base_options()
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__expanding_avg", options, None)
-        assert result is True
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(feature_name, options, None)
+        assert result is expected
 
     def test_rejects_no_partition_by(self) -> None:
         options = Options(context={"order_by": "timestamp"})
@@ -168,30 +153,9 @@ class TestPatternMatching:
         result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
         assert result is False
 
-    def test_rejects_invalid_agg_type(self) -> None:
-        options = self._base_options()
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__unknown_rolling_3", options, None)
-        assert result is False
-
-    def test_accepts_cumavg(self) -> None:
-        """cumavg is a valid cumulative operation (cumulative and expanding are aliases)."""
-        options = self._base_options()
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__cumavg", options, None)
-        assert result is True
-
-    def test_rejects_invalid_time_unit(self) -> None:
-        options = self._base_options()
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__avg_7_banana_window", options, None)
-        assert result is False
-
     def test_rejects_partition_by_as_string(self) -> None:
         options = Options(context={"partition_by": "region", "order_by": "timestamp"})
         result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
-        assert result is False
-
-    def test_rejects_plain_feature_without_config(self) -> None:
-        options = self._base_options()
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("plain_feature", options, None)
         assert result is False
 
 
@@ -448,20 +412,19 @@ class TestNameBasedUnaffectedByConfigValidation:
 class TestNameBasedFrameTypeInOptions:
     """A frame name already encodes its size, so a frame_type carried in Options must not demand frame_size."""
 
-    def test_rolling_name_with_frame_type_option(self) -> None:
-        options = Options(context={"frame_type": "rolling", "partition_by": ["region"], "order_by": "timestamp"})
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
-        assert result is True
-
-    def test_time_window_name_with_frame_type_option(self) -> None:
-        options = Options(context={"frame_type": "time", "partition_by": ["region"], "order_by": "timestamp"})
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__avg_7_day_window", options, None)
-        assert result is True
-
-    def test_rolling_name_with_stray_time_frame_type_option(self) -> None:
-        """A time frame_type option contradicting a rolling name must not trigger config-path size/unit rules."""
-        options = Options(context={"frame_type": "time", "partition_by": ["region"], "order_by": "timestamp"})
-        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
+    @pytest.mark.parametrize(
+        ("feature_name", "frame_type"),
+        [
+            pytest.param("sales__sum_rolling_3", "rolling", id="rolling_name"),
+            pytest.param("sales__avg_7_day_window", "time", id="time_window_name"),
+            # A time frame_type option contradicting a rolling name must not trigger
+            # config-path size/unit rules.
+            pytest.param("sales__sum_rolling_3", "time", id="rolling_name_with_stray_time"),
+        ],
+    )
+    def test_name_with_frame_type_option(self, feature_name: str, frame_type: str) -> None:
+        options = Options(context={"frame_type": frame_type, "partition_by": ["region"], "order_by": "timestamp"})
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True
 
     def test_rolling_name_with_propagated_frame_type(self) -> None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -29,20 +29,18 @@ class TestClassAttributes:
         assert OffsetFeatureGroup._supports_offset_type("lag_1")
         assert OffsetFeatureGroup._supports_offset_type("lag_5")
 
-    def test_supports_lead(self) -> None:
-        assert OffsetFeatureGroup._supports_offset_type("lead_1")
-
-    def test_supports_diff(self) -> None:
-        assert OffsetFeatureGroup._supports_offset_type("diff_1")
-
-    def test_supports_pct_change(self) -> None:
-        assert OffsetFeatureGroup._supports_offset_type("pct_change_1")
-
-    def test_supports_first_value(self) -> None:
-        assert OffsetFeatureGroup._supports_offset_type("first_value")
-
-    def test_supports_last_value(self) -> None:
-        assert OffsetFeatureGroup._supports_offset_type("last_value")
+    @pytest.mark.parametrize(
+        "offset_type",
+        [
+            pytest.param("lead_1", id="lead"),
+            pytest.param("diff_1", id="diff"),
+            pytest.param("pct_change_1", id="pct_change"),
+            pytest.param("first_value", id="first_value"),
+            pytest.param("last_value", id="last_value"),
+        ],
+    )
+    def test_supports_offset_type(self, offset_type: str) -> None:
+        assert OffsetFeatureGroup._supports_offset_type(offset_type)
 
     def test_rejects_invalid(self) -> None:
         assert not OffsetFeatureGroup._supports_offset_type("lag_0")
@@ -87,14 +85,16 @@ class TestPatternMatching:
 
 
 class TestPatternParsing:
-    def test_parse_lag(self) -> None:
-        assert OffsetFeatureGroup.get_offset_type("value_int__lag_1_offset") == "lag_1"
-
-    def test_parse_lead(self) -> None:
-        assert OffsetFeatureGroup.get_offset_type("value_int__lead_3_offset") == "lead_3"
-
-    def test_parse_first_value(self) -> None:
-        assert OffsetFeatureGroup.get_offset_type("value_int__first_value_offset") == "first_value"
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("value_int__lag_1_offset", "lag_1", id="lag"),
+            pytest.param("value_int__lead_3_offset", "lead_3", id="lead"),
+            pytest.param("value_int__first_value_offset", "first_value", id="first_value"),
+        ],
+    )
+    def test_parse_offset_type(self, feature_name: str, expected: str) -> None:
+        assert OffsetFeatureGroup.get_offset_type(feature_name) == expected
 
     def test_parse_source_feature(self) -> None:
         from mloda.user import Feature

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
@@ -53,53 +53,36 @@ class TestPatternMatching:
         result = PercentileFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_no_match_wrong_suffix(self) -> None:
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("value_int__p50_grouped", id="wrong_suffix"),
+            pytest.param("value_int__p50", id="no_suffix"),
+            pytest.param("p50_percentile", id="no_source_column"),
+            pytest.param("value_int__p101_percentile", id="invalid_percentile_too_high"),
+            pytest.param("value_int__p-1_percentile", id="invalid_percentile_negative"),
+            pytest.param("value_int__pfoo_percentile", id="non_numeric"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options(context={"partition_by": ["region"]})
-        result = PercentileFeatureGroup.match_feature_group_criteria("value_int__p50_grouped", options, None)
-        assert result is False
-
-    def test_no_match_no_suffix(self) -> None:
-        options = Options(context={"partition_by": ["region"]})
-        result = PercentileFeatureGroup.match_feature_group_criteria("value_int__p50", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        options = Options(context={"partition_by": ["region"]})
-        result = PercentileFeatureGroup.match_feature_group_criteria("p50_percentile", options, None)
-        assert result is False
-
-    def test_no_match_invalid_percentile_too_high(self) -> None:
-        options = Options(context={"partition_by": ["region"]})
-        result = PercentileFeatureGroup.match_feature_group_criteria("value_int__p101_percentile", options, None)
-        assert result is False
-
-    def test_no_match_invalid_percentile_negative(self) -> None:
-        options = Options(context={"partition_by": ["region"]})
-        result = PercentileFeatureGroup.match_feature_group_criteria("value_int__p-1_percentile", options, None)
-        assert result is False
-
-    def test_no_match_non_numeric(self) -> None:
-        options = Options(context={"partition_by": ["region"]})
-        result = PercentileFeatureGroup.match_feature_group_criteria("value_int__pfoo_percentile", options, None)
+        result = PercentileFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
 
 class TestPatternParsing:
-    def test_parse_p50(self) -> None:
-        result = PercentileFeatureGroup.get_percentile_value("value_int__p50_percentile")
-        assert result == 0.5
-
-    def test_parse_p25(self) -> None:
-        result = PercentileFeatureGroup.get_percentile_value("value_int__p25_percentile")
-        assert result == 0.25
-
-    def test_parse_p0(self) -> None:
-        result = PercentileFeatureGroup.get_percentile_value("value_int__p0_percentile")
-        assert result == 0.0
-
-    def test_parse_p100(self) -> None:
-        result = PercentileFeatureGroup.get_percentile_value("value_int__p100_percentile")
-        assert result == 1.0
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("value_int__p50_percentile", 0.5, id="p50"),
+            pytest.param("value_int__p25_percentile", 0.25, id="p25"),
+            pytest.param("value_int__p0_percentile", 0.0, id="p0"),
+            pytest.param("value_int__p100_percentile", 1.0, id="p100"),
+        ],
+    )
+    def test_parse_percentile_value(self, feature_name: str, expected: float) -> None:
+        result = PercentileFeatureGroup.get_percentile_value(feature_name)
+        assert result == expected
 
     def test_parse_source_feature(self) -> None:
         feature = Feature(
@@ -119,104 +102,30 @@ class TestPatternParsing:
 
 
 class TestConfigBasedFeatures:
-    def test_config_based_match(self) -> None:
+    @pytest.mark.parametrize(
+        ("percentile", "expected"),
+        [
+            pytest.param(0.75, True, id="valid"),
+            pytest.param(1.5, False, id="rejects_invalid_percentile_too_high"),
+            pytest.param(-0.1, False, id="rejects_invalid_percentile_negative"),
+            pytest.param(True, False, id="rejects_bool_true"),
+            pytest.param(False, False, id="rejects_bool_false"),
+            pytest.param(1, True, id="boundary_int_one"),
+            pytest.param(0, True, id="boundary_int_zero"),
+            pytest.param(1.0, True, id="boundary_float_one"),
+            pytest.param(0.0, True, id="boundary_float_zero"),
+        ],
+    )
+    def test_config_based_match(self, percentile: float | int | bool, expected: bool) -> None:
         options = Options(
             context={
-                "percentile": 0.75,
+                "percentile": percentile,
                 "in_features": "value_int",
                 "partition_by": ["region"],
             }
         )
         result = PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is True
-
-    def test_config_based_match_rejects_invalid_percentile_too_high(self) -> None:
-        options = Options(
-            context={
-                "percentile": 1.5,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-            }
-        )
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is False
-
-    def test_config_based_match_rejects_invalid_percentile_negative(self) -> None:
-        options = Options(
-            context={
-                "percentile": -0.1,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-            }
-        )
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is False
-
-    def test_config_based_match_rejects_bool_true(self) -> None:
-        options = Options(
-            context={
-                "percentile": True,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-            }
-        )
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is False
-
-    def test_config_based_match_rejects_bool_false(self) -> None:
-        options = Options(
-            context={
-                "percentile": False,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-            }
-        )
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is False
-
-    def test_config_based_match_boundary_int_one(self) -> None:
-        options = Options(
-            context={
-                "percentile": 1,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-            }
-        )
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is True
-
-    def test_config_based_match_boundary_int_zero(self) -> None:
-        options = Options(
-            context={
-                "percentile": 0,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-            }
-        )
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is True
-
-    def test_config_based_match_boundary_float_one(self) -> None:
-        options = Options(
-            context={
-                "percentile": 1.0,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-            }
-        )
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is True
-
-    def test_config_based_match_boundary_float_zero(self) -> None:
-        options = Options(
-            context={
-                "percentile": 0.0,
-                "in_features": "value_int",
-                "partition_by": ["region"],
-            }
-        )
-        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is True
+        assert result is expected
 
     def test_config_based_match_rejects_missing_partition_by(self) -> None:
         options = Options(

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
@@ -56,47 +56,34 @@ class TestPatternMatching:
         result = PointArithmeticFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_no_match_wrong_suffix(self) -> None:
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("value_int&amount__add_constant", id="wrong_suffix"),
+            pytest.param("value_int&amount__add", id="no_suffix"),
+            pytest.param("add_point", id="no_source_column"),
+            pytest.param("value_int&amount__unknown_point", id="invalid_operation"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options()
-        result = PointArithmeticFeatureGroup.match_feature_group_criteria(
-            "value_int&amount__add_constant", options, None
-        )
-        assert result is False
-
-    def test_no_match_no_suffix(self) -> None:
-        options = Options()
-        result = PointArithmeticFeatureGroup.match_feature_group_criteria("value_int&amount__add", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        options = Options()
-        result = PointArithmeticFeatureGroup.match_feature_group_criteria("add_point", options, None)
-        assert result is False
-
-    def test_no_match_invalid_operation(self) -> None:
-        options = Options()
-        result = PointArithmeticFeatureGroup.match_feature_group_criteria(
-            "value_int&amount__unknown_point", options, None
-        )
+        result = PointArithmeticFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
 
 class TestPatternParsing:
-    def test_parse_add_operation(self) -> None:
-        operation = PointArithmeticFeatureGroup.get_arithmetic_op("value_int&amount__add_point")
-        assert operation == "add"
-
-    def test_parse_subtract_operation(self) -> None:
-        operation = PointArithmeticFeatureGroup.get_arithmetic_op("value_int&amount__subtract_point")
-        assert operation == "subtract"
-
-    def test_parse_multiply_operation(self) -> None:
-        operation = PointArithmeticFeatureGroup.get_arithmetic_op("value_int&amount__multiply_point")
-        assert operation == "multiply"
-
-    def test_parse_divide_operation(self) -> None:
-        operation = PointArithmeticFeatureGroup.get_arithmetic_op("value_int&amount__divide_point")
-        assert operation == "divide"
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("value_int&amount__add_point", "add", id="add"),
+            pytest.param("value_int&amount__subtract_point", "subtract", id="subtract"),
+            pytest.param("value_int&amount__multiply_point", "multiply", id="multiply"),
+            pytest.param("value_int&amount__divide_point", "divide", id="divide"),
+        ],
+    )
+    def test_parse_operation(self, feature_name: str, expected: str) -> None:
+        operation = PointArithmeticFeatureGroup.get_arithmetic_op(feature_name)
+        assert operation == expected
 
     def test_parse_source_features(self) -> None:
         feature = Feature("value_int&amount__add_point", options=Options())

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -35,35 +35,35 @@ class TestClassAttributes:
         for op in expected_ops:
             assert op in RankFeatureGroup.RANK_TYPES, f"Missing rank type: {op}"
 
-    def test_supports_ntile(self) -> None:
-        assert RankFeatureGroup._supports_rank_type("ntile_4")
-        assert RankFeatureGroup._supports_rank_type("ntile_10")
+    @pytest.mark.parametrize(
+        "rank_types",
+        [
+            pytest.param(["ntile_4", "ntile_10"], id="ntile"),
+            pytest.param(["top_5", "top_1"], id="top_n"),
+            pytest.param(["bottom_5", "bottom_1"], id="bottom_n"),
+        ],
+    )
+    def test_supports_parametric_rank_types(self, rank_types: list[str]) -> None:
+        for rank_type in rank_types:
+            assert RankFeatureGroup._supports_rank_type(rank_type)
 
-    def test_rejects_invalid_ntile(self) -> None:
-        assert not RankFeatureGroup._supports_rank_type("ntile_0")
-        assert not RankFeatureGroup._supports_rank_type("ntile_abc")
+    @pytest.mark.parametrize(
+        "rank_types",
+        [
+            pytest.param(["ntile_0", "ntile_abc"], id="ntile"),
+            pytest.param(["top_0", "top_abc"], id="top_n"),
+            pytest.param(["bottom_0", "bottom_abc"], id="bottom_n"),
+        ],
+    )
+    def test_rejects_invalid_parametric_rank_types(self, rank_types: list[str]) -> None:
+        for rank_type in rank_types:
+            assert not RankFeatureGroup._supports_rank_type(rank_type)
 
     def test_supports_ntile_1(self) -> None:
         assert RankFeatureGroup._supports_rank_type("ntile_1")
 
     def test_rejects_ntile_negative(self) -> None:
         assert not RankFeatureGroup._supports_rank_type("ntile_-1")
-
-    def test_supports_top_n(self) -> None:
-        assert RankFeatureGroup._supports_rank_type("top_5")
-        assert RankFeatureGroup._supports_rank_type("top_1")
-
-    def test_supports_bottom_n(self) -> None:
-        assert RankFeatureGroup._supports_rank_type("bottom_5")
-        assert RankFeatureGroup._supports_rank_type("bottom_1")
-
-    def test_rejects_invalid_top_n(self) -> None:
-        assert not RankFeatureGroup._supports_rank_type("top_0")
-        assert not RankFeatureGroup._supports_rank_type("top_abc")
-
-    def test_rejects_invalid_bottom_n(self) -> None:
-        assert not RankFeatureGroup._supports_rank_type("bottom_0")
-        assert not RankFeatureGroup._supports_rank_type("bottom_abc")
 
     def test_min_in_features_is_one(self) -> None:
         assert RankFeatureGroup.MIN_IN_FEATURES == 1
@@ -117,59 +117,39 @@ class TestPatternMatching:
         result = RankFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_matches_ntile(self) -> None:
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("value_int__ntile_4_ranked", True, id="ntile"),
+            pytest.param("value_int__rank_window", False, id="wrong_suffix"),
+            pytest.param("rank_ranked", False, id="no_source_column"),
+            pytest.param("value_int__unknown_ranked", False, id="invalid_rank_type"),
+            pytest.param("value_int__top_5_ranked", True, id="top_n"),
+            pytest.param("value_int__bottom_3_ranked", True, id="bottom_n"),
+        ],
+    )
+    def test_match_by_name(self, feature_name: str, expected: bool) -> None:
         options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
-        result = RankFeatureGroup.match_feature_group_criteria("value_int__ntile_4_ranked", options, None)
-        assert result is True
-
-    def test_no_match_wrong_suffix(self) -> None:
-        options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
-        result = RankFeatureGroup.match_feature_group_criteria("value_int__rank_window", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
-        result = RankFeatureGroup.match_feature_group_criteria("rank_ranked", options, None)
-        assert result is False
-
-    def test_no_match_invalid_rank_type(self) -> None:
-        options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
-        result = RankFeatureGroup.match_feature_group_criteria("value_int__unknown_ranked", options, None)
-        assert result is False
-
-    def test_matches_top_n(self) -> None:
-        options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
-        result = RankFeatureGroup.match_feature_group_criteria("value_int__top_5_ranked", options, None)
-        assert result is True
-
-    def test_matches_bottom_n(self) -> None:
-        options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
-        result = RankFeatureGroup.match_feature_group_criteria("value_int__bottom_3_ranked", options, None)
-        assert result is True
+        result = RankFeatureGroup.match_feature_group_criteria(feature_name, options, None)
+        assert result is expected
 
 
 class TestPatternParsing:
     """Tests for extracting rank type and source column."""
 
-    def test_parse_row_number(self) -> None:
-        rank_type = RankFeatureGroup.get_rank_type("value_int__row_number_ranked")
-        assert rank_type == "row_number"
-
-    def test_parse_dense_rank(self) -> None:
-        rank_type = RankFeatureGroup.get_rank_type("my_col__dense_rank_ranked")
-        assert rank_type == "dense_rank"
-
-    def test_parse_ntile(self) -> None:
-        rank_type = RankFeatureGroup.get_rank_type("value_int__ntile_4_ranked")
-        assert rank_type == "ntile_4"
-
-    def test_parse_top_n(self) -> None:
-        rank_type = RankFeatureGroup.get_rank_type("value_int__top_5_ranked")
-        assert rank_type == "top_5"
-
-    def test_parse_bottom_n(self) -> None:
-        rank_type = RankFeatureGroup.get_rank_type("value_int__bottom_3_ranked")
-        assert rank_type == "bottom_3"
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("value_int__row_number_ranked", "row_number", id="row_number"),
+            pytest.param("my_col__dense_rank_ranked", "dense_rank", id="dense_rank"),
+            pytest.param("value_int__ntile_4_ranked", "ntile_4", id="ntile"),
+            pytest.param("value_int__top_5_ranked", "top_5", id="top_n"),
+            pytest.param("value_int__bottom_3_ranked", "bottom_3", id="bottom_n"),
+        ],
+    )
+    def test_parse_rank_type(self, feature_name: str, expected: str) -> None:
+        rank_type = RankFeatureGroup.get_rank_type(feature_name)
+        assert rank_type == expected
 
     def test_parse_source_feature(self) -> None:
         from mloda.user import Feature

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/tests/test_base.py
@@ -54,24 +54,18 @@ class TestPatternMatching:
         result = ScalarAggregateFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_no_match_wrong_suffix(self) -> None:
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("value_int__sum_grouped", id="wrong_suffix"),
+            pytest.param("value_int__sum", id="no_suffix"),
+            pytest.param("sum_scalar", id="no_source_column"),
+            pytest.param("value_int__unknown_scalar", id="invalid_operation"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options()
-        result = ScalarAggregateFeatureGroup.match_feature_group_criteria("value_int__sum_grouped", options, None)
-        assert result is False
-
-    def test_no_match_no_suffix(self) -> None:
-        options = Options()
-        result = ScalarAggregateFeatureGroup.match_feature_group_criteria("value_int__sum", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        options = Options()
-        result = ScalarAggregateFeatureGroup.match_feature_group_criteria("sum_scalar", options, None)
-        assert result is False
-
-    def test_no_match_invalid_operation(self) -> None:
-        options = Options()
-        result = ScalarAggregateFeatureGroup.match_feature_group_criteria("value_int__unknown_scalar", options, None)
+        result = ScalarAggregateFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -65,43 +65,34 @@ class TestPatternMatching:
         result = ScalarArithmeticFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_no_match_wrong_suffix(self) -> None:
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("value_int__add_scalar", id="wrong_suffix"),
+            pytest.param("value_int__add", id="no_suffix"),
+            pytest.param("add_constant", id="no_source_column"),
+            pytest.param("value_int__unknown_constant", id="invalid_operation"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options()
-        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("value_int__add_scalar", options, None)
-        assert result is False
-
-    def test_no_match_no_suffix(self) -> None:
-        options = Options()
-        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("value_int__add", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        options = Options()
-        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("add_constant", options, None)
-        assert result is False
-
-    def test_no_match_invalid_operation(self) -> None:
-        options = Options()
-        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria("value_int__unknown_constant", options, None)
+        result = ScalarArithmeticFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
 
 class TestPatternParsing:
-    def test_parse_add_operation(self) -> None:
-        operation = ScalarArithmeticFeatureGroup.get_arithmetic_op("value_int__add_constant")
-        assert operation == "add"
-
-    def test_parse_subtract_operation(self) -> None:
-        operation = ScalarArithmeticFeatureGroup.get_arithmetic_op("value_int__subtract_constant")
-        assert operation == "subtract"
-
-    def test_parse_multiply_operation(self) -> None:
-        operation = ScalarArithmeticFeatureGroup.get_arithmetic_op("value_int__multiply_constant")
-        assert operation == "multiply"
-
-    def test_parse_divide_operation(self) -> None:
-        operation = ScalarArithmeticFeatureGroup.get_arithmetic_op("value_int__divide_constant")
-        assert operation == "divide"
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("value_int__add_constant", "add", id="add"),
+            pytest.param("value_int__subtract_constant", "subtract", id="subtract"),
+            pytest.param("value_int__multiply_constant", "multiply", id="multiply"),
+            pytest.param("value_int__divide_constant", "divide", id="divide"),
+        ],
+    )
+    def test_parse_operation(self, feature_name: str, expected: str) -> None:
+        operation = ScalarArithmeticFeatureGroup.get_arithmetic_op(feature_name)
+        assert operation == expected
 
     def test_parse_source_feature(self) -> None:
         feature = Feature("value_int__add_constant", options=Options(context={"constant": 5}))

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_security.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_security.py
@@ -274,27 +274,22 @@ def _make_fs_with_constant(name: str, constant: Any) -> FeatureSet:
 class TestConstantTypeValidation:
     """Regression guards: ``constant`` must be a real int or float (bool is rejected)."""
 
-    def test_constant_true_rejected(self) -> None:
-        """``constant=True`` must be rejected even though ``bool`` is an ``int`` subclass."""
+    @pytest.mark.parametrize(
+        ("constant", "match"),
+        [
+            # ``constant=True`` must be rejected even though ``bool`` is an ``int`` subclass.
+            pytest.param(True, r"int or float|bool", id="true"),
+            # ``constant=False`` must be rejected, not silently coerced to ``0`` (which would
+            # collapse into a divide-by-zero on op=divide). Every case uses op=add so this asserts
+            # the type check fires, independent of the divide-by-zero check.
+            pytest.param(False, r"int or float|bool", id="false"),
+            pytest.param("five", r"int or float", id="string"),
+        ],
+    )
+    def test_non_numeric_constant_rejected(self, constant: Any, match: str) -> None:
         arrow_table = PyArrowDataOpsTestDataCreator.create()
-        fs = _make_fs_with_constant("value_int__add_constant", True)
-        with pytest.raises(ValueError, match=r"int or float|bool"):
-            PyArrowScalarArithmetic.calculate_feature(arrow_table, fs)
-
-    def test_constant_false_rejected(self) -> None:
-        """``constant=False`` must be rejected, not silently coerced to ``0`` (which would
-        collapse into a divide-by-zero on op=divide). Use op=add so this asserts the
-        type check fires, independent of the divide-by-zero check.
-        """
-        arrow_table = PyArrowDataOpsTestDataCreator.create()
-        fs = _make_fs_with_constant("value_int__add_constant", False)
-        with pytest.raises(ValueError, match=r"int or float|bool"):
-            PyArrowScalarArithmetic.calculate_feature(arrow_table, fs)
-
-    def test_constant_string_rejected(self) -> None:
-        arrow_table = PyArrowDataOpsTestDataCreator.create()
-        fs = _make_fs_with_constant("value_int__add_constant", "five")
-        with pytest.raises(ValueError, match=r"int or float"):
+        fs = _make_fs_with_constant("value_int__add_constant", constant)
+        with pytest.raises(ValueError, match=match):
             PyArrowScalarArithmetic.calculate_feature(arrow_table, fs)
 
     def test_constant_multi_element_list_rejected(self) -> None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/tests/test_base.py
@@ -65,26 +65,19 @@ class TestPatternMatching:
         name = f"ts__sessionize_30_{unit}"
         assert PandasSessionization.match_feature_group_criteria(name, _match_options()) is True
 
-    def test_matches_n1_hour(self) -> None:
-        assert PandasSessionization.match_feature_group_criteria("x__sessionize_1_hour", _match_options()) is True
-
-    def test_matches_underscore_source(self) -> None:
-        assert (
-            PandasSessionization.match_feature_group_criteria("created_at__sessionize_15_minute", _match_options())
-            is True
-        )
-
-    def test_no_match_no_unit(self) -> None:
-        assert PandasSessionization.match_feature_group_criteria("ts__sessionize", _match_options()) is False
-
-    def test_no_match_missing_unit_token(self) -> None:
-        assert PandasSessionization.match_feature_group_criteria("ts__sessionize_30", _match_options()) is False
-
-    def test_no_match_invalid_unit(self) -> None:
-        assert PandasSessionization.match_feature_group_criteria("ts__sessionize_30_month", _match_options()) is False
-
-    def test_no_match_no_source_column(self) -> None:
-        assert PandasSessionization.match_feature_group_criteria("sessionize_30_minute", _match_options()) is False
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("x__sessionize_1_hour", True, id="n1_hour"),
+            pytest.param("created_at__sessionize_15_minute", True, id="underscore_source"),
+            pytest.param("ts__sessionize", False, id="no_unit"),
+            pytest.param("ts__sessionize_30", False, id="missing_unit_token"),
+            pytest.param("ts__sessionize_30_month", False, id="invalid_unit"),
+            pytest.param("sessionize_30_minute", False, id="no_source_column"),
+        ],
+    )
+    def test_match_by_name(self, feature_name: str, expected: bool) -> None:
+        assert PandasSessionization.match_feature_group_criteria(feature_name, _match_options()) is expected
 
     def test_n_zero_matches_regex_but_rejected_at_parse(self) -> None:
         """``sessionize_0_minute`` matches the ``\\d+`` regex but n=0 is rejected at parse time.
@@ -97,41 +90,41 @@ class TestPatternMatching:
 
 
 class TestThresholdParser:
-    def test_parse_30_minute(self) -> None:
-        assert _parse_sessionize_op("sessionize_30_minute") == (30, "minute")
+    @pytest.mark.parametrize(
+        ("op_token", "expected"),
+        [
+            pytest.param("sessionize_30_minute", (30, "minute"), id="30_minute"),
+            pytest.param("sessionize_1_hour", (1, "hour"), id="1_hour"),
+            pytest.param("sessionize_2_day", (2, "day"), id="2_day"),
+            pytest.param("sessionize_1_week", (1, "week"), id="1_week"),
+        ],
+    )
+    def test_parse_op_components(self, op_token: str, expected: tuple[int, str]) -> None:
+        assert _parse_sessionize_op(op_token) == expected
 
-    def test_parse_1_hour(self) -> None:
-        assert _parse_sessionize_op("sessionize_1_hour") == (1, "hour")
+    @pytest.mark.parametrize(
+        ("n", "unit", "expected"),
+        [
+            pytest.param(30, "minute", 30 * 60, id="minute"),
+            pytest.param(1, "hour", 3600, id="hour"),
+            pytest.param(2, "day", 2 * 86400, id="day"),
+            pytest.param(1, "week", 604800, id="week"),
+        ],
+    )
+    def test_threshold_seconds(self, n: int, unit: str, expected: int) -> None:
+        assert _sessionize_threshold_seconds(n, unit) == expected
 
-    def test_parse_2_day(self) -> None:
-        assert _parse_sessionize_op("sessionize_2_day") == (2, "day")
-
-    def test_parse_1_week(self) -> None:
-        assert _parse_sessionize_op("sessionize_1_week") == (1, "week")
-
-    def test_threshold_seconds_minute(self) -> None:
-        assert _sessionize_threshold_seconds(30, "minute") == 30 * 60
-
-    def test_threshold_seconds_hour(self) -> None:
-        assert _sessionize_threshold_seconds(1, "hour") == 3600
-
-    def test_threshold_seconds_day(self) -> None:
-        assert _sessionize_threshold_seconds(2, "day") == 2 * 86400
-
-    def test_threshold_seconds_week(self) -> None:
-        assert _sessionize_threshold_seconds(1, "week") == 604800
-
-    def test_threshold_seconds_rejects_bad_unit(self) -> None:
-        with pytest.raises(ValueError, match=r"(?i)unit|month"):
-            _sessionize_threshold_seconds(1, "month")
-
-    def test_threshold_seconds_rejects_n_zero(self) -> None:
-        with pytest.raises(ValueError, match=r"(?i)positive|> 0|n"):
-            _sessionize_threshold_seconds(0, "minute")
-
-    def test_threshold_seconds_rejects_negative_n(self) -> None:
-        with pytest.raises(ValueError, match=r"(?i)positive|> 0|n"):
-            _sessionize_threshold_seconds(-5, "minute")
+    @pytest.mark.parametrize(
+        ("n", "unit", "match"),
+        [
+            pytest.param(1, "month", r"(?i)unit|month", id="bad_unit"),
+            pytest.param(0, "minute", r"(?i)positive|> 0|n", id="n_zero"),
+            pytest.param(-5, "minute", r"(?i)positive|> 0|n", id="negative_n"),
+        ],
+    )
+    def test_threshold_seconds_rejects(self, n: int, unit: str, match: str) -> None:
+        with pytest.raises(ValueError, match=match):
+            _sessionize_threshold_seconds(n, unit)
 
     def test_parse_rejects_bad_unit(self) -> None:
         with pytest.raises(ValueError, match=r"(?i)unit|month"):

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
@@ -74,67 +74,49 @@ class TestPatternMatching:
         result = TimeBucketizationFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_no_match_wrong_suffix(self) -> None:
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("timestamp__truncate_1_day", id="wrong_suffix"),
+            pytest.param("timestamp", id="no_suffix"),
+            pytest.param("floor_1_day", id="no_source_column"),
+            pytest.param("timestamp__truncate_1_day", id="invalid_op"),
+            pytest.param("timestamp__floor_1_century", id="invalid_unit"),
+            # The pattern itself allows ``\d+`` to include 0; the FG's
+            # _validate_string_match must reject n=0 so this match returns False.
+            pytest.param("timestamp__floor_0_day", id="n_zero"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options()
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("timestamp__truncate_1_day", options, None)
-        assert result is False
-
-    def test_no_match_no_suffix(self) -> None:
-        options = Options()
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("timestamp", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        options = Options()
-        # ``floor_1_day`` alone has no source-column prefix.
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("floor_1_day", options, None)
-        assert result is False
-
-    def test_no_match_invalid_op(self) -> None:
-        options = Options()
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("timestamp__truncate_1_day", options, None)
-        assert result is False
-
-    def test_no_match_invalid_unit(self) -> None:
-        options = Options()
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("timestamp__floor_1_century", options, None)
-        assert result is False
-
-    def test_no_match_n_zero(self) -> None:
-        """``floor_0_day`` is grammatically valid for the regex (``\\d+``) but ``n=0``
-        is rejected by validation. The pattern accepts; the FG validation rejects."""
-        options = Options()
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("timestamp__floor_0_day", options, None)
-        # Pattern itself allows ``\d+`` to include 0; the FG's _validate_string_match
-        # must reject n=0 so this match returns False.
+        result = TimeBucketizationFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
 
 class TestPatternParsing:
-    def test_parse_floor_1_day(self) -> None:
-        op = TimeBucketizationFeatureGroup.get_bucket_op("timestamp__floor_1_day")
-        assert op == "floor_1_day"
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            pytest.param("timestamp__floor_1_day", "floor_1_day", id="floor_1_day"),
+            pytest.param("timestamp__ceil_5_minute", "ceil_5_minute", id="ceil_5_minute"),
+            pytest.param("timestamp__round_1_week", "round_1_week", id="round_1_week"),
+        ],
+    )
+    def test_parse_bucket_op(self, feature_name: str, expected: str) -> None:
+        op = TimeBucketizationFeatureGroup.get_bucket_op(feature_name)
+        assert op == expected
 
-    def test_parse_ceil_5_minute(self) -> None:
-        op = TimeBucketizationFeatureGroup.get_bucket_op("timestamp__ceil_5_minute")
-        assert op == "ceil_5_minute"
-
-    def test_parse_round_1_week(self) -> None:
-        op = TimeBucketizationFeatureGroup.get_bucket_op("timestamp__round_1_week")
-        assert op == "round_1_week"
-
-    def test_parse_op_components_floor_1_day(self) -> None:
-        """Module-level helper splits the op token into (op, n, unit)."""
-        components = _parse_bucket_op("floor_1_day")
-        assert components == ("floor", 1, "day")
-
-    def test_parse_op_components_ceil_15_minute(self) -> None:
-        components = _parse_bucket_op("ceil_15_minute")
-        assert components == ("ceil", 15, "minute")
-
-    def test_parse_op_components_round_1_year(self) -> None:
-        components = _parse_bucket_op("round_1_year")
-        assert components == ("round", 1, "year")
+    @pytest.mark.parametrize(
+        ("op_token", "expected"),
+        [
+            pytest.param("floor_1_day", ("floor", 1, "day"), id="floor_1_day"),
+            pytest.param("ceil_15_minute", ("ceil", 15, "minute"), id="ceil_15_minute"),
+            pytest.param("round_1_year", ("round", 1, "year"), id="round_1_year"),
+        ],
+    )
+    def test_parse_op_components(self, op_token: str, expected: tuple[str, int, str]) -> None:
+        components = _parse_bucket_op(op_token)
+        assert components == expected
 
     def test_parse_source_feature(self) -> None:
         feature = Feature("timestamp__floor_1_day", options=Options())
@@ -163,45 +145,24 @@ class TestPatternParsing:
 
 
 class TestConfigBasedFeatures:
-    def test_config_based_match(self) -> None:
+    @pytest.mark.parametrize(
+        ("bucket_op", "expected"),
+        [
+            pytest.param("floor_1_day", True, id="valid"),
+            pytest.param("bogus_1_day", False, id="rejects_invalid_op"),
+            pytest.param("floor_1_century", False, id="rejects_invalid_unit"),
+            pytest.param("floor_0_day", False, id="rejects_n_zero"),
+        ],
+    )
+    def test_config_based_match(self, bucket_op: str, expected: bool) -> None:
         options = Options(
             context={
-                "bucket_op": "floor_1_day",
+                "bucket_op": bucket_op,
                 "in_features": "timestamp",
             }
         )
         result = TimeBucketizationFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is True
-
-    def test_config_based_match_rejects_invalid_op(self) -> None:
-        options = Options(
-            context={
-                "bucket_op": "bogus_1_day",
-                "in_features": "timestamp",
-            }
-        )
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is False
-
-    def test_config_based_match_rejects_invalid_unit(self) -> None:
-        options = Options(
-            context={
-                "bucket_op": "floor_1_century",
-                "in_features": "timestamp",
-            }
-        )
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is False
-
-    def test_config_based_match_rejects_n_zero(self) -> None:
-        options = Options(
-            context={
-                "bucket_op": "floor_0_day",
-                "in_features": "timestamp",
-            }
-        )
-        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("my_result", options, None)
-        assert result is False
+        assert result is expected
 
 
 class TestSingleColumnEnforcement:

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -86,28 +86,18 @@ class TestPatternMatching:
         result = WindowAggregationFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_no_match_wrong_suffix(self) -> None:
-        """Feature with wrong suffix (grouped instead of groupby) should not match."""
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("value_int__avg_grouped", id="wrong_suffix"),
+            pytest.param("value_int__avg", id="no_suffix"),
+            pytest.param("avg_window", id="no_source_column"),
+            pytest.param("value_int__unknown_window", id="invalid_operation"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options(context={"partition_by": ["region"]})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__avg_grouped", options, None)
-        assert result is False
-
-    def test_no_match_no_suffix(self) -> None:
-        """Feature without _window suffix should not match."""
-        options = Options(context={"partition_by": ["region"]})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__avg", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        """Feature with no source column (just operation_window) should not match."""
-        options = Options(context={"partition_by": ["region"]})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("avg_window", options, None)
-        assert result is False
-
-    def test_no_match_invalid_operation(self) -> None:
-        """Feature with an unknown/invalid operation should not match."""
-        options = Options(context={"partition_by": ["region"]})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__unknown_window", options, None)
+        result = WindowAggregationFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
 
@@ -150,47 +140,37 @@ class TestPatternParsing:
 class TestConfigValidation:
     """Tests for partition_by configuration validation."""
 
-    def test_partition_by_required(self) -> None:
-        """match_feature_group_criteria should fail without partition_by in options."""
-        options = Options(context={})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__sum_window", options, None)
-        assert result is False
-
-    def test_partition_by_accepts_list_of_strings(self) -> None:
-        """partition_by should accept a list of strings."""
-        options = Options(context={"partition_by": ["region", "country"]})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__sum_window", options, None)
-        assert result is True
-
-    def test_partition_by_must_be_list(self) -> None:
-        """partition_by as a plain string (not a list) should fail validation."""
-        options = Options(context={"partition_by": "region"})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__sum_window", options, None)
-        assert result is False
-
-    def test_first_requires_order_by(self) -> None:
-        """first_window without order_by should not match."""
-        options = Options(context={"partition_by": ["region"]})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__first_window", options, None)
-        assert result is False
-
-    def test_last_requires_order_by(self) -> None:
-        """last_window without order_by should not match."""
-        options = Options(context={"partition_by": ["region"]})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__last_window", options, None)
-        assert result is False
-
-    def test_first_matches_with_order_by(self) -> None:
-        """first_window with order_by should match."""
-        options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__first_window", options, None)
-        assert result is True
-
-    def test_sum_does_not_require_order_by(self) -> None:
-        """sum_window should match without order_by (order-independent)."""
-        options = Options(context={"partition_by": ["region"]})
-        result = WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__sum_window", options, None)
-        assert result is True
+    @pytest.mark.parametrize(
+        ("feature_name", "context", "expected"),
+        [
+            pytest.param("value_int__sum_window", {}, False, id="partition_by_required"),
+            pytest.param(
+                "value_int__sum_window",
+                {"partition_by": ["region", "country"]},
+                True,
+                id="partition_by_accepts_list_of_strings",
+            ),
+            pytest.param("value_int__sum_window", {"partition_by": "region"}, False, id="partition_by_must_be_list"),
+            pytest.param("value_int__first_window", {"partition_by": ["region"]}, False, id="first_requires_order_by"),
+            pytest.param("value_int__last_window", {"partition_by": ["region"]}, False, id="last_requires_order_by"),
+            pytest.param(
+                "value_int__first_window",
+                {"partition_by": ["region"], "order_by": "value_int"},
+                True,
+                id="first_matches_with_order_by",
+            ),
+            # sum is order-independent
+            pytest.param(
+                "value_int__sum_window", {"partition_by": ["region"]}, True, id="sum_does_not_require_order_by"
+            ),
+        ],
+    )
+    def test_match_feature_group_criteria(self, feature_name: str, context: dict[str, Any], expected: bool) -> None:
+        # Options keeps the dict it is handed and mutates it on other paths, so the shared
+        # argvalue must not be passed in directly.
+        options = Options(context=dict(context))
+        result = WindowAggregationFeatureGroup.match_feature_group_criteria(feature_name, options, None)
+        assert result is expected
 
 
 class TestConfigBasedFeatures:

--- a/mloda/community/feature_groups/data_operations/string/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_base.py
@@ -39,25 +39,19 @@ class TestPatternMatching:
         result = StringFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is True, f"Should match: {feature_name}"
 
-    def test_no_match_wrong_suffix(self) -> None:
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("name__split", id="wrong_suffix"),
+            pytest.param("name", id="no_suffix"),
+            pytest.param("upper", id="no_source_column"),
+            # The prefix before __ requires at least one character.
+            pytest.param("__upper", id="empty_prefix"),
+        ],
+    )
+    def test_no_match(self, feature_name: str) -> None:
         options = Options()
-        result = StringFeatureGroup.match_feature_group_criteria("name__split", options, None)
-        assert result is False
-
-    def test_no_match_no_suffix(self) -> None:
-        options = Options()
-        result = StringFeatureGroup.match_feature_group_criteria("name", options, None)
-        assert result is False
-
-    def test_no_match_no_source_column(self) -> None:
-        options = Options()
-        result = StringFeatureGroup.match_feature_group_criteria("upper", options, None)
-        assert result is False
-
-    def test_no_match_empty_prefix(self) -> None:
-        """Empty prefix before __ must not match (requires at least one character)."""
-        options = Options()
-        result = StringFeatureGroup.match_feature_group_criteria("__upper", options, None)
+        result = StringFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
 
     def test_multi_underscore_source_column(self) -> None:

--- a/mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py
+++ b/mloda/community/feature_groups/data_operations/string/tests/test_sqlite.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from mloda.community.feature_groups.data_operations.string.sqlite_string import (
     SqliteStringOps,
 )
@@ -44,25 +46,12 @@ class TestSqliteUnsupportedOps:
     """SQLite refuses upper/lower/reverse at match time; the resolver falls
     back to another framework rather than silently producing ASCII-only output."""
 
-    def test_upper_does_not_match(self) -> None:
+    @pytest.mark.parametrize("operation", ["upper", "lower", "reverse"])
+    def test_unsupported_op_does_not_match(self, operation: str) -> None:
         from mloda.core.abstract_plugins.components.options import Options
 
         options = Options()
-        result = SqliteStringOps.match_feature_group_criteria("name__upper", options, None)
-        assert result is False
-
-    def test_lower_does_not_match(self) -> None:
-        from mloda.core.abstract_plugins.components.options import Options
-
-        options = Options()
-        result = SqliteStringOps.match_feature_group_criteria("name__lower", options, None)
-        assert result is False
-
-    def test_reverse_does_not_match(self) -> None:
-        from mloda.core.abstract_plugins.components.options import Options
-
-        options = Options()
-        result = SqliteStringOps.match_feature_group_criteria("name__reverse", options, None)
+        result = SqliteStringOps.match_feature_group_criteria(f"name__{operation}", options, None)
         assert result is False
 
     def test_supported_ops_still_match(self) -> None:

--- a/mloda/community/feature_groups/data_operations/tests/test_catalog.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_catalog.py
@@ -342,43 +342,37 @@ class TestOffsetCell:
 
 
 class TestIsSupported:
-    def test_exact_cell_sqlite_median_false(self) -> None:
-        """SQLite cannot compute a median aggregation."""
-        assert DataOperationsCatalog.is_supported("aggregation", "median", "SqliteFramework") is False
-
-    def test_exact_cell_duckdb_median_true(self) -> None:
-        """DuckDB computes median natively."""
-        pytest.importorskip("duckdb")
-        assert DataOperationsCatalog.is_supported("aggregation", "median", "DuckDBFramework") is True
-
-    def test_exact_cell_sqlite_mean_true(self) -> None:
-        """SQLite supports mean via its AVG alias."""
-        assert DataOperationsCatalog.is_supported("aggregation", "mean", "SqliteFramework") is True
-
-    def test_exact_cell_duckdb_rank_ntile_true(self) -> None:
-        """DuckDB supports the parametric ntile rank family."""
-        pytest.importorskip("duckdb")
-        assert DataOperationsCatalog.is_supported("rank", "ntile", "DuckDBFramework") is True
-
-    def test_operation_level_ema_pyarrow_false(self) -> None:
-        """subtype=None asks whether the operation exists on the framework at all."""
-        assert DataOperationsCatalog.is_supported("ema", framework="PyArrowTable") is False
-
-    def test_operation_level_ema_pandas_true(self) -> None:
-        pytest.importorskip("pandas")
-        assert DataOperationsCatalog.is_supported("ema", framework="PandasDataFrame") is True
-
-    def test_operation_level_percentile_sqlite_false(self) -> None:
-        assert DataOperationsCatalog.is_supported("percentile", framework="SqliteFramework") is False
-
-    def test_framework_matching_is_case_insensitive(self) -> None:
-        """Framework names match case-insensitively."""
-        assert DataOperationsCatalog.is_supported("aggregation", "sum", "sqliteframework") is True
-
-    def test_any_framework_median_true(self) -> None:
-        """framework=None asks whether at least one framework supports the subtype."""
-        pytest.importorskip("duckdb")
-        assert DataOperationsCatalog.is_supported("aggregation", subtype="median") is True
+    @pytest.mark.parametrize(
+        ("operation", "subtype", "framework", "expected", "requires"),
+        [
+            pytest.param("aggregation", "median", "SqliteFramework", False, None, id="sqlite_median_false"),
+            pytest.param("aggregation", "median", "DuckDBFramework", True, "duckdb", id="duckdb_median_true"),
+            # SQLite supports mean via its AVG alias.
+            pytest.param("aggregation", "mean", "SqliteFramework", True, None, id="sqlite_mean_true"),
+            # ntile is a parametric rank family, not a fixed rank type.
+            pytest.param("rank", "ntile", "DuckDBFramework", True, "duckdb", id="duckdb_rank_ntile_true"),
+            # subtype=None asks whether the operation exists on the framework at all.
+            pytest.param("ema", None, "PyArrowTable", False, None, id="ema_pyarrow_false"),
+            pytest.param("ema", None, "PandasDataFrame", True, "pandas", id="ema_pandas_true"),
+            pytest.param("percentile", None, "SqliteFramework", False, None, id="percentile_sqlite_false"),
+            pytest.param("aggregation", "sum", "sqliteframework", True, None, id="case_insensitive_framework"),
+            # framework=None asks whether at least one framework supports the subtype.
+            pytest.param("aggregation", "median", None, True, "duckdb", id="any_framework_median_true"),
+            # Unknown or absent frameworks return False (open world, no error).
+            pytest.param("aggregation", "sum", "NoSuchFramework", False, None, id="unknown_framework_false"),
+        ],
+    )
+    def test_is_supported(
+        self,
+        operation: str,
+        subtype: str | None,
+        framework: str | None,
+        expected: bool,
+        requires: str | None,
+    ) -> None:
+        if requires is not None:
+            pytest.importorskip(requires)
+        assert DataOperationsCatalog.is_supported(operation, subtype, framework) is expected
 
     def test_unknown_operation_raises_value_error_listing_operations(self) -> None:
         """Unknown operations raise ValueError listing the valid operation names."""
@@ -397,7 +391,3 @@ class TestIsSupported:
         assert "bogus" in message
         assert "median" in message
         assert "sum" in message
-
-    def test_unknown_framework_returns_false(self) -> None:
-        """Unknown or absent frameworks return False (open world, no error)."""
-        assert DataOperationsCatalog.is_supported("aggregation", "sum", "NoSuchFramework") is False

--- a/mloda/community/feature_groups/data_operations/tests/test_mask_utils.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_mask_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from mloda.community.feature_groups.data_operations.mask_utils import (
@@ -15,41 +17,44 @@ class TestParseMaskSpec:
     def test_none_returns_none(self) -> None:
         assert parse_mask_spec(None) is None
 
-    def test_single_tuple(self) -> None:
-        result = parse_mask_spec(("col", "equal", "X"))
-        assert result == [("col", "equal", "X")]
+    @pytest.mark.parametrize(
+        ("mask_option", "expected"),
+        [
+            pytest.param(("col", "equal", "X"), [("col", "equal", "X")], id="single_tuple"),
+            pytest.param(
+                [("a", "equal", 1), ("b", "greater_equal", 10)],
+                [("a", "equal", 1), ("b", "greater_equal", 10)],
+                id="list_of_tuples",
+            ),
+            pytest.param(("col", "is_in", ["A", "B"]), [("col", "is_in", ["A", "B"])], id="is_in_list"),
+            pytest.param(("col", "greater_than", 10), [("col", "greater_than", 10)], id="greater_than"),
+            # A 2-element tuple sets val=None, which is valid for 'equal'.
+            pytest.param(("col", "equal"), [("col", "equal", None)], id="two_element_equal_none"),
+        ],
+    )
+    def test_accepts_valid_spec(self, mask_option: Any, expected: list[tuple[str, str, Any]]) -> None:
+        result = parse_mask_spec(mask_option)
+        assert result == expected
 
-    def test_list_of_tuples(self) -> None:
-        result = parse_mask_spec([("a", "equal", 1), ("b", "greater_equal", 10)])
-        assert result == [("a", "equal", 1), ("b", "greater_equal", 10)]
-
-    def test_invalid_operator(self) -> None:
-        with pytest.raises(ValueError, match="Unsupported mask operator"):
-            parse_mask_spec(("col", "not_equal", "X"))
-
-    def test_invalid_type(self) -> None:
-        with pytest.raises(ValueError, match="must be a tuple or list"):
-            parse_mask_spec("bad")
-
-    def test_wrong_tuple_length(self) -> None:
-        with pytest.raises(ValueError, match="2 or 3 elements"):
-            parse_mask_spec(("a",))
-
-    def test_non_string_column(self) -> None:
-        with pytest.raises(ValueError, match="column must be a string"):
-            parse_mask_spec((123, "equal", "X"))
-
-    def test_is_in_string_rejected(self) -> None:
-        with pytest.raises(ValueError, match="is_in values must be a list"):
-            parse_mask_spec(("col", "is_in", "DE"))
-
-    def test_is_in_bytes_rejected(self) -> None:
-        with pytest.raises(ValueError, match="is_in values must be a list"):
-            parse_mask_spec(("col", "is_in", b"DE"))
-
-    def test_is_in_list_accepted(self) -> None:
-        result = parse_mask_spec(("col", "is_in", ["A", "B"]))
-        assert result == [("col", "is_in", ["A", "B"])]
+    @pytest.mark.parametrize(
+        ("mask_option", "message"),
+        [
+            pytest.param(("col", "not_equal", "X"), "Unsupported mask operator", id="invalid_operator"),
+            pytest.param("bad", "must be a tuple or list", id="invalid_type"),
+            pytest.param(("a",), "2 or 3 elements", id="wrong_tuple_length"),
+            pytest.param((123, "equal", "X"), "column must be a string", id="non_string_column"),
+            pytest.param(("col", "is_in", "DE"), "is_in values must be a list", id="is_in_string"),
+            pytest.param(("col", "is_in", b"DE"), "is_in values must be a list", id="is_in_bytes"),
+            pytest.param(("col", "is_in", []), "must not be empty", id="is_in_empty_list"),
+            pytest.param(("col", "is_in", set()), "must not be empty", id="is_in_empty_set"),
+            # A 2-element tuple is only valid for 'equal', not for other operators.
+            pytest.param(("col", "greater_than"), "only valid for 'equal'", id="two_element_greater_than"),
+            pytest.param(("col", "is_in"), "only valid for 'equal'", id="two_element_is_in"),
+        ],
+    )
+    def test_rejects_invalid_spec(self, mask_option: Any, message: str) -> None:
+        with pytest.raises(ValueError, match=message):
+            parse_mask_spec(mask_option)
 
     def test_is_in_set_accepted(self) -> None:
         result = parse_mask_spec(("col", "is_in", {"A", "B"}))
@@ -61,32 +66,6 @@ class TestParseMaskSpec:
 
         with pytest.raises(ValueError, match="Mask value must be"):
             parse_mask_spec(("col", "equal", datetime.now()))
-
-    def test_greater_than_operator(self) -> None:
-        result = parse_mask_spec(("col", "greater_than", 10))
-        assert result == [("col", "greater_than", 10)]
-
-    def test_two_element_equal_none(self) -> None:
-        """2-element tuple sets val=None, which is valid for 'equal'."""
-        result = parse_mask_spec(("col", "equal"))
-        assert result == [("col", "equal", None)]
-
-    def test_is_in_empty_list_rejected(self) -> None:
-        with pytest.raises(ValueError, match="must not be empty"):
-            parse_mask_spec(("col", "is_in", []))
-
-    def test_is_in_empty_set_rejected(self) -> None:
-        with pytest.raises(ValueError, match="must not be empty"):
-            parse_mask_spec(("col", "is_in", set()))
-
-    def test_two_element_greater_than_rejected(self) -> None:
-        """2-element tuple is only valid for 'equal', not other operators."""
-        with pytest.raises(ValueError, match="only valid for 'equal'"):
-            parse_mask_spec(("col", "greater_than"))
-
-    def test_two_element_is_in_rejected(self) -> None:
-        with pytest.raises(ValueError, match="only valid for 'equal'"):
-            parse_mask_spec(("col", "is_in"))
 
 
 class TestBuildPolarsMaskExpr:
@@ -131,9 +110,23 @@ class TestBuildPolarsMaskExpr:
 
 
 class TestBuildSqlCaseWhen:
-    def test_single_equal(self) -> None:
-        result = build_sql_case_when([("status", "equal", "active")], '"value"')
-        assert result == """CASE WHEN "status" = 'active' THEN "value" END"""
+    @pytest.mark.parametrize(
+        ("column", "operator", "value", "expected"),
+        [
+            pytest.param(
+                "status", "equal", "active", """CASE WHEN "status" = 'active' THEN "value" END""", id="single_equal"
+            ),
+            pytest.param("amount", "greater_than", 100, 'CASE WHEN "amount" > 100 THEN "value" END', id="greater_than"),
+            pytest.param("amount", "less_than", 100, 'CASE WHEN "amount" < 100 THEN "value" END', id="less_than"),
+            pytest.param("amount", "less_equal", 100, 'CASE WHEN "amount" <= 100 THEN "value" END', id="less_equal"),
+            pytest.param(
+                "amount", "greater_equal", 100, 'CASE WHEN "amount" >= 100 THEN "value" END', id="greater_equal"
+            ),
+        ],
+    )
+    def test_single_condition(self, column: str, operator: str, value: str | int, expected: str) -> None:
+        result = build_sql_case_when([(column, operator, value)], '"value"')
+        assert result == expected
 
     def test_multiple_conditions(self) -> None:
         result = build_sql_case_when(
@@ -148,23 +141,7 @@ class TestBuildSqlCaseWhen:
         result = build_sql_case_when([("col", "is_in", ["a", "b"])], '"src"')
         assert "IN ('a', 'b')" in result
 
-    def test_greater_than(self) -> None:
-        result = build_sql_case_when([("amount", "greater_than", 100)], '"value"')
-        assert result == """CASE WHEN "amount" > 100 THEN "value" END"""
-
     def test_equal_none_produces_is_null(self) -> None:
         result = build_sql_case_when([("col", "equal", None)], '"src"')
         assert "IS NULL" in result
         assert "= NULL" not in result
-
-    def test_less_than(self) -> None:
-        result = build_sql_case_when([("amount", "less_than", 100)], '"value"')
-        assert result == 'CASE WHEN "amount" < 100 THEN "value" END'
-
-    def test_less_equal(self) -> None:
-        result = build_sql_case_when([("amount", "less_equal", 100)], '"value"')
-        assert result == 'CASE WHEN "amount" <= 100 THEN "value" END'
-
-    def test_greater_equal(self) -> None:
-        result = build_sql_case_when([("amount", "greater_equal", 100)], '"value"')
-        assert result == 'CASE WHEN "amount" >= 100 THEN "value" END'

--- a/mloda/testing/feature_groups/data_operations/aggregation/aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/aggregation/aggregation.py
@@ -38,6 +38,61 @@ EXPECTED_MAX_BY_REGION: dict[Any, int] = {"A": 20, "B": 60, "C": 40, None: -10}
 
 
 # ---------------------------------------------------------------------------
+# Parametrized case tables
+# ---------------------------------------------------------------------------
+
+# (agg_type, needs_skip, use_approx). ``needs_skip`` is False for the operations
+# every framework must support; True means the case skips when the agg type is
+# missing from supported_agg_types().
+CROSS_FRAMEWORK_AGG_CASES: list[tuple[str, bool, bool]] = [
+    ("sum", False, False),
+    ("avg", False, True),
+    ("mean", True, True),
+    ("count", False, False),
+    ("min", False, False),
+    ("max", False, False),
+    ("std", True, True),
+    ("var", True, True),
+    ("median", True, True),
+    ("nunique", True, False),
+    # PyArrow skips nulls (Group B returns 50, not None).
+    ("first", True, False),
+    ("last", True, False),
+    # PyArrow picks the first-encountered value on ties (Group A=10, Group B=50).
+    ("mode", True, False),
+]
+
+# (agg_type, expected {region: value}) for the advanced aggregations.
+ADVANCED_AGG_CASES: list[tuple[str, dict[Any, int]]] = [
+    # On ties (the all-unique groups A and B), PyArrow picks the first-encountered value.
+    # Frameworks that use different tie-breaking must exclude 'mode' from supported_agg_types().
+    ("mode", {"A": 10, "B": 50, "C": 15, None: -10}),
+    # Distinct non-null values: A={10,-5,0,20}, B={50,30,60}, C={15,40}, None={-10}.
+    ("nunique", {"A": 4, "B": 3, "C": 2, None: 1}),
+    # PyArrow skips nulls, so Group B returns 50 (first non-null), not None.
+    # Frameworks that cannot match must exclude 'first' from supported_agg_types().
+    ("first", {"A": 10, "B": 50, "C": 15, None: -10}),
+    # Group values in insertion order: A=[10,-5,0,20], B=[None,50,30,60], C=[15,15,40],
+    # None=[-10]. No group has a trailing null, so all frameworks agree on the last value.
+    ("last", {"A": 20, "B": 60, "C": 40, None: -10}),
+]
+
+# (agg_type, needs_skip) for aggregations over the all-null ``score`` column.
+ALL_NULL_COLUMN_AGG_CASES: list[tuple[str, bool]] = [
+    ("sum", False),
+    ("min", False),
+    ("max", False),
+    ("avg", False),
+    ("median", True),
+    ("mode", True),
+    ("std", True),
+    ("var", True),
+    ("first", True),
+    ("last", True),
+]
+
+
+# ---------------------------------------------------------------------------
 # Standalone helpers
 # ---------------------------------------------------------------------------
 
@@ -299,74 +354,15 @@ class AggregationTestBase(MaskTestMixin, DataOpsTestBase):
             else:
                 assert result_map[key] == ref_map[key], f"group {key}: {result_map[key]} != reference {ref_map[key]}"
 
-    def test_cross_framework_sum(self) -> None:
-        """Sum must match reference."""
-        self._compare_agg_with_reference("value_int__sum_agg", ["region"])
-
-    def test_cross_framework_avg(self) -> None:
-        """Avg must match reference."""
-        self._compare_agg_with_reference("value_int__avg_agg", ["region"], use_approx=True)
-
-    def test_cross_framework_mean(self) -> None:
-        """Mean (avg alias) must match reference."""
-        self._skip_if_unsupported("mean")
-        self._compare_agg_with_reference("value_int__mean_agg", ["region"], use_approx=True)
-
-    def test_cross_framework_count(self) -> None:
-        """Count must match reference."""
-        self._compare_agg_with_reference("value_int__count_agg", ["region"])
-
-    def test_cross_framework_min(self) -> None:
-        """Min must match reference."""
-        self._compare_agg_with_reference("value_int__min_agg", ["region"])
-
-    def test_cross_framework_max(self) -> None:
-        """Max must match reference."""
-        self._compare_agg_with_reference("value_int__max_agg", ["region"])
-
-    def test_cross_framework_std(self) -> None:
-        """Std must match reference."""
-        self._skip_if_unsupported("std")
-        self._compare_agg_with_reference("value_int__std_agg", ["region"], use_approx=True)
-
-    def test_cross_framework_var(self) -> None:
-        """Var must match reference."""
-        self._skip_if_unsupported("var")
-        self._compare_agg_with_reference("value_int__var_agg", ["region"], use_approx=True)
-
-    def test_cross_framework_median(self) -> None:
-        """Median must match reference."""
-        self._skip_if_unsupported("median")
-        self._compare_agg_with_reference("value_int__median_agg", ["region"], use_approx=True)
-
-    def test_cross_framework_nunique(self) -> None:
-        """Nunique must match reference."""
-        self._skip_if_unsupported("nunique")
-        self._compare_agg_with_reference("value_int__nunique_agg", ["region"])
-
-    def test_cross_framework_first(self) -> None:
-        """First must match reference.
-
-        PyArrow skips nulls (Group B returns 50, not None).
-        Frameworks that cannot match must exclude 'first' from supported_agg_types().
-        """
-        self._skip_if_unsupported("first")
-        self._compare_agg_with_reference("value_int__first_agg", ["region"])
-
-    def test_cross_framework_last(self) -> None:
-        """Last must match reference."""
-        self._skip_if_unsupported("last")
-        self._compare_agg_with_reference("value_int__last_agg", ["region"])
-
-    def test_cross_framework_mode(self) -> None:
-        """Mode must match reference.
-
-        PyArrow picks the first-encountered value on ties (Group A=10,
-        Group B=50).  Frameworks that use different tie-breaking must
-        exclude 'mode' from supported_agg_types().
-        """
-        self._skip_if_unsupported("mode")
-        self._compare_agg_with_reference("value_int__mode_agg", ["region"])
+    @pytest.mark.parametrize(
+        ("agg_type", "needs_skip", "use_approx"),
+        CROSS_FRAMEWORK_AGG_CASES,
+        ids=[case[0] for case in CROSS_FRAMEWORK_AGG_CASES],
+    )
+    def test_cross_framework_agg(self, agg_type: str, needs_skip: bool, use_approx: bool) -> None:
+        if needs_skip:
+            self._skip_if_unsupported(agg_type)
+        self._compare_agg_with_reference(f"value_int__{agg_type}_agg", ["region"], use_approx=use_approx)
 
     # -- Statistical aggregation tests (skipped if unsupported) --------------
 
@@ -465,86 +461,39 @@ class AggregationTestBase(MaskTestMixin, DataOpsTestBase):
 
     # -- Advanced aggregation tests (skipped if unsupported) -----------------
 
-    def test_mode_agg_region(self) -> None:
-        """Mode of value_int grouped by region.
-
-        reference: A=10, B=50, C=15, None=-10.
-        On ties (all-unique groups A, B), PyArrow picks the first-encountered value.
-        """
-        self._skip_if_unsupported("mode")
-        fs = make_feature_set("value_int__mode_agg", ["region"])
+    @pytest.mark.parametrize(
+        ("agg_type", "expected"),
+        ADVANCED_AGG_CASES,
+        ids=[case[0] for case in ADVANCED_AGG_CASES],
+    )
+    def test_advanced_agg_region(self, agg_type: str, expected: dict[Any, int]) -> None:
+        self._skip_if_unsupported(agg_type)
+        feature_name = f"value_int__{agg_type}_agg"
+        fs = make_feature_set(feature_name, ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
         region_col = self.extract_column(result, "region")
-        result_col = self.extract_column(result, "value_int__mode_agg")
+        result_col = self.extract_column(result, feature_name)
         result_map = _build_result_map(region_col, result_col)
-        assert result_map["A"] == 10
-        assert result_map["B"] == 50
-        assert result_map["C"] == 15
-        assert result_map[None] == -10
-
-    def test_nunique_agg_region(self) -> None:
-        """Count of unique value_int values grouped by region."""
-        self._skip_if_unsupported("nunique")
-        fs = make_feature_set("value_int__nunique_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        region_col = self.extract_column(result, "region")
-        result_col = self.extract_column(result, "value_int__nunique_agg")
-        result_map = _build_result_map(region_col, result_col)
-        assert result_map["A"] == 4  # {10, -5, 0, 20}
-        assert result_map["B"] == 3  # {50, 30, 60} - nulls excluded
-        assert result_map["C"] == 2  # {15, 40}
-        assert result_map[None] == 1  # {-10}
-
-    def test_first_agg_region(self) -> None:
-        """First value of value_int grouped by region.
-
-        reference: A=10, B=50, C=15, None=-10.
-        PyArrow skips nulls, so Group B returns 50 (first non-null), not None.
-        Frameworks that cannot match must exclude 'first' from supported_agg_types().
-        """
-        self._skip_if_unsupported("first")
-        fs = make_feature_set("value_int__first_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        region_col = self.extract_column(result, "region")
-        result_col = self.extract_column(result, "value_int__first_agg")
-        result_map = _build_result_map(region_col, result_col)
-
-        assert result_map["A"] == 10
-        assert result_map["B"] == 50
-        assert result_map["C"] == 15
-        assert result_map[None] == -10
-
-    def test_last_agg_region(self) -> None:
-        """Last value of value_int grouped by region.
-
-        Group values (insertion order): A=[10,-5,0,20], B=[None,50,30,60],
-        C=[15,15,40], None=[-10]. No group has a trailing null, so all
-        frameworks agree on the last value.
-        """
-        self._skip_if_unsupported("last")
-        fs = make_feature_set("value_int__last_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        region_col = self.extract_column(result, "region")
-        result_col = self.extract_column(result, "value_int__last_agg")
-        result_map = _build_result_map(region_col, result_col)
-
-        assert result_map["A"] == 20
-        assert result_map["B"] == 60
-        assert result_map["C"] == 40
-        assert result_map[None] == -10
+        for region, value in expected.items():
+            assert result_map[region] == value, f"region={region}"
 
     # -- Null edge case tests ------------------------------------------------
 
-    def test_null_policy_skip_all_null_column(self) -> None:
-        """NullPolicy.SKIP: score column is all null. Aggregation should produce all nulls."""
-        fs = make_feature_set("score__sum_agg", ["region"])
+    @pytest.mark.parametrize(
+        ("agg_type", "needs_skip"),
+        ALL_NULL_COLUMN_AGG_CASES,
+        ids=[case[0] for case in ALL_NULL_COLUMN_AGG_CASES],
+    )
+    def test_all_null_column_per_group(self, agg_type: str, needs_skip: bool) -> None:
+        """NullPolicy.SKIP: score is all-null, so each group aggregates to None."""
+        if needs_skip:
+            self._skip_if_unsupported(agg_type)
+        feature_name = f"score__{agg_type}_agg"
+        fs = make_feature_set(feature_name, ["region"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        result_col = self.extract_column(result, "score__sum_agg")
+        result_col = self.extract_column(result, feature_name)
         assert all(v is None for v in result_col)
 
     def test_all_null_column_count_per_group(self) -> None:
@@ -554,84 +503,6 @@ class AggregationTestBase(MaskTestMixin, DataOpsTestBase):
 
         result_col = self.extract_column(result, "score__count_agg")
         assert all(v == 0 for v in result_col)
-
-    def test_all_null_column_min_per_group(self) -> None:
-        """score is all-null. Min per group should be None."""
-        fs = make_feature_set("score__min_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__min_agg")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_max_per_group(self) -> None:
-        """score is all-null. Max per group should be None."""
-        fs = make_feature_set("score__max_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__max_agg")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_avg_per_group(self) -> None:
-        """score is all-null. Avg per group should be None."""
-        fs = make_feature_set("score__avg_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__avg_agg")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_median_per_group(self) -> None:
-        """score is all-null. Median per group should be None."""
-        self._skip_if_unsupported("median")
-        fs = make_feature_set("score__median_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__median_agg")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_mode_per_group(self) -> None:
-        """score is all-null. Mode per group should be None."""
-        self._skip_if_unsupported("mode")
-        fs = make_feature_set("score__mode_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__mode_agg")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_std_per_group(self) -> None:
-        """score is all-null. Std per group should be None."""
-        self._skip_if_unsupported("std")
-        fs = make_feature_set("score__std_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__std_agg")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_var_per_group(self) -> None:
-        """score is all-null. Var per group should be None."""
-        self._skip_if_unsupported("var")
-        fs = make_feature_set("score__var_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__var_agg")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_first_per_group(self) -> None:
-        """score is all-null. First per group should be None."""
-        self._skip_if_unsupported("first")
-        fs = make_feature_set("score__first_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__first_agg")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_last_per_group(self) -> None:
-        """score is all-null. Last per group should be None."""
-        self._skip_if_unsupported("last")
-        fs = make_feature_set("score__last_agg", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__last_agg")
-        assert all(v is None for v in result_col)
 
     def test_all_null_column_nunique_per_group(self) -> None:
         """score is all-null. Nunique per group should be 0 (no distinct non-null values).

--- a/mloda/testing/feature_groups/data_operations/row_changing/resample/resample.py
+++ b/mloda/testing/feature_groups/data_operations/row_changing/resample/resample.py
@@ -497,45 +497,38 @@ class ResampleTestBase(DataOpsTestBase):
 
         self._assert_map_equals(result_map, ref_map, use_approx=use_approx)
 
-    def test_cross_framework_1_hour_mean(self) -> None:
-        self._compare_resample_with_reference("value__resample_1_hour_mean", ["region"], use_approx=True)
-
-    def test_cross_framework_1_hour_sum(self) -> None:
-        self._compare_resample_with_reference("value__resample_1_hour_sum", ["region"], use_approx=True)
-
-    def test_cross_framework_1_hour_count(self) -> None:
-        self._compare_resample_with_reference("value__resample_1_hour_count", ["region"])
-
-    def test_cross_framework_15_minute_mean(self) -> None:
-        self._compare_resample_with_reference("value__resample_15_minute_mean", ["region"], use_approx=True)
-
-    def test_cross_framework_whole_table(self) -> None:
-        self._compare_resample_with_reference("value__resample_1_hour_mean", [], use_approx=True)
+    @pytest.mark.parametrize(
+        ("feature_name", "partition_by", "use_approx"),
+        [
+            pytest.param("value__resample_1_hour_mean", ["region"], True, id="1_hour_mean"),
+            pytest.param("value__resample_1_hour_sum", ["region"], True, id="1_hour_sum"),
+            # count is an exact integer, so no approximate comparison.
+            pytest.param("value__resample_1_hour_count", ["region"], False, id="1_hour_count"),
+            pytest.param("value__resample_15_minute_mean", ["region"], True, id="15_minute_mean"),
+            pytest.param("value__resample_1_hour_mean", [], True, id="whole_table"),
+        ],
+    )
+    def test_cross_framework(self, feature_name: str, partition_by: list[str], use_approx: bool) -> None:
+        """Every resample spec must agree with the PyArrow reference."""
+        self._compare_resample_with_reference(feature_name, partition_by, use_approx=use_approx)
 
     # -- Error / validation --------------------------------------------------
 
-    def test_bad_unit_rejected(self) -> None:
-        """A bogus unit (``century``) must raise ValueError."""
-        fs = self._resample_fs("value__resample_1_century_mean", ["region"])
-        with pytest.raises(ValueError, match=r"(?i)unit|unsupported|century"):
-            self.implementation_class().calculate_feature(self.test_data, fs)
-
-    def test_bad_agg_median_rejected(self) -> None:
-        """``median`` is not in the v1 agg set and must raise ValueError."""
-        fs = self._resample_fs("value__resample_1_hour_median", ["region"])
-        with pytest.raises(ValueError, match=r"(?i)agg|unsupported|median"):
-            self.implementation_class().calculate_feature(self.test_data, fs)
-
-    def test_bad_agg_last_rejected(self) -> None:
-        """Order-DEPENDENT ``last`` is deliberately excluded in v1 and must raise ValueError."""
-        fs = self._resample_fs("value__resample_1_hour_last", ["region"])
-        with pytest.raises(ValueError, match=r"(?i)agg|unsupported|last"):
-            self.implementation_class().calculate_feature(self.test_data, fs)
-
-    def test_n_zero_rejected(self) -> None:
-        """``n=0`` is not a valid bucket size and must raise ValueError."""
-        fs = self._resample_fs("value__resample_0_hour_mean", ["region"])
-        with pytest.raises(ValueError, match=r"(?i)positive|n|0"):
+    @pytest.mark.parametrize(
+        ("feature_name", "match"),
+        [
+            pytest.param("value__resample_1_century_mean", r"(?i)unit|unsupported|century", id="bad_unit"),
+            # ``median`` is not in the v1 agg set.
+            pytest.param("value__resample_1_hour_median", r"(?i)agg|unsupported|median", id="bad_agg_median"),
+            # Order-DEPENDENT ``last`` is deliberately excluded in v1.
+            pytest.param("value__resample_1_hour_last", r"(?i)agg|unsupported|last", id="bad_agg_last"),
+            # ``n=0`` is not a valid bucket size.
+            pytest.param("value__resample_0_hour_mean", r"(?i)positive|n|0", id="n_zero"),
+        ],
+    )
+    def test_bad_spec_rejected(self, feature_name: str, match: str) -> None:
+        fs = self._resample_fs(feature_name, ["region"])
+        with pytest.raises(ValueError, match=match):
             self.implementation_class().calculate_feature(self.test_data, fs)
 
     def test_missing_time_column_rejected(self) -> None:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/datetime/datetime.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/datetime/datetime.py
@@ -292,55 +292,36 @@ class DateTimeTestBase(DataOpsTestBase):
         assert len(result_col) == len(ref_col), f"row count {len(result_col)} != reference {len(ref_col)}"
         assert result_col == ref_col
 
-    def test_cross_framework_year(self) -> None:
-        """Year must match reference."""
-        self._compare_with_reference("timestamp__year")
-
-    def test_cross_framework_month(self) -> None:
-        """Month must match reference."""
-        self._compare_with_reference("timestamp__month")
-
-    def test_cross_framework_day(self) -> None:
-        """Day must match reference."""
-        self._compare_with_reference("timestamp__day")
-
-    def test_cross_framework_hour(self) -> None:
-        """Hour must match reference."""
-        self._compare_with_reference("timestamp__hour")
-
-    def test_cross_framework_minute(self) -> None:
-        """Minute must match reference."""
-        self._compare_with_reference("timestamp__minute")
-
-    def test_cross_framework_second(self) -> None:
-        """Second must match reference."""
-        self._compare_with_reference("timestamp__second")
-
-    def test_cross_framework_dayofweek(self) -> None:
-        """Day of week must match reference."""
-        self._compare_with_reference("timestamp__dayofweek")
-
-    def test_cross_framework_is_weekend(self) -> None:
-        """Is-weekend must match reference."""
-        self._compare_with_reference("timestamp__is_weekend")
-
-    def test_cross_framework_quarter(self) -> None:
-        """Quarter must match reference."""
-        self._compare_with_reference("timestamp__quarter")
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("timestamp__year", id="year"),
+            pytest.param("timestamp__month", id="month"),
+            pytest.param("timestamp__day", id="day"),
+            pytest.param("timestamp__hour", id="hour"),
+            pytest.param("timestamp__minute", id="minute"),
+            pytest.param("timestamp__second", id="second"),
+            pytest.param("timestamp__dayofweek", id="dayofweek"),
+            pytest.param("timestamp__is_weekend", id="is_weekend"),
+            pytest.param("timestamp__quarter", id="quarter"),
+        ],
+    )
+    def test_cross_framework(self, feature_name: str) -> None:
+        self._compare_with_reference(feature_name)
 
     # -- Cross-framework comparison on varied-times dataset ------------------
 
-    def test_cross_framework_varied_hour(self) -> None:
-        """Non-zero hours must match reference on varied dataset."""
-        self._compare_varied_with_reference("timestamp__hour")
-
-    def test_cross_framework_varied_minute(self) -> None:
-        """Non-zero minutes must match reference on varied dataset."""
-        self._compare_varied_with_reference("timestamp__minute")
-
-    def test_cross_framework_varied_second(self) -> None:
-        """Non-zero seconds must match reference on varied dataset."""
-        self._compare_varied_with_reference("timestamp__second")
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("timestamp__hour", id="hour"),
+            pytest.param("timestamp__minute", id="minute"),
+            pytest.param("timestamp__second", id="second"),
+        ],
+    )
+    def test_cross_framework_varied(self, feature_name: str) -> None:
+        """The varied dataset has non-zero hours, minutes and seconds."""
+        self._compare_varied_with_reference(feature_name)
 
     # -- All-null column tests -----------------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -220,27 +220,23 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
 
     # -- Cross-framework comparison ------------------------------------------
 
-    def test_cross_framework_lag(self) -> None:
-        self._compare_with_reference("value_int__lag_1_offset", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_lead(self) -> None:
-        self._compare_with_reference("value_int__lead_1_offset", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_first_value(self) -> None:
-        self._compare_with_reference("value_int__first_value_offset", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_last_value(self) -> None:
-        self._compare_with_reference("value_int__last_value_offset", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_diff(self) -> None:
-        self._skip_if_unsupported("diff")
-        self._compare_with_reference("value_int__diff_1_offset", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_pct_change(self) -> None:
-        self._skip_if_unsupported("pct_change")
-        self._compare_with_reference(
-            "value_int__pct_change_1_offset", partition_by=["region"], order_by="value_int", use_approx=True
-        )
+    @pytest.mark.parametrize(
+        ("feature_name", "skip_offset_type", "use_approx"),
+        [
+            pytest.param("value_int__lag_1_offset", None, False, id="lag"),
+            pytest.param("value_int__lead_1_offset", None, False, id="lead"),
+            pytest.param("value_int__first_value_offset", None, False, id="first_value"),
+            pytest.param("value_int__last_value_offset", None, False, id="last_value"),
+            pytest.param("value_int__diff_1_offset", "diff", False, id="diff"),
+            # pct_change is fractional, so it is compared approximately and only
+            # on frameworks that support it.
+            pytest.param("value_int__pct_change_1_offset", "pct_change", True, id="pct_change"),
+        ],
+    )
+    def test_cross_framework(self, feature_name: str, skip_offset_type: str | None, use_approx: bool) -> None:
+        if skip_offset_type is not None:
+            self._skip_if_unsupported(skip_offset_type)
+        self._compare_with_reference(feature_name, partition_by=["region"], order_by="value_int", use_approx=use_approx)
 
     # -- All-null column tests -----------------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/percentile/percentile.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/percentile/percentile.py
@@ -297,31 +297,22 @@ class PercentileTestBase(MaskTestMixin, DataOpsTestBase):
 
     # -- Cross-framework comparison (matches reference) ----------------
 
-    def test_cross_framework_p50(self) -> None:
-        """P50 must match reference."""
-        self._compare_with_reference("value_int__p50_percentile", partition_by=["region"], use_approx=True)
-
-    def test_cross_framework_p25(self) -> None:
-        """P25 must match reference."""
-        self._compare_with_reference("value_int__p25_percentile", partition_by=["region"], use_approx=True)
-
-    def test_cross_framework_p75(self) -> None:
-        """P75 must match reference."""
-        self._compare_with_reference("value_int__p75_percentile", partition_by=["region"], use_approx=True)
-
-    # -- Cross-framework null comparisons --------------------------------------
-
-    def test_cross_framework_all_null_p50(self) -> None:
-        """All-null column p50 must match reference."""
-        self._compare_with_reference("score__p50_percentile", partition_by=["region"])
-
-    def test_cross_framework_multi_null_p50(self) -> None:
-        """Multi-null column (value_float) p50 must match reference."""
-        self._compare_with_reference("value_float__p50_percentile", partition_by=["region"], use_approx=True)
-
-    def test_cross_framework_amount_p50(self) -> None:
-        """Amount column (2 nulls) p50 must match reference."""
-        self._compare_with_reference("amount__p50_percentile", partition_by=["region"], use_approx=True)
+    @pytest.mark.parametrize(
+        ("feature_name", "use_approx"),
+        [
+            pytest.param("value_int__p50_percentile", True, id="p50"),
+            pytest.param("value_int__p25_percentile", True, id="p25"),
+            pytest.param("value_int__p75_percentile", True, id="p75"),
+            # score is all null, so the comparison is exact (no approx needed).
+            pytest.param("score__p50_percentile", False, id="all_null_p50"),
+            # value_float has 2 nulls (rows 2, 11).
+            pytest.param("value_float__p50_percentile", True, id="multi_null_p50"),
+            # amount has 2 nulls (rows 1, 7).
+            pytest.param("amount__p50_percentile", True, id="amount_p50"),
+        ],
+    )
+    def test_cross_framework(self, feature_name: str, use_approx: bool) -> None:
+        self._compare_with_reference(feature_name, partition_by=["region"], use_approx=use_approx)
 
     # -- Edge case tests -------------------------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/point_arithmetic/point_arithmetic.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/point_arithmetic/point_arithmetic.py
@@ -415,27 +415,20 @@ class PointArithmeticTestBase(DataOpsTestBase):
             else:
                 assert fw_val == pytest.approx(ref_val, rel=1e-6), f"row {i}: {fw_val} != {ref_val}"
 
-    def test_cross_framework_add(self) -> None:
-        self._compare_arithmetic_with_reference("value_int&amount__add_point")
-
-    def test_cross_framework_subtract(self) -> None:
-        self._compare_arithmetic_with_reference("value_int&amount__subtract_point")
-
-    def test_cross_framework_multiply(self) -> None:
-        self._compare_arithmetic_with_reference("value_int&amount__multiply_point")
-
-    def test_cross_framework_divide(self) -> None:
-        """Cross-framework divide parity, excluding the zero-divisor row.
-
-        Row 5 (50 / 0.0) legitimately diverges between backends (SQLite NULL
-        vs PyArrow inf); that row is pinned per-backend by
-        ``test_divide_by_zero_returns_inf_or_null_per_backend`` and is excluded
-        here.
-        """
-        self._compare_arithmetic_with_reference(
-            "value_int&amount__divide_point",
-            skip_rows={i for i, b in enumerate(AMOUNT) if b == 0},
-        )
+    @pytest.mark.parametrize(
+        ("feature_name", "skip_rows"),
+        [
+            pytest.param("value_int&amount__add_point", None, id="add"),
+            pytest.param("value_int&amount__subtract_point", None, id="subtract"),
+            pytest.param("value_int&amount__multiply_point", None, id="multiply"),
+            # Row 5 (50 / 0.0) legitimately diverges between backends (SQLite NULL vs PyArrow
+            # inf); that row is pinned per-backend by
+            # ``test_divide_by_zero_returns_inf_or_null_per_backend`` and is excluded here.
+            pytest.param("value_int&amount__divide_point", {i for i, b in enumerate(AMOUNT) if b == 0}, id="divide"),
+        ],
+    )
+    def test_cross_framework(self, feature_name: str, skip_rows: set[int] | None) -> None:
+        self._compare_arithmetic_with_reference(feature_name, skip_rows=skip_rows)
 
     # -- Divide-by-zero per-backend semantics -------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
@@ -297,36 +297,24 @@ class RankTestBase(DataOpsTestBase):
 
     # -- Cross-framework comparison (matches reference) --------------
 
-    def test_cross_framework_row_number(self) -> None:
-        """Row number must match reference."""
-        self._compare_with_reference("value_int__row_number_ranked", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_rank(self) -> None:
-        """Rank must match reference."""
-        self._compare_with_reference("value_int__rank_ranked", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_dense_rank(self) -> None:
-        """Dense rank must match reference."""
-        self._compare_with_reference("value_int__dense_rank_ranked", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_percent_rank(self) -> None:
-        """Percent rank must match reference."""
-        self._skip_if_unsupported("percent_rank")
-        self._compare_with_reference(
-            "value_int__percent_rank_ranked", partition_by=["region"], order_by="value_int", use_approx=True
-        )
-
-    def test_cross_framework_ntile(self) -> None:
-        """Ntile must match reference."""
-        self._compare_with_reference("value_int__ntile_2_ranked", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_top_n(self) -> None:
-        """Top N must match reference."""
-        self._compare_with_reference("value_int__top_3_ranked", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_bottom_n(self) -> None:
-        """Bottom N must match reference."""
-        self._compare_with_reference("value_int__bottom_2_ranked", partition_by=["region"], order_by="value_int")
+    @pytest.mark.parametrize(
+        ("feature_name", "skip_rank_type", "use_approx"),
+        [
+            pytest.param("value_int__row_number_ranked", None, False, id="row_number"),
+            pytest.param("value_int__rank_ranked", None, False, id="rank"),
+            pytest.param("value_int__dense_rank_ranked", None, False, id="dense_rank"),
+            # percent_rank is fractional, so it is compared approximately and only
+            # on frameworks that support it.
+            pytest.param("value_int__percent_rank_ranked", "percent_rank", True, id="percent_rank"),
+            pytest.param("value_int__ntile_2_ranked", None, False, id="ntile"),
+            pytest.param("value_int__top_3_ranked", None, False, id="top_n"),
+            pytest.param("value_int__bottom_2_ranked", None, False, id="bottom_n"),
+        ],
+    )
+    def test_cross_framework(self, feature_name: str, skip_rank_type: str | None, use_approx: bool) -> None:
+        if skip_rank_type is not None:
+            self._skip_if_unsupported(skip_rank_type)
+        self._compare_with_reference(feature_name, partition_by=["region"], order_by="value_int", use_approx=use_approx)
 
     # -- All-null column tests -----------------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/scalar_aggregate/scalar_aggregate.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/scalar_aggregate/scalar_aggregate.py
@@ -334,123 +334,75 @@ class ScalarAggregateTestBase(MaskTestMixin, DataOpsTestBase):
 
     # -- Cross-framework comparison ------------------------------------------
 
-    def test_cross_framework_sum(self) -> None:
-        self._compare_with_reference("value_int__sum_scalar")
-
-    def test_cross_framework_avg(self) -> None:
-        self._compare_with_reference("value_int__avg_scalar", use_approx=True)
-
-    def test_cross_framework_count(self) -> None:
-        self._compare_with_reference("value_int__count_scalar")
-
-    def test_cross_framework_min(self) -> None:
-        self._compare_with_reference("value_int__min_scalar")
-
-    def test_cross_framework_max(self) -> None:
-        self._compare_with_reference("value_int__max_scalar")
+    @pytest.mark.parametrize(
+        ("feature_name", "use_approx"),
+        [
+            pytest.param("value_int__sum_scalar", False, id="sum"),
+            pytest.param("value_int__avg_scalar", True, id="avg"),
+            pytest.param("value_int__count_scalar", False, id="count"),
+            pytest.param("value_int__min_scalar", False, id="min"),
+            pytest.param("value_int__max_scalar", False, id="max"),
+            # score is all-null
+            pytest.param("score__min_scalar", False, id="all_null_min"),
+            pytest.param("score__max_scalar", False, id="all_null_max"),
+            pytest.param("score__avg_scalar", False, id="all_null_avg"),
+            pytest.param("score__count_scalar", False, id="all_null_count"),
+            # value_float has 2 nulls (rows 2, 11)
+            pytest.param("value_float__sum_scalar", True, id="multi_null_sum"),
+            pytest.param("value_float__count_scalar", False, id="multi_null_count"),
+            # amount has 2 nulls (rows 1, 7)
+            pytest.param("amount__sum_scalar", True, id="amount_sum"),
+            pytest.param("amount__count_scalar", False, id="amount_count"),
+        ],
+    )
+    def test_cross_framework(self, feature_name: str, use_approx: bool) -> None:
+        self._compare_with_reference(feature_name, use_approx=use_approx)
 
     # -- Null consistency tests (all-null column: score) ---------------------
 
-    def test_all_null_column_sum(self) -> None:
-        """score is all-null. Sum should broadcast None to every row."""
-        fs = make_feature_set("score__sum_scalar")
+    @pytest.mark.parametrize(
+        ("feature_name", "skip_op"),
+        [
+            pytest.param("score__sum_scalar", None, id="sum"),
+            pytest.param("score__min_scalar", None, id="min"),
+            pytest.param("score__max_scalar", None, id="max"),
+            pytest.param("score__avg_scalar", None, id="avg"),
+            pytest.param("score__std_scalar", "std", id="std"),
+            pytest.param("score__var_scalar", "var", id="var"),
+            pytest.param("score__median_scalar", "median", id="median"),
+        ],
+    )
+    def test_all_null_column(self, feature_name: str, skip_op: str | None) -> None:
+        """score is all-null. Every aggregate except count should broadcast None to every row.
+
+        count broadcasts 0 instead; see test_null_column_count.
+        """
+        if skip_op is not None:
+            self._skip_if_unsupported(skip_op)
+        fs = make_feature_set(feature_name)
         result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "score__sum_scalar")
+        result_col = self.extract_column(result, feature_name)
         assert all(v is None for v in result_col)
 
-    def test_all_null_column_min(self) -> None:
-        """score is all-null. Min should broadcast None."""
-        fs = make_feature_set("score__min_scalar")
+    # -- Null consistency tests (count of non-nulls) -------------------------
+
+    @pytest.mark.parametrize(
+        ("feature_name", "expected"),
+        [
+            # score is all-null
+            pytest.param("score__count_scalar", 0, id="all_null"),
+            # value_float has 2 nulls (rows 2, 11)
+            pytest.param("value_float__count_scalar", 10, id="multi_null"),
+            # amount has 2 nulls (rows 1, 7)
+            pytest.param("amount__count_scalar", 10, id="amount"),
+        ],
+    )
+    def test_null_column_count(self, feature_name: str, expected: int) -> None:
+        """Count should broadcast the number of non-null values to every row."""
+        fs = make_feature_set(feature_name)
         result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "score__min_scalar")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_max(self) -> None:
-        """score is all-null. Max should broadcast None."""
-        fs = make_feature_set("score__max_scalar")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "score__max_scalar")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_avg(self) -> None:
-        """score is all-null. Avg should broadcast None."""
-        fs = make_feature_set("score__avg_scalar")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "score__avg_scalar")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_count(self) -> None:
-        """score is all-null. Count of non-nulls should broadcast 0."""
-        fs = make_feature_set("score__count_scalar")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "score__count_scalar")
-        assert all(v == 0 for v in result_col)
-
-    def test_all_null_column_std(self) -> None:
-        """score is all-null. Std should broadcast None."""
-        self._skip_if_unsupported("std")
-        fs = make_feature_set("score__std_scalar")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "score__std_scalar")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_var(self) -> None:
-        """score is all-null. Var should broadcast None."""
-        self._skip_if_unsupported("var")
-        fs = make_feature_set("score__var_scalar")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "score__var_scalar")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_median(self) -> None:
-        """score is all-null. Median should broadcast None."""
-        self._skip_if_unsupported("median")
-        fs = make_feature_set("score__median_scalar")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "score__median_scalar")
-        assert all(v is None for v in result_col)
-
-    # -- Null consistency tests (multi-null columns) -------------------------
-
-    def test_multi_null_column_count(self) -> None:
-        """value_float has 2 nulls (rows 2, 11). Count should be 10."""
-        fs = make_feature_set("value_float__count_scalar")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "value_float__count_scalar")
-        assert all(v == 10 for v in result_col)
-
-    def test_amount_null_count(self) -> None:
-        """amount has 2 nulls (rows 1, 7). Count should be 10."""
-        fs = make_feature_set("amount__count_scalar")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-        result_col = self.extract_column(result, "amount__count_scalar")
-        assert all(v == 10 for v in result_col)
-
-    # -- Cross-framework null comparisons ------------------------------------
-
-    def test_cross_framework_all_null_min(self) -> None:
-        self._compare_with_reference("score__min_scalar")
-
-    def test_cross_framework_all_null_max(self) -> None:
-        self._compare_with_reference("score__max_scalar")
-
-    def test_cross_framework_all_null_avg(self) -> None:
-        self._compare_with_reference("score__avg_scalar")
-
-    def test_cross_framework_all_null_count(self) -> None:
-        self._compare_with_reference("score__count_scalar")
-
-    def test_cross_framework_multi_null_sum(self) -> None:
-        self._compare_with_reference("value_float__sum_scalar", use_approx=True)
-
-    def test_cross_framework_multi_null_count(self) -> None:
-        self._compare_with_reference("value_float__count_scalar")
-
-    def test_cross_framework_amount_sum(self) -> None:
-        self._compare_with_reference("amount__sum_scalar", use_approx=True)
-
-    def test_cross_framework_amount_count(self) -> None:
-        self._compare_with_reference("amount__count_scalar")
+        result_col = self.extract_column(result, feature_name)
+        assert all(v == expected for v in result_col)
 
     # -- Mask tests ------------------------------------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/scalar_arithmetic/scalar_arithmetic.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/scalar_arithmetic/scalar_arithmetic.py
@@ -298,17 +298,17 @@ class ScalarArithmeticTestBase(DataOpsTestBase):
             else:
                 assert fw_val == pytest.approx(ref_val, rel=1e-6), f"row {i}: {fw_val} != {ref_val}"
 
-    def test_cross_framework_add(self) -> None:
-        self._compare_arithmetic_with_reference("value_int__add_constant", 5)
-
-    def test_cross_framework_subtract(self) -> None:
-        self._compare_arithmetic_with_reference("value_int__subtract_constant", 10)
-
-    def test_cross_framework_multiply(self) -> None:
-        self._compare_arithmetic_with_reference("value_int__multiply_constant", 2)
-
-    def test_cross_framework_divide(self) -> None:
-        self._compare_arithmetic_with_reference("value_int__divide_constant", 2.0)
+    @pytest.mark.parametrize(
+        ("feature_name", "constant"),
+        [
+            pytest.param("value_int__add_constant", 5, id="add"),
+            pytest.param("value_int__subtract_constant", 10, id="subtract"),
+            pytest.param("value_int__multiply_constant", 2, id="multiply"),
+            pytest.param("value_int__divide_constant", 2.0, id="divide"),
+        ],
+    )
+    def test_cross_framework(self, feature_name: str, constant: int | float) -> None:
+        self._compare_arithmetic_with_reference(feature_name, constant)
 
     def test_divide_by_integer_constant_returns_float(self) -> None:
         """Cross-backend: dividing by an INT constant must still produce float results.

--- a/mloda/testing/feature_groups/data_operations/row_preserving/time_bucketization/time_bucketization.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/time_bucketization/time_bucketization.py
@@ -438,86 +438,56 @@ class TimeBucketizationTestBase(DataOpsTestBase):
             else:
                 assert fw_v == ref_v, f"row {i}: {fw_v!r} != reference {ref_v!r}"
 
-    def test_cross_framework_floor_1_day(self) -> None:
-        self._compare_bucket_with_reference("timestamp__floor_1_day")
-
-    def test_cross_framework_floor_2_day(self) -> None:
-        """Multi-day fixed-freq floor must agree with PyArrow's epoch-anchored buckets.
-
-        Backends that use a built-in ``time_bucket`` (DuckDB) anchor sub-month
-        widths at 2000-01-03 by default, which diverges from PyArrow's
-        epoch-anchored (multiples since 1970-01-01) buckets. This test pins
-        agreement and would catch a regression on that anchor.
-        """
-        self._compare_bucket_with_reference("timestamp__floor_2_day")
-
-    def test_cross_framework_floor_3_day(self) -> None:
-        """3-day floor: extra coverage for multi-day anchor alignment with PyArrow."""
-        self._compare_bucket_with_reference("timestamp__floor_3_day")
-
-    def test_cross_framework_ceil_1_day(self) -> None:
-        self._compare_bucket_with_reference("timestamp__ceil_1_day")
-
-    def test_cross_framework_round_5_minute(self) -> None:
-        self._compare_bucket_with_reference("timestamp__round_5_minute")
-
-    def test_cross_framework_floor_1_week(self) -> None:
-        self._compare_bucket_with_reference("timestamp__floor_1_week")
-
-    def test_cross_framework_floor_1_month(self) -> None:
-        self._compare_bucket_with_reference("timestamp__floor_1_month")
-
-    def test_cross_framework_floor_1_year(self) -> None:
-        self._compare_bucket_with_reference("timestamp__floor_1_year")
+    @pytest.mark.parametrize(
+        "feature_name",
+        [
+            pytest.param("timestamp__floor_1_day", id="floor_1_day"),
+            # Backends with a built-in ``time_bucket`` (DuckDB) anchor sub-month widths
+            # at 2000-01-03 by default, which diverges from PyArrow's epoch-anchored
+            # buckets (multiples since 1970-01-01). These two cases pin that anchor.
+            pytest.param("timestamp__floor_2_day", id="floor_2_day"),
+            pytest.param("timestamp__floor_3_day", id="floor_3_day"),
+            pytest.param("timestamp__ceil_1_day", id="ceil_1_day"),
+            pytest.param("timestamp__round_5_minute", id="round_5_minute"),
+            pytest.param("timestamp__floor_1_week", id="floor_1_week"),
+            pytest.param("timestamp__floor_1_month", id="floor_1_month"),
+            pytest.param("timestamp__floor_1_year", id="floor_1_year"),
+        ],
+    )
+    def test_cross_framework(self, feature_name: str) -> None:
+        """Every bucket op must agree with the PyArrow reference."""
+        self._compare_bucket_with_reference(feature_name)
 
     # -- Error / validation --------------------------------------------------
 
-    def test_unsupported_bucket_op_raises(self) -> None:
-        """A bogus op in Options must raise ValueError at compute time."""
+    @pytest.mark.parametrize(
+        ("result_name", "bucket_op", "match"),
+        [
+            pytest.param(
+                "bogus_result",
+                "bogus_1_day",
+                r"(?i)bucket_op|unsupported|could not extract",
+                id="unsupported_bucket_op",
+            ),
+            pytest.param("bad_unit", "floor_1_century", r"(?i)unit|unsupported|century", id="unsupported_unit"),
+            # ``n=0`` is not a valid bucket size.
+            pytest.param("zero_bucket", "floor_0_day", r"(?i)positive|n|0", id="n_zero"),
+        ],
+    )
+    def test_invalid_bucket_op_rejected(self, result_name: str, bucket_op: str, match: str) -> None:
+        """An invalid op in Options must raise ValueError at compute time."""
         feature = Feature(
-            "bogus_result",
+            result_name,
             options=Options(
                 context={
-                    "bucket_op": "bogus_1_day",
+                    "bucket_op": bucket_op,
                     "in_features": "timestamp",
                 }
             ),
         )
         fs = FeatureSet()
         fs.add(feature)
-        with pytest.raises(ValueError, match=r"(?i)bucket_op|unsupported|could not extract"):
-            self.implementation_class().calculate_feature(self.test_data, fs)
-
-    def test_unsupported_unit_raises(self) -> None:
-        """A bogus unit (e.g. ``century``) in Options must raise ValueError at compute."""
-        feature = Feature(
-            "bad_unit",
-            options=Options(
-                context={
-                    "bucket_op": "floor_1_century",
-                    "in_features": "timestamp",
-                }
-            ),
-        )
-        fs = FeatureSet()
-        fs.add(feature)
-        with pytest.raises(ValueError, match=r"(?i)unit|unsupported|century"):
-            self.implementation_class().calculate_feature(self.test_data, fs)
-
-    def test_n_zero_rejected(self) -> None:
-        """``n=0`` is not a valid bucket size and must raise ValueError at compute."""
-        feature = Feature(
-            "zero_bucket",
-            options=Options(
-                context={
-                    "bucket_op": "floor_0_day",
-                    "in_features": "timestamp",
-                }
-            ),
-        )
-        fs = FeatureSet()
-        fs.add(feature)
-        with pytest.raises(ValueError, match=r"(?i)positive|n|0"):
+        with pytest.raises(ValueError, match=match):
             self.implementation_class().calculate_feature(self.test_data, fs)
 
     @pytest.mark.parametrize("unit", ["week", "month", "year"])

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -4,11 +4,10 @@ Expected values are computed from the canonical 12-row dataset in
 DataOperationsTestDataCreator, partitioned by the 'region' column
 (A=rows 0-3, B=rows 4-7, C=rows 8-10, None=row 11).
 
-The ``WindowAggregationTestBase`` class provides 16 concrete test methods
-(10 per-framework + 5 cross-framework comparison + 1 column check) that
-any framework implementation inherits by subclassing and implementing
-5 abstract methods. This follows the same pattern as mloda core's
-``DataFrameTestBase`` in ``tests/test_plugins/compute_framework/test_tooling/``.
+The ``WindowAggregationTestBase`` class provides concrete test methods that any
+framework implementation inherits by subclassing and implementing the abstract
+methods. This follows the same pattern as mloda core's ``DataFrameTestBase`` in
+``tests/test_plugins/compute_framework/test_tooling/``.
 """
 
 from __future__ import annotations
@@ -250,70 +249,33 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
 
     # -- Cross-framework comparison (matches reference) --------------
 
-    def test_cross_framework_sum(self) -> None:
-        """Sum must match reference."""
-        self._compare_with_reference("value_int__sum_window", partition_by=["region"])
-
-    def test_cross_framework_avg(self) -> None:
-        """Avg must match reference."""
-        self._compare_with_reference("value_int__avg_window", partition_by=["region"], use_approx=True)
-
-    def test_cross_framework_mean(self) -> None:
-        """Mean (avg alias) must match reference."""
-        self._skip_if_unsupported("mean")
-        self._compare_with_reference("value_int__mean_window", partition_by=["region"], use_approx=True)
-
-    def test_cross_framework_count(self) -> None:
-        """Count must match reference."""
-        self._compare_with_reference("value_int__count_window", partition_by=["region"])
-
-    def test_cross_framework_min(self) -> None:
-        """Min must match reference."""
-        self._compare_with_reference("value_int__min_window", partition_by=["region"])
-
-    def test_cross_framework_max(self) -> None:
-        """Max must match reference."""
-        self._compare_with_reference("value_int__max_window", partition_by=["region"])
-
-    def test_cross_framework_std(self) -> None:
-        """Std must match reference."""
-        self._skip_if_unsupported("std")
-        self._compare_with_reference("value_int__std_window", partition_by=["region"], use_approx=True)
-
-    def test_cross_framework_var(self) -> None:
-        """Var must match reference."""
-        self._skip_if_unsupported("var")
-        self._compare_with_reference("value_int__var_window", partition_by=["region"], use_approx=True)
-
-    def test_cross_framework_median(self) -> None:
-        """Median must match reference."""
-        self._skip_if_unsupported("median")
-        self._compare_with_reference("value_int__median_window", partition_by=["region"], use_approx=True)
-
-    def test_cross_framework_nunique(self) -> None:
-        """Nunique must match reference."""
-        self._skip_if_unsupported("nunique")
-        self._compare_with_reference("value_int__nunique_window", partition_by=["region"])
-
-    def test_cross_framework_first(self) -> None:
-        """First must match reference (with order_by)."""
-        self._skip_if_unsupported("first")
-        self._compare_with_reference("value_int__first_window", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_last(self) -> None:
-        """Last must match reference (with order_by)."""
-        self._skip_if_unsupported("last")
-        self._compare_with_reference("value_int__last_window", partition_by=["region"], order_by="value_int")
-
-    def test_cross_framework_mode(self) -> None:
-        """Mode must match reference.
-
-        PyArrow picks the first-encountered value on ties.
-        Frameworks that use different tie-breaking must exclude
-        'mode' from supported_agg_types().
-        """
-        self._skip_if_unsupported("mode")
-        self._compare_with_reference("value_int__mode_window", partition_by=["region"])
+    @pytest.mark.parametrize(
+        ("feature_name", "skip_op", "order_by", "use_approx"),
+        [
+            pytest.param("value_int__sum_window", None, None, False, id="sum"),
+            pytest.param("value_int__avg_window", None, None, True, id="avg"),
+            # mean is an avg alias
+            pytest.param("value_int__mean_window", "mean", None, True, id="mean"),
+            pytest.param("value_int__count_window", None, None, False, id="count"),
+            pytest.param("value_int__min_window", None, None, False, id="min"),
+            pytest.param("value_int__max_window", None, None, False, id="max"),
+            pytest.param("value_int__std_window", "std", None, True, id="std"),
+            pytest.param("value_int__var_window", "var", None, True, id="var"),
+            pytest.param("value_int__median_window", "median", None, True, id="median"),
+            pytest.param("value_int__nunique_window", "nunique", None, False, id="nunique"),
+            pytest.param("value_int__first_window", "first", "value_int", False, id="first"),
+            pytest.param("value_int__last_window", "last", "value_int", False, id="last"),
+            # PyArrow picks the first-encountered value on ties. Frameworks that use
+            # different tie-breaking must exclude 'mode' from supported_agg_types().
+            pytest.param("value_int__mode_window", "mode", None, False, id="mode"),
+        ],
+    )
+    def test_cross_framework(
+        self, feature_name: str, skip_op: str | None, order_by: str | None, use_approx: bool
+    ) -> None:
+        if skip_op is not None:
+            self._skip_if_unsupported(skip_op)
+        self._compare_with_reference(feature_name, partition_by=["region"], order_by=order_by, use_approx=use_approx)
 
     # -- Statistical aggregation tests (skipped if unsupported) --------------
 
@@ -467,52 +429,31 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
 
     # -- Null edge case tests ------------------------------------------------
 
-    def test_null_policy_skip_all_null_column(self) -> None:
-        """NullPolicy.SKIP: score column is all null. Aggregation should produce all nulls or zeros.
+    @pytest.mark.parametrize(
+        ("agg_type", "needs_skip", "order_by"),
+        [
+            # NullPolicy.SKIP: PyArrow/Polars/DuckDB/SQLite return null for the sum of an
+            # all-null group. Pandas returns 0 (groupby.transform("sum") treats all-null as 0).
+            pytest.param("sum", False, None, id="sum"),
+            pytest.param("std", True, None, id="std"),
+            pytest.param("var", True, None, id="var"),
+            # first/last need an order_by; score (the all-null column) is used as its own key.
+            pytest.param("first", True, "score", id="first"),
+            pytest.param("last", True, "score", id="last"),
+        ],
+    )
+    def test_all_null_column(self, agg_type: str, needs_skip: bool, order_by: str | None) -> None:
+        """score is all-null. Every aggregate listed here should produce None for every row.
 
-        PyArrow/Polars/DuckDB/SQLite return null for sum of all-null group.
-        Pandas returns 0 (groupby.transform("sum") treats all-null as 0).
+        nunique is the exception and produces 0; see test_all_null_column_nunique.
         """
-        fs = make_feature_set("score__sum_window", ["region"])
+        if needs_skip:
+            self._skip_if_unsupported(agg_type)
+        feature_name = f"score__{agg_type}_window"
+        fs = make_feature_set(feature_name, ["region"], order_by=order_by)
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        result_col = self.extract_column(result, "score__sum_window")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_std(self) -> None:
-        """score is all-null. Std per group should be None."""
-        self._skip_if_unsupported("std")
-        fs = make_feature_set("score__std_window", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__std_window")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_var(self) -> None:
-        """score is all-null. Var per group should be None."""
-        self._skip_if_unsupported("var")
-        fs = make_feature_set("score__var_window", ["region"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__var_window")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_first(self) -> None:
-        """score is all-null. First per group should be None."""
-        self._skip_if_unsupported("first")
-        fs = make_feature_set("score__first_window", ["region"], order_by="score")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__first_window")
-        assert all(v is None for v in result_col)
-
-    def test_all_null_column_last(self) -> None:
-        """score is all-null. Last per group should be None."""
-        self._skip_if_unsupported("last")
-        fs = make_feature_set("score__last_window", ["region"], order_by="score")
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "score__last_window")
+        result_col = self.extract_column(result, feature_name)
         assert all(v is None for v in result_col)
 
     def test_all_null_column_nunique(self) -> None:
@@ -610,59 +551,34 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
         assert result_col[1] == pytest.approx(1.25, rel=1e-6)
         assert result_col[3] == pytest.approx(1.25, rel=1e-6)
 
-    def test_multi_key_partition_median(self) -> None:
-        """Median of value_int partitioned by [region, category]."""
-        self._skip_if_unsupported("median")
-        fs = make_feature_set("value_int__median_window", ["region", "category"])
+    @pytest.mark.parametrize(
+        ("agg_type", "a_x_expected", "a_y_expected", "c_y_expected"),
+        [
+            pytest.param("median", 5.0, 7.5, 27.5, id="median"),
+            # std and var are the population forms (ddof=0)
+            pytest.param("std", 5.0, 12.5, 12.5, id="std"),
+            pytest.param("var", 25.0, 156.25, 156.25, id="var"),
+        ],
+    )
+    def test_multi_key_partition_stats(
+        self, agg_type: str, a_x_expected: float, a_y_expected: float, c_y_expected: float
+    ) -> None:
+        self._skip_if_unsupported(agg_type)
+        feature_name = f"value_int__{agg_type}_window"
+        fs = make_feature_set(feature_name, ["region", "category"])
         result = self.implementation_class().calculate_feature(self.test_data, fs)
 
-        result_col = self.extract_column(result, "value_int__median_window")
-        # (A,X) rows 0,2: median([10, 0]) = 5.0
-        assert result_col[0] == pytest.approx(5.0, rel=1e-6)
-        assert result_col[2] == pytest.approx(5.0, rel=1e-6)
-        # (A,Y) rows 1,3: median([-5, 20]) = 7.5
-        assert result_col[1] == pytest.approx(7.5, rel=1e-6)
-        assert result_col[3] == pytest.approx(7.5, rel=1e-6)
-        # (C,Y) rows 8,10: median([15, 40]) = 27.5
-        assert result_col[8] == pytest.approx(27.5, rel=1e-6)
-        assert result_col[10] == pytest.approx(27.5, rel=1e-6)
-
-    def test_multi_key_partition_std(self) -> None:
-        """Population std of value_int partitioned by [region, category].
-
-        Only groups with >= 2 non-null values are checked.
-        """
-        self._skip_if_unsupported("std")
-        fs = make_feature_set("value_int__std_window", ["region", "category"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "value_int__std_window")
-        # (A,X) rows 0,2: std([10, 0]) = 5.0
-        assert result_col[0] == pytest.approx(5.0, rel=1e-6)
-        assert result_col[2] == pytest.approx(5.0, rel=1e-6)
-        # (A,Y) rows 1,3: std([-5, 20]) = 12.5
-        assert result_col[1] == pytest.approx(12.5, rel=1e-6)
-        assert result_col[3] == pytest.approx(12.5, rel=1e-6)
-        # (C,Y) rows 8,10: std([15, 40]) = 12.5
-        assert result_col[8] == pytest.approx(12.5, rel=1e-6)
-        assert result_col[10] == pytest.approx(12.5, rel=1e-6)
-
-    def test_multi_key_partition_var(self) -> None:
-        """Population variance of value_int partitioned by [region, category]."""
-        self._skip_if_unsupported("var")
-        fs = make_feature_set("value_int__var_window", ["region", "category"])
-        result = self.implementation_class().calculate_feature(self.test_data, fs)
-
-        result_col = self.extract_column(result, "value_int__var_window")
-        # (A,X) rows 0,2: var([10, 0]) = 25.0
-        assert result_col[0] == pytest.approx(25.0, rel=1e-6)
-        assert result_col[2] == pytest.approx(25.0, rel=1e-6)
-        # (A,Y) rows 1,3: var([-5, 20]) = 156.25
-        assert result_col[1] == pytest.approx(156.25, rel=1e-6)
-        assert result_col[3] == pytest.approx(156.25, rel=1e-6)
-        # (C,Y) rows 8,10: var([15, 40]) = 156.25
-        assert result_col[8] == pytest.approx(156.25, rel=1e-6)
-        assert result_col[10] == pytest.approx(156.25, rel=1e-6)
+        result_col = self.extract_column(result, feature_name)
+        # Only groups with >= 2 non-null values are checked.
+        # (A,X) rows 0,2: values [10, 0]
+        assert result_col[0] == pytest.approx(a_x_expected, rel=1e-6)
+        assert result_col[2] == pytest.approx(a_x_expected, rel=1e-6)
+        # (A,Y) rows 1,3: values [-5, 20]
+        assert result_col[1] == pytest.approx(a_y_expected, rel=1e-6)
+        assert result_col[3] == pytest.approx(a_y_expected, rel=1e-6)
+        # (C,Y) rows 8,10: values [15, 40]
+        assert result_col[8] == pytest.approx(c_y_expected, rel=1e-6)
+        assert result_col[10] == pytest.approx(c_y_expected, rel=1e-6)
 
     def test_multi_key_partition_nunique(self) -> None:
         """Nunique of value_int partitioned by [region, category]."""

--- a/mloda/testing/feature_groups/data_operations/string/string.py
+++ b/mloda/testing/feature_groups/data_operations/string/string.py
@@ -245,28 +245,22 @@ class StringTestBase(DataOpsTestBase):
 
     # -- Cross-framework comparison (matches reference) --------------
 
-    def test_cross_framework_upper(self) -> None:
-        """Upper must match reference."""
-        self._skip_if_unsupported("upper")
-        self._compare_with_reference("name__upper")
-
-    def test_cross_framework_lower(self) -> None:
-        """Lower must match reference."""
-        self._skip_if_unsupported("lower")
-        self._compare_with_reference("name__lower")
-
-    def test_cross_framework_trim(self) -> None:
-        """Trim must match reference."""
-        self._compare_with_reference("name__trim")
-
-    def test_cross_framework_length(self) -> None:
-        """Length must match reference."""
-        self._compare_with_reference("name__length")
-
-    def test_cross_framework_reverse(self) -> None:
-        """Reverse must match reference."""
-        self._skip_if_unsupported("reverse")
-        self._compare_with_reference("name__reverse")
+    @pytest.mark.parametrize(
+        ("operation", "may_skip"),
+        [
+            pytest.param("upper", True, id="upper"),
+            pytest.param("lower", True, id="lower"),
+            # No framework in this repo excludes trim or length from supported_ops(),
+            # so these two cases are not given a skip.
+            pytest.param("trim", False, id="trim"),
+            pytest.param("length", False, id="length"),
+            pytest.param("reverse", True, id="reverse"),
+        ],
+    )
+    def test_cross_framework(self, operation: str, may_skip: bool) -> None:
+        if may_skip:
+            self._skip_if_unsupported(operation)
+        self._compare_with_reference(f"name__{operation}")
 
     # -- Unsupported operation error path ------------------------------------
 

--- a/tests/test_end2end/test_entry_points.py
+++ b/tests/test_end2end/test_entry_points.py
@@ -65,33 +65,35 @@ def _generate(pkg_name: str) -> str:
     return str(gen.generate_pyproject(pkg_name, packages[pkg_name], shared, packages))
 
 
-def test_feature_group_package_declares_entry_point() -> None:
-    """A FeatureGroup plugin package must declare a mloda.feature_groups entry point."""
-    content = _generate("mloda-community-ffill")
-    assert '[project.entry-points."mloda.feature_groups"]' in content, content
-    assert (
-        'mloda-community-ffill = "mloda.community.feature_groups.data_operations.row_preserving.ffill.manifest:FEATURE_GROUPS"'
-        in content
-    ), content
+# (package, entry-point group, exact entry line it must emit), one package per group.
+_PLUGIN_ENTRY_POINTS = [
+    pytest.param(
+        "mloda-community-ffill",
+        "mloda.feature_groups",
+        'mloda-community-ffill = "mloda.community.feature_groups.data_operations.row_preserving.ffill.manifest:FEATURE_GROUPS"',
+        id="feature_group",
+    ),
+    pytest.param(
+        "mloda-community-compute-frameworks-example",
+        "mloda.compute_frameworks",
+        'mloda-community-compute-frameworks-example = "mloda.community.compute_frameworks.example.manifest:COMPUTE_FRAMEWORKS"',
+        id="compute_framework",
+    ),
+    pytest.param(
+        "mloda-community-extenders-example",
+        "mloda.extenders",
+        'mloda-community-extenders-example = "mloda.community.extenders.example.manifest:EXTENDERS"',
+        id="extender",
+    ),
+]
 
 
-def test_compute_framework_package_declares_entry_point() -> None:
-    """A ComputeFramework plugin package must declare a mloda.compute_frameworks entry point."""
-    content = _generate("mloda-community-compute-frameworks-example")
-    assert '[project.entry-points."mloda.compute_frameworks"]' in content, content
-    assert (
-        'mloda-community-compute-frameworks-example = "mloda.community.compute_frameworks.example.manifest:COMPUTE_FRAMEWORKS"'
-        in content
-    ), content
-
-
-def test_extender_package_declares_entry_point() -> None:
-    """An Extender plugin package must declare a mloda.extenders entry point."""
-    content = _generate("mloda-community-extenders-example")
-    assert '[project.entry-points."mloda.extenders"]' in content, content
-    assert 'mloda-community-extenders-example = "mloda.community.extenders.example.manifest:EXTENDERS"' in content, (
-        content
-    )
+@pytest.mark.parametrize(("pkg_name", "group", "entry"), _PLUGIN_ENTRY_POINTS)
+def test_plugin_package_declares_entry_point(pkg_name: str, group: str, entry: str) -> None:
+    """A plugin package must declare its entry point under the group matching its plugin type."""
+    content = _generate(pkg_name)
+    assert f'[project.entry-points."{group}"]' in content, content
+    assert entry in content, content
 
 
 def test_bundle_aggregates_child_entry_points() -> None:

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -26,9 +26,21 @@ def test_empty_tree_only_root_index(tmp_path: Path) -> None:
     assert lint_docs.find_orphan_guides(tmp_path) == []
 
 
-def test_linked_guide_not_flagged(tmp_path: Path) -> None:
-    _write(tmp_path / "index.md", "# Root\n\n[Guide](guide.md)\n")
-    _write(tmp_path / "guide.md", "# Guide\n")
+# (root index body, target file name, target body) triples whose link form must reach the target.
+REACHING_LINK_FORMS = [
+    pytest.param("# Root\n\n[Guide](guide.md)\n", "guide.md", "# Guide\n", id="linked_guide"),
+    pytest.param(
+        "# Root\n\n[Guide](guide.md#section)\n", "guide.md", "# Guide\n\n## Section\n", id="anchor_bearing_link"
+    ),
+    # A link with nested brackets in its text must still resolve to the target.
+    pytest.param("# Root\n\n[a [nested] label](foo.md)\n", "foo.md", "# Foo\n", id="nested_bracket_link_text"),
+]
+
+
+@pytest.mark.parametrize(("index_body", "target_name", "target_body"), REACHING_LINK_FORMS)
+def test_link_form_reaches_target(index_body: str, target_name: str, target_body: str, tmp_path: Path) -> None:
+    _write(tmp_path / "index.md", index_body)
+    _write(tmp_path / target_name, target_body)
     assert lint_docs.find_orphan_guides(tmp_path) == []
 
 
@@ -69,24 +81,11 @@ def test_link_inside_code_fence_is_ignored(tmp_path: Path) -> None:
     assert any("only-in-fence.md" in err for err in errors)
 
 
-def test_anchor_bearing_link_reaches_target(tmp_path: Path) -> None:
-    _write(tmp_path / "index.md", "# Root\n\n[Guide](guide.md#section)\n")
-    _write(tmp_path / "guide.md", "# Guide\n\n## Section\n")
-    assert lint_docs.find_orphan_guides(tmp_path) == []
-
-
 def test_http_link_does_not_count_as_local(tmp_path: Path) -> None:
     _write(tmp_path / "index.md", "# Root\n\n[Ext](https://example.com/foo.md)\n")
     _write(tmp_path / "foo.md", "# Local foo\n")
     errors = lint_docs.find_orphan_guides(tmp_path)
     assert any("foo.md" in err for err in errors)
-
-
-def test_nested_bracket_link_text_is_reachable(tmp_path: Path) -> None:
-    """A link with nested brackets in its text must still resolve to the target."""
-    _write(tmp_path / "index.md", "# Root\n\n[a [nested] label](foo.md)\n")
-    _write(tmp_path / "foo.md", "# Foo\n")
-    assert lint_docs.find_orphan_guides(tmp_path) == []
 
 
 def test_missing_root_index_returns_sentinel(tmp_path: Path) -> None:
@@ -365,10 +364,104 @@ def test_check_retired_property_spec_spellings_allows_surviving_option_key(field
     assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
 
 
-def test_check_retired_property_spec_spellings_ignores_prose_match(tmp_path: Path) -> None:
-    """Like the internal-import check, only fenced code blocks are scanned."""
+# Snippets the retired-spelling check must leave alone, each with the reason it is legal.
+ACCEPTED_SPEC_SNIPPETS = [
+    # Like the internal-import check, only fenced code blocks are scanned.
+    pytest.param(
+        "# A\n\nThe retired `DefaultOptionKeys.allowed_values` spelling is gone; use `property_spec` instead.\n",
+        id="prose_match",
+    ),
+    # The builder form is the supported spelling; its ``allowed_values={...}`` kwarg is not a spec value.
+    pytest.param(
+        "# A\n"
+        "\n"
+        "```python\n"
+        "PROPERTY_MAPPING = {\n"
+        '    "operation_type": property_spec(\n'
+        '        "Arithmetic operation",\n'
+        "        strict=True,\n"
+        '        allowed_values={"add": "Addition", "sub": "Subtraction"},\n'
+        '        default="add",\n'
+        "    ),\n"
+        "}\n"
+        "```\n",
+        id="property_spec_value",
+    ),
+    # ``DefaultOptionKeys.in_features`` as the mapping KEY stays valid when the value is a ``property_spec``.
+    pytest.param(
+        "# A\n"
+        "\n"
+        "```python\n"
+        "PROPERTY_MAPPING = {\n"
+        "    DefaultOptionKeys.in_features: property_spec(\n"
+        '        "Source feature",\n'
+        "        context=True,\n"
+        "    ),\n"
+        "}\n"
+        "```\n",
+        id="in_features_mapping_key",
+    ),
+    # ``: {`` inside an explanation string is prose, not a raw dict value.
+    pytest.param(
+        '# A\n\n```python\nPROPERTY_MAPPING = {\n    "fmt": property_spec("Template, e.g. {col}: {value}"),\n}\n```\n',
+        id="colon_brace_inside_string",
+    ),
+    # ``: {`` inside a trailing comment is not a raw dict value either.
+    pytest.param(
+        "# A\n"
+        "\n"
+        "```python\n"
+        "PROPERTY_MAPPING = {\n"
+        '    "op": property_spec("Arithmetic"),  # shape: {value: doc}\n'
+        "}\n"
+        "```\n",
+        id="colon_brace_in_comment",
+    ),
+    # A dict nested inside a ``property_spec(...)`` kwarg is not a PROPERTY_MAPPING value.
+    pytest.param(
+        "# A\n"
+        "\n"
+        "```python\n"
+        "PROPERTY_MAPPING = {\n"
+        '    "op": property_spec("Arithmetic", allowed_values={"add": {"alias": "plus"}}),\n'
+        "}\n"
+        "```\n",
+        id="nested_dict_in_kwarg",
+    ),
+    # A ```text fence quoting a migration message is documentation, not code: skip both checks.
+    pytest.param(
+        "# A\n"
+        "\n"
+        "```text\n"
+        "AttributeError: DefaultOptionKeys.allowed_values does not exist on the unreleased core.\n"
+        "The old shape was: PROPERTY_MAPPING = {\n"
+        '    "operation_type": {"explanation": "Arithmetic operation"},\n'
+        "}\n"
+        "```\n",
+        id="non_python_fence",
+    ),
+    # Guide snippets are often fragments: a bare dict body must not raise and must not be read as a raw dict.
+    pytest.param(
+        '# A\n\n```python\n    "aggregation_type": ...,\n    "order_by": property_spec("x"),\n```\n',
+        id="unparseable_fence",
+    ),
+    # A mapping cut off before its closing brace must not fall back to a scan that misreads the entries.
+    pytest.param(
+        "# A\n"
+        "\n"
+        "```python\n"
+        "PROPERTY_MAPPING = {\n"
+        '    "fmt": property_spec("Template, e.g. {col}: {value}"),\n'
+        "    ...\n"
+        "```\n",
+        id="truncated_mapping_fence",
+    ),
+]
+
+
+@pytest.mark.parametrize("content", ACCEPTED_SPEC_SNIPPETS)
+def test_check_retired_property_spec_spellings_accepts_snippet(content: str, tmp_path: Path) -> None:
     md_file = tmp_path / "a.md"
-    content = "# A\n\nThe retired `DefaultOptionKeys.allowed_values` spelling is gone; use `property_spec` instead.\n"
     _write(md_file, content)
     assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
 
@@ -382,10 +475,10 @@ def test_check_retired_property_spec_spellings_reports_file_and_line(tmp_path: P
     assert errors[0].startswith(f"{md_file}:7:")
 
 
-def test_check_retired_property_spec_spellings_flags_raw_dict_spec(tmp_path: Path) -> None:
-    """A raw dict as a PROPERTY_MAPPING value now raises ValueError at class definition; flag where it opens."""
-    md_file = tmp_path / "a.md"
-    content = (
+# Raw dict PROPERTY_MAPPING values, paired with the 1-based line the single error must point at.
+# A raw dict value now raises ValueError at class definition, so the error is reported where the dict opens.
+FLAGGED_RAW_DICT_SNIPPETS = [
+    pytest.param(
         "# A\n"
         "\n"
         "```python\n"
@@ -394,89 +487,30 @@ def test_check_retired_property_spec_spellings_flags_raw_dict_spec(tmp_path: Pat
         '        "explanation": "Arithmetic operation",\n'
         "    },\n"
         "}\n"
-        "```\n"
-    )
-    _write(md_file, content)
-    errors = lint_docs.check_retired_property_spec_spellings(md_file, content)
-    assert len(errors) == 1
-    assert errors[0].startswith(f"{md_file}:5:")
-    assert "property_spec" in errors[0]
-
-
-def test_check_retired_property_spec_spellings_accepts_property_spec_value(tmp_path: Path) -> None:
-    """The builder form is the supported spelling; its ``allowed_values={...}`` kwarg is not a spec value."""
-    md_file = tmp_path / "a.md"
-    content = (
-        "# A\n"
-        "\n"
-        "```python\n"
-        "PROPERTY_MAPPING = {\n"
-        '    "operation_type": property_spec(\n'
-        '        "Arithmetic operation",\n'
-        "        strict=True,\n"
-        '        allowed_values={"add": "Addition", "sub": "Subtraction"},\n'
-        '        default="add",\n'
-        "    ),\n"
-        "}\n"
-        "```\n"
-    )
-    _write(md_file, content)
-    assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
-
-
-def test_check_retired_property_spec_spellings_accepts_in_features_mapping_key(tmp_path: Path) -> None:
-    """``DefaultOptionKeys.in_features`` as the mapping KEY stays valid when the value is a ``property_spec``."""
-    md_file = tmp_path / "a.md"
-    content = (
-        "# A\n"
-        "\n"
-        "```python\n"
-        "PROPERTY_MAPPING = {\n"
-        "    DefaultOptionKeys.in_features: property_spec(\n"
-        '        "Source feature",\n'
-        "        context=True,\n"
-        "    ),\n"
-        "}\n"
-        "```\n"
-    )
-    _write(md_file, content)
-    assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
-
-
-def test_check_retired_property_spec_spellings_flags_single_line_raw_dict(tmp_path: Path) -> None:
-    """A raw dict value written entirely on the PROPERTY_MAPPING opener line is still a raw dict."""
-    md_file = tmp_path / "a.md"
-    content = '# A\n\n```python\nPROPERTY_MAPPING = {"operation_type": {"explanation": "Arithmetic operation"}}\n```\n'
-    _write(md_file, content)
-    errors = lint_docs.check_retired_property_spec_spellings(md_file, content)
-    assert len(errors) == 1
-    assert errors[0].startswith(f"{md_file}:4:")
-    assert "property_spec" in errors[0]
-
-
-def test_check_retired_property_spec_spellings_flags_raw_dict_opened_on_mapping_line(tmp_path: Path) -> None:
-    """The first entry may open on the opener line and close later; it must still be checked."""
-    md_file = tmp_path / "a.md"
-    content = (
+        "```\n",
+        5,
+        id="raw_dict_spec",
+    ),
+    # A raw dict value written entirely on the PROPERTY_MAPPING opener line is still a raw dict.
+    pytest.param(
+        '# A\n\n```python\nPROPERTY_MAPPING = {"operation_type": {"explanation": "Arithmetic operation"}}\n```\n',
+        4,
+        id="single_line_raw_dict",
+    ),
+    # The first entry may open on the opener line and close later; it must still be checked.
+    pytest.param(
         "# A\n"
         "\n"
         "```python\n"
         'PROPERTY_MAPPING = {"operation_type": {\n'
         '    "explanation": "Arithmetic operation",\n'
         "}}\n"
-        "```\n"
-    )
-    _write(md_file, content)
-    errors = lint_docs.check_retired_property_spec_spellings(md_file, content)
-    assert len(errors) == 1
-    assert errors[0].startswith(f"{md_file}:4:")
-    assert "property_spec" in errors[0]
-
-
-def test_check_retired_property_spec_spellings_flags_raw_dict_after_paren_in_string(tmp_path: Path) -> None:
-    """An unbalanced paren inside a string literal must not hide the following raw dict entry."""
-    md_file = tmp_path / "a.md"
-    content = (
+        "```\n",
+        4,
+        id="raw_dict_opened_on_mapping_line",
+    ),
+    # An unbalanced paren inside a string literal must not hide the following raw dict entry.
+    pytest.param(
         "# A\n"
         "\n"
         "```python\n"
@@ -484,19 +518,12 @@ def test_check_retired_property_spec_spellings_flags_raw_dict_after_paren_in_str
         '    "a": property_spec("mismatched ( paren in text"),\n'
         '    "b": {"explanation": "raw"},\n'
         "}\n"
-        "```\n"
-    )
-    _write(md_file, content)
-    errors = lint_docs.check_retired_property_spec_spellings(md_file, content)
-    assert len(errors) == 1
-    assert errors[0].startswith(f"{md_file}:6:")
-    assert "property_spec" in errors[0]
-
-
-def test_check_retired_property_spec_spellings_flags_raw_dict_after_brace_in_string(tmp_path: Path) -> None:
-    """An unbalanced brace inside a string literal must not hide the following raw dict entry."""
-    md_file = tmp_path / "a.md"
-    content = (
+        "```\n",
+        6,
+        id="raw_dict_after_paren_in_string",
+    ),
+    # An unbalanced brace inside a string literal must not hide the following raw dict entry.
+    pytest.param(
         "# A\n"
         "\n"
         "```python\n"
@@ -504,72 +531,23 @@ def test_check_retired_property_spec_spellings_flags_raw_dict_after_brace_in_str
         '    "a": property_spec(r"pattern with a { brace"),\n'
         '    "b": {"explanation": "raw"},\n'
         "}\n"
-        "```\n"
-    )
+        "```\n",
+        6,
+        id="raw_dict_after_brace_in_string",
+    ),
+]
+
+
+@pytest.mark.parametrize(("content", "expected_line"), FLAGGED_RAW_DICT_SNIPPETS)
+def test_check_retired_property_spec_spellings_flags_raw_dict_value(
+    content: str, expected_line: int, tmp_path: Path
+) -> None:
+    md_file = tmp_path / "a.md"
     _write(md_file, content)
     errors = lint_docs.check_retired_property_spec_spellings(md_file, content)
     assert len(errors) == 1
-    assert errors[0].startswith(f"{md_file}:6:")
+    assert errors[0].startswith(f"{md_file}:{expected_line}:")
     assert "property_spec" in errors[0]
-
-
-def test_check_retired_property_spec_spellings_accepts_colon_brace_inside_string(tmp_path: Path) -> None:
-    """``: {`` inside an explanation string is prose, not a raw dict value."""
-    md_file = tmp_path / "a.md"
-    content = (
-        '# A\n\n```python\nPROPERTY_MAPPING = {\n    "fmt": property_spec("Template, e.g. {col}: {value}"),\n}\n```\n'
-    )
-    _write(md_file, content)
-    assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
-
-
-def test_check_retired_property_spec_spellings_accepts_colon_brace_in_comment(tmp_path: Path) -> None:
-    """``: {`` inside a trailing comment is not a raw dict value either."""
-    md_file = tmp_path / "a.md"
-    content = (
-        "# A\n"
-        "\n"
-        "```python\n"
-        "PROPERTY_MAPPING = {\n"
-        '    "op": property_spec("Arithmetic"),  # shape: {value: doc}\n'
-        "}\n"
-        "```\n"
-    )
-    _write(md_file, content)
-    assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
-
-
-def test_check_retired_property_spec_spellings_accepts_nested_dict_in_kwarg(tmp_path: Path) -> None:
-    """A dict nested inside a ``property_spec(...)`` kwarg is not a PROPERTY_MAPPING value."""
-    md_file = tmp_path / "a.md"
-    content = (
-        "# A\n"
-        "\n"
-        "```python\n"
-        "PROPERTY_MAPPING = {\n"
-        '    "op": property_spec("Arithmetic", allowed_values={"add": {"alias": "plus"}}),\n'
-        "}\n"
-        "```\n"
-    )
-    _write(md_file, content)
-    assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
-
-
-def test_check_retired_property_spec_spellings_ignores_non_python_fence(tmp_path: Path) -> None:
-    """A ```text fence quoting a migration message is documentation, not code: skip both checks."""
-    md_file = tmp_path / "a.md"
-    content = (
-        "# A\n"
-        "\n"
-        "```text\n"
-        "AttributeError: DefaultOptionKeys.allowed_values does not exist on the unreleased core.\n"
-        "The old shape was: PROPERTY_MAPPING = {\n"
-        '    "operation_type": {"explanation": "Arithmetic operation"},\n'
-        "}\n"
-        "```\n"
-    )
-    _write(md_file, content)
-    assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
 
 
 def test_check_retired_property_spec_spellings_scans_py_alias_fence(tmp_path: Path) -> None:
@@ -590,30 +568,6 @@ def test_check_retired_property_spec_spellings_scans_py_alias_fence(tmp_path: Pa
     assert len(errors) == 2
     assert any(err.startswith(f"{md_file}:5:") and "property_spec" in err for err in errors)
     assert any("DefaultOptionKeys.allowed_values" in err for err in errors)
-
-
-def test_check_retired_property_spec_spellings_tolerates_unparseable_fence(tmp_path: Path) -> None:
-    """Guide snippets are often fragments: a bare dict body must not raise and must not be read as a raw dict."""
-    md_file = tmp_path / "a.md"
-    content = '# A\n\n```python\n    "aggregation_type": ...,\n    "order_by": property_spec("x"),\n```\n'
-    _write(md_file, content)
-    assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
-
-
-def test_check_retired_property_spec_spellings_tolerates_truncated_mapping_fence(tmp_path: Path) -> None:
-    """A mapping cut off before its closing brace must not fall back to a scan that misreads the entries."""
-    md_file = tmp_path / "a.md"
-    content = (
-        "# A\n"
-        "\n"
-        "```python\n"
-        "PROPERTY_MAPPING = {\n"
-        '    "fmt": property_spec("Template, e.g. {col}: {value}"),\n'
-        "    ...\n"
-        "```\n"
-    )
-    _write(md_file, content)
-    assert lint_docs.check_retired_property_spec_spellings(md_file, content) == []
 
 
 def test_main_reports_retired_property_spec_spellings(

--- a/tests/test_end2end/test_no_hashabledict_credentials.py
+++ b/tests/test_end2end/test_no_hashabledict_credentials.py
@@ -15,6 +15,8 @@ This is a best-effort proximity heuristic and can miss a reintroduction where
 
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -72,25 +74,16 @@ def _write(path: Path, body: str) -> None:
     path.write_text(body)
 
 
-def test_credentials_list_hashabledict_flagged(tmp_path: Path) -> None:
-    """A HashableDict inside a credentials= list on one line is flagged."""
-    _write(tmp_path / "m.py", "credentials=[HashableDict({'host': 'h'})]\n")
-    hits = find_hashabledict_credential_usages(tmp_path)
-    assert len(hits) == 1
-    assert "m.py" in hits[0]
-
-
-def test_credentials_dict_value_hashabledict_flagged(tmp_path: Path) -> None:
-    """A HashableDict as a credentials dict value is flagged."""
-    _write(tmp_path / "m.py", "credentials={'pg-prod': HashableDict({'host': 'h'})}\n")
-    hits = find_hashabledict_credential_usages(tmp_path)
-    assert len(hits) == 1
-    assert "m.py" in hits[0]
-
-
-def test_add_credentials_hashabledict_flagged(tmp_path: Path) -> None:
-    """A HashableDict passed to add_credentials is flagged."""
-    _write(tmp_path / "m.py", "collection.add_credentials(HashableDict({'host': 'h'}))\n")
+@pytest.mark.parametrize(
+    "line",
+    [
+        pytest.param("credentials=[HashableDict({'host': 'h'})]\n", id="credentials_list"),
+        pytest.param("credentials={'pg-prod': HashableDict({'host': 'h'})}\n", id="credentials_dict_value"),
+        pytest.param("collection.add_credentials(HashableDict({'host': 'h'}))\n", id="add_credentials"),
+    ],
+)
+def test_credential_hashabledict_on_one_line_flagged(line: str, tmp_path: Path) -> None:
+    _write(tmp_path / "m.py", line)
     hits = find_hashabledict_credential_usages(tmp_path)
     assert len(hits) == 1
     assert "m.py" in hits[0]

--- a/tests/test_end2end/test_no_named_form_string_credentials.py
+++ b/tests/test_end2end/test_no_named_form_string_credentials.py
@@ -18,6 +18,8 @@ across lines or bound to an intermediate variable.
 import re
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -130,71 +132,41 @@ def _write(path: Path, body: str) -> None:
     path.write_text(body)
 
 
-def test_named_form_single_quoted_string_flagged(tmp_path: Path) -> None:
-    """A single-quoted named-form string credential value is flagged."""
-    _write(tmp_path / "m.py", "credentials={'prod': 'dsn-string'}\n")
+# Single lines of ``m.py`` whose named-form credential value is a bare string.
+_FLAGGED_LINES = [
+    pytest.param("credentials={'prod': 'dsn-string'}\n", id="single_quoted_string"),
+    pytest.param('credentials={"prod": "dsn-string"}\n', id="double_quoted_string"),
+    pytest.param("collection.add_credentials({'prod': 'dsn-string'})\n", id="add_credentials_string"),
+    # Every entry is inspected, not only the first: here the first value is a legal nested mapping.
+    pytest.param("credentials={'prod': {'dsn': 'ok'}, 'staging': 'dsn-string'}\n", id="multi_entry_later_string"),
+]
+
+# Single lines of ``m.py`` whose credential form is legal, so the guard must leave them alone.
+_ACCEPTED_LINES = [
+    pytest.param("credentials={'prod': {'dsn': 'dsn-string'}}\n", id="nested_mapping_value"),
+    pytest.param("credentials={'pg-prod': Credential(host='h')}\n", id="credential_object_value"),
+    pytest.param("credentials={'prod': {'dsn': 'x'}, 'staging': {'dsn': 'y'}}\n", id="multi_entry_all_mappings"),
+    pytest.param(
+        "credentials={'prod': Credential(host='h'), 'staging': Credential(host='h2')}\n",
+        id="multi_entry_all_credentials",
+    ),
+    # Auto-named form: the string is a Credential kwarg, not a mapping value.
+    pytest.param("credentials=Credential(dsn='dsn-string')\n", id="bare_credential_object"),
+    pytest.param("credentials=[Credential(host='h'), {'host': 'h2'}]\n", id="list_form"),
+]
+
+
+@pytest.mark.parametrize("line", _FLAGGED_LINES)
+def test_named_form_string_value_flagged(line: str, tmp_path: Path) -> None:
+    _write(tmp_path / "m.py", line)
     hits = find_named_form_string_credential_usages(tmp_path)
     assert len(hits) == 1
     assert "m.py" in hits[0]
 
 
-def test_named_form_double_quoted_string_flagged(tmp_path: Path) -> None:
-    """A double-quoted named-form string credential value is flagged."""
-    _write(tmp_path / "m.py", 'credentials={"prod": "dsn-string"}\n')
-    hits = find_named_form_string_credential_usages(tmp_path)
-    assert len(hits) == 1
-    assert "m.py" in hits[0]
-
-
-def test_add_credentials_named_form_string_flagged(tmp_path: Path) -> None:
-    """A named-form string value passed to add_credentials is flagged."""
-    _write(tmp_path / "m.py", "collection.add_credentials({'prod': 'dsn-string'})\n")
-    hits = find_named_form_string_credential_usages(tmp_path)
-    assert len(hits) == 1
-    assert "m.py" in hits[0]
-
-
-def test_nested_mapping_value_not_flagged(tmp_path: Path) -> None:
-    """A named-form value that is a nested mapping is not flagged."""
-    _write(tmp_path / "m.py", "credentials={'prod': {'dsn': 'dsn-string'}}\n")
-    assert find_named_form_string_credential_usages(tmp_path) == []
-
-
-def test_named_form_credential_object_value_not_flagged(tmp_path: Path) -> None:
-    """A named-form value that is a Credential(...) is not flagged."""
-    _write(tmp_path / "m.py", "credentials={'pg-prod': Credential(host='h')}\n")
-    assert find_named_form_string_credential_usages(tmp_path) == []
-
-
-def test_multi_entry_later_string_value_flagged(tmp_path: Path) -> None:
-    """A multi-entry mapping whose first value is a nested mapping but a later value is a bare string is flagged."""
-    _write(tmp_path / "m.py", "credentials={'prod': {'dsn': 'ok'}, 'staging': 'dsn-string'}\n")
-    hits = find_named_form_string_credential_usages(tmp_path)
-    assert len(hits) == 1
-    assert "m.py" in hits[0]
-
-
-def test_multi_entry_all_mapping_values_not_flagged(tmp_path: Path) -> None:
-    """A multi-entry mapping where every value is a nested mapping is not flagged."""
-    _write(tmp_path / "m.py", "credentials={'prod': {'dsn': 'x'}, 'staging': {'dsn': 'y'}}\n")
-    assert find_named_form_string_credential_usages(tmp_path) == []
-
-
-def test_multi_entry_all_credential_values_not_flagged(tmp_path: Path) -> None:
-    """A multi-entry mapping where every value is a Credential(...) is not flagged."""
-    _write(tmp_path / "m.py", "credentials={'prod': Credential(host='h'), 'staging': Credential(host='h2')}\n")
-    assert find_named_form_string_credential_usages(tmp_path) == []
-
-
-def test_bare_credential_object_not_flagged(tmp_path: Path) -> None:
-    """A bare auto-named Credential(...) with a string kwarg is not flagged."""
-    _write(tmp_path / "m.py", "credentials=Credential(dsn='dsn-string')\n")
-    assert find_named_form_string_credential_usages(tmp_path) == []
-
-
-def test_list_form_not_flagged(tmp_path: Path) -> None:
-    """A list-form credentials value is not flagged."""
-    _write(tmp_path / "m.py", "credentials=[Credential(host='h'), {'host': 'h2'}]\n")
+@pytest.mark.parametrize("line", _ACCEPTED_LINES)
+def test_valid_credential_form_not_flagged(line: str, tmp_path: Path) -> None:
+    _write(tmp_path / "m.py", line)
     assert find_named_form_string_credential_usages(tmp_path) == []
 
 


### PR DESCRIPTION
Across the data-operation test harnesses, the community test bases and the end2end policy lints, groups of three or more test functions had bodies that were identical once the literal arguments were erased. Each group is now one `pytest.mark.parametrize` with an explicit id per case, so a failing case names the operation it covers (`test_cross_framework_agg[mode]` rather than one of thirteen near-identical methods).

Net effect: 1,175 lines added, 1,923 removed across 36 files.

## Invariants

- **Collected test count is unchanged in every one of the 168 test files**, not just in total (5094 before, 5094 after). A drop would have meant a parametrize table lost an entry.
- **Pass/skip split is unchanged**: 4889 passed, 205 skipped on `main` and on this branch, with an identical sorted skip report.
- Skips stay per case. Where only some members guarded with `_skip_if_unsupported`, the op is a parameter field and the guard runs inside the body, so an unsupported op skips alone while its siblings still run. Same for the `importorskip` cases in the catalog tests.
- No assertion was weakened to make a merge possible. Identity assertions stay identity assertions, and tests whose bodies genuinely differed were left alone.

## Notes

- `mloda/testing/**` is a published harness that per-backend test classes inherit, so these methods ship to plugin authors. No backend subclass overrode any collapsed method.
- `known-divergences.md` cites regression tests by symbol and is enforced by `test_known_divergences.py`, which resolves each reference with `getattr`. The entries for the all-null aggregation policy, the mode tie-breaking divergence and the SQLite string exclusions now name the collapsed methods, and the prose bullets name the specific case.
- The new-operation guide shows the parametrized test base, since that is now the idiom a new operation should follow.
- Where a docstring carried something the code does not say (which fixture rows are null, PyArrow tie-breaking, DuckDB bucket anchoring, why a backend excludes an op), it survives as a comment on the parameter it belongs to.