### PR TITLE
fix(point_arithmetic): reject one-operand names at match time

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/base.py
@@ -54,7 +54,14 @@ def _is_ordered_in_features(value: object) -> bool:
 
 
 class PointArithmeticFeatureGroup(ArithmeticFeatureGroupBase):
-    PREFIX_PATTERN = r".*__([\w]+)_point$"
+    # The source side must carry the '&' separator: point arithmetic needs two
+    # operands, so a one-operand name like 'x__add_point' cannot be computed.
+    # Without the '&' here such a name matched at resolution time and only blew
+    # up later in _extract_source_features, so the user got a compute-time
+    # ValueError instead of a "no feature group found" error naming the real
+    # problem. The config path (arithmetic_op plus a two-element in_features)
+    # does not go through this pattern and is unaffected.
+    PREFIX_PATTERN = r".*&.*__([\w]+)_point$"
 
     MIN_IN_FEATURES = 2
     MAX_IN_FEATURES = 2

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/tests/test_base.py
@@ -63,12 +63,28 @@ class TestPatternMatching:
             pytest.param("value_int&amount__add", id="no_suffix"),
             pytest.param("add_point", id="no_source_column"),
             pytest.param("value_int&amount__unknown_point", id="invalid_operation"),
+            pytest.param("x__add_point", id="single_operand"),
+            pytest.param("value_int__divide_point", id="single_operand_valid_op"),
         ],
     )
     def test_no_match(self, feature_name: str) -> None:
         options = Options()
         result = PointArithmeticFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is False
+
+    def test_single_operand_name_is_rejected_at_match_time(self) -> None:
+        """Point arithmetic needs two operands, so a one-operand name must not match.
+
+        A name that matches but cannot compute is worse than a plain non-match:
+        resolution commits the feature to this family, so the user gets a
+        compute-time ValueError out of ``_extract_source_features`` rather than
+        a "no feature group found" error naming the real problem. Sibling
+        families in this package reject unusable inputs at match time.
+        """
+        assert PointArithmeticFeatureGroup.match_feature_group_criteria("x__add_point", Options(), None) is False
+
+        # The two-operand form of the same op is unaffected.
+        assert PointArithmeticFeatureGroup.match_feature_group_criteria("x&y__add_point", Options(), None) is True
 
 
 class TestPatternParsing:

--- a/mloda/community/feature_groups/data_operations/tests/test_prefix_pattern_collisions.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_prefix_pattern_collisions.py
@@ -110,7 +110,9 @@ FAMILIES: tuple[FamilySpec, ...] = (
         "point_arithmetic",
         f"{_DO}.row_preserving.point_arithmetic.base",
         "PointArithmeticFeatureGroup",
-        ("x__add_point",),
+        # Two operands: the documented pattern is ``{col_a}&{col_b}__{op}_point``,
+        # so the one-operand form is not a valid name for this family (#403).
+        ("x&y__add_point",),
     ),
     FamilySpec("rank", f"{_DO}.row_preserving.rank.base", "RankFeatureGroup", ("sales__row_number_ranked",)),
     FamilySpec(
@@ -318,12 +320,14 @@ def _gen_scalar_arithmetic() -> tuple[str, ...]:
 
 
 def _gen_point_arithmetic() -> tuple[str, ...]:
-    # Vocabulary: point_arithmetic.base.ARITHMETIC_OPERATIONS. Names: ``{col}__{op}_point``.
+    # Vocabulary: point_arithmetic.base.ARITHMETIC_OPERATIONS.
+    # Names: ``{col_a}&{col_b}__{op}_point`` - the family needs two operands, so
+    # the one-operand form is not part of its vocabulary (#403).
     from mloda.community.feature_groups.data_operations.row_preserving.point_arithmetic.base import (
         ARITHMETIC_OPERATIONS,
     )
 
-    return tuple(f"x__{op}_point" for op in ARITHMETIC_OPERATIONS)
+    return tuple(f"x&y__{op}_point" for op in ARITHMETIC_OPERATIONS)
 
 
 def _gen_rank() -> tuple[str, ...]:


### PR DESCRIPTION
Closes #403.

## Reproduced

```
match_feature_group_criteria('x__add_point', Options())  -> True
_extract_source_features(Feature('x__add_point', ...))
  -> ValueError: Feature 'x__add_point' requires at least 2 in_feature(s), but found 1
```

`PREFIX_PATTERN = r".*__([\w]+)_point$"` put no constraint on the source side of `__`, so a one-operand name matched at resolution time and only blew up at compute time.

## Fix

Took the first option in the DoD — tightened the pattern to require the `&` separator, matching the documented `{col_a}&{col_b}__{op}_point`:

```python
PREFIX_PATTERN = r".*&.*__([\w]+)_point$"
```

Behaviour after, checked directly:

| name | matches |
|---|---|
| `x__add_point` | **False** (was True) |
| `value_int__divide_point` | **False** (was True) |
| `x&y__add_point` | True |
| `value_int&amount__divide_point` | True |
| `value_int&amount__add__subtract_point` | True |
| `a__b&c__add_point` | True |
| `add_point` | False |
| `x&y__unknown_point` | False |

**The config path is untouched.** It does not go through this pattern — `test_config_based_match` uses the name `"my_result"`, which has no `&` and never matched the regex; it still returns True.

**The greedy-parse contract still holds.** `test_greedy_regex_for_chained_op_tokens` explicitly says "a future regex tightening must be a deliberate decision; this test exists to surface any silent change to the parse contract". This is that deliberate decision, and it does not move the contract: `value_int&amount__add__subtract_point` still parses to `['value_int', 'amount__add']` with op `subtract`, because that name already carries a `&`.

## The published example names

The issue's closing note — "the family's own published example names used the one-operand form" — turned out to be literal. `test_prefix_pattern_collisions.py` registers point_arithmetic's vocabulary twice, and **both** used one operand:

- the representative name, `("x__add_point",)`
- the generated vocabulary, `tuple(f"x__{op}_point" for op in ARITHMETIC_OPERATIONS)`

Both now use the two-operand form, so the routing lint tests the family's real vocabulary rather than names it cannot execute.

## Tests

- Two rows added to the existing `test_no_match` parametrize: `single_operand` (`x__add_point`) and `single_operand_valid_op` (`value_int__divide_point`).
- One focused test asserting the rejection alongside the two-operand form of the same op, with the *why* in its docstring.

**Revert-verified**: all three fail against the old pattern.

## Verification

- `point_arithmetic/` — 220 passed, 8 skipped
- `data_operations/` + `tests/` — 4516 passed, 205 skipped
- `ruff format --check --line-length 120 .` → 456 files already formatted; `ruff check .` → all checks passed; `mypy --strict --ignore-missing-imports` → 314 source files clean

**Pre-existing local failures, reproduced on a clean tree and unrelated to this change:** `test_framework_support_matrix.py::test_framework_support_matrix_is_in_sync` (1) and `test_bandit_exclusions.py` (4, `bandit` not resolvable in my env).
