### PR TITLE
docs(releasing): note PyPI's new-project rate limit; restore 5s upload delay

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -136,7 +136,7 @@ jobs:
           # PyPI answered 429 part way through the 0.4.1 release, leaving it partially
           # published. Which limiter fires is still unconfirmed, so upload one file at a
           # time with a pause between them rather than one batch `twine upload dist/*`.
-          PYPI_UPLOAD_DELAY_SECONDS: '10'
+          PYPI_UPLOAD_DELAY_SECONDS: '5'
         # --skip-existing keeps a rerun after a partial upload from failing on files already on PyPI.
         # --verbose so a 429 prints the response body and the RateLimit / RateLimit-Policy
         # headers; without it twine reports a bare "Too Many Requests" that names no policy.
@@ -148,7 +148,7 @@ jobs:
             exit 1
           fi
 
-          delay="${PYPI_UPLOAD_DELAY_SECONDS:-10}"
+          delay="${PYPI_UPLOAD_DELAY_SECONDS:-5}"
           total=${#dists[@]}
           index=0
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -59,6 +59,14 @@ the four bundles and `mloda-community-example`, not the set as a whole.
 Flagging a package does not publish it: it ships with the next release run, and
 `tox -e verify-published` and `tox -e verify-floor-installs` fail for it until then.
 
+A release that introduces packages new to PyPI can be rejected with
+`429 Too many new projects created`. PyPI throttles the creation of *new* project names,
+independently of uploads to projects that already exist, and in practice the threshold is
+low (around four) and the lockout lasts many hours. It is not something the release
+workflow can pace or retry around. See
+[pypi/support#10572](https://github.com/pypi/support/issues/10572) and
+[this monorepo release thread](https://discuss.python.org/t/request-temporary-new-project-rate-limit-lift-on-pypi-for-a-coordinated-monorepo-release-user-pace/108030).
+
 Not every package ships standalone. Most demo and example packages reach users inside the
 `mloda-community` / `mloda-enterprise` bundle wheels instead; `mloda-community-example`
 and `mloda-community-example-a` are the exceptions, published to keep end-to-end PyPI


### PR DESCRIPTION
## Summary

Closes out the 0.4.1 publish investigation from #397 and #398.

The failure was never upload pacing. With `--verbose` in place (added in #398), PyPI's actual response was:

```
429 Too many new projects created
```

That limiter throttles the creation of *new project names* and is only consulted when a project does not yet exist (`warehouse/packaging/services.py:420-487`). Uploads to projects that already exist never touch it, which is why 23 of the 24 packages published fine and only `mloda-community-time-bucketization`, the one name new to PyPI, was rejected, in every run and at every position in the upload order.

It also reproduced from a local machine on a different IP, so it is not the shared GitHub-runner egress IP.

## Changes

- **`docs/releasing.md`**: a short note under "Published packages" that a release introducing packages new to PyPI can be rejected this way, that the practical threshold is low and the lockout long, and that the release workflow cannot pace or retry around it. Deliberately just a mention, with links out, not a how-to.
- **`.github/workflows/release.yaml`**: `PYPI_UPLOAD_DELAY_SECONDS` back from 10 to 5. The bump was made while the cause was unknown and does nothing for this failure mode; 10s added roughly 4 minutes per release for no benefit.

The per-file loop and `--verbose` stay. The loop earns its place on logging alone (it names exactly which wheel failed), and `--verbose` is what surfaced the real error.

## Corroboration

The behaviour is undocumented and reported by others at similar scale, around four new projects, with lockouts of 12+ hours:

- [pypi/support#10572](https://github.com/pypi/support/issues/10572), ~4 projects over 2 days, then 429
- [discuss.python.org, coordinated monorepo release](https://discuss.python.org/t/request-temporary-new-project-rate-limit-lift-on-pypi-for-a-coordinated-monorepo-release-user-pace/108030), 23-package monorepo, 4 created then throttled 12+ hours, resolved by publishing the rest by hand over several days

## Verification

- Workflow parses as YAML; the step exposes `PYPI_UPLOAD_DELAY_SECONDS: '5'`.
- Extracted `run:` block against a stub `twine`: `--verbose` still passed through, two files take 5.0s, so the 5s default is in effect.

## Status of 0.4.1

Published for 23 of 24 packages. `mloda-community-time-bucketization` is still missing and needs a single manual upload once the throttle clears; the wheel is already built.