### PR TITLE
test(time_bucketization): give the wrong_suffix case a genuinely wrong suffix

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
@@ -77,7 +77,11 @@ class TestPatternMatching:
     @pytest.mark.parametrize(
         "feature_name",
         [
-            pytest.param("timestamp__truncate_1_day", id="wrong_suffix"),
+            # A valid op, n and unit, but PREFIX_PATTERN is anchored at ``$``, so
+            # anything trailing the unit puts the name outside this family. This
+            # input used to be ``timestamp__truncate_1_day``, identical to the
+            # ``invalid_op`` case below, so nothing covered a wrong suffix (#400).
+            pytest.param("timestamp__floor_1_day_bucket", id="wrong_suffix"),
             pytest.param("timestamp", id="no_suffix"),
             pytest.param("floor_1_day", id="no_source_column"),
             pytest.param("timestamp__truncate_1_day", id="invalid_op"),


### PR DESCRIPTION
Closes #400.

`TestPatternMatching::test_no_match` passed `"timestamp__truncate_1_day"` for both the `wrong_suffix` and the `invalid_op` row. `truncate` is not one of `floor`/`ceil`/`round`, so both rows exercised the invalid-op path and `test_no_match[wrong_suffix]` passed for a reason unrelated to its name — nothing covered a wrong suffix at all.

`wrong_suffix` now uses `"timestamp__floor_1_day_bucket"`: a valid op, a valid `n`, and a valid unit, with a trailing token that `PREFIX_PATTERN`'s `$` anchor rejects.

I checked it fails against the raw regex rather than at validation, so it exercises the pattern itself and stays distinct from all three neighbouring cases:

| id | input | regex match | criteria |
|---|---|---|---|
| `wrong_suffix` | `timestamp__floor_1_day_bucket` | False | False |
| `invalid_op` | `timestamp__truncate_1_day` | False | False |
| `invalid_unit` | `timestamp__floor_1_century` | False | False |
| `n_zero` | `timestamp__floor_0_day` | **True** | False (validation) |
| *(control)* | `timestamp__floor_1_day` | True | True |

Collected test count is unchanged as required: **96 before, 96 after**.

## Verification

`time_bucketization/` — 297 passed, 6 skipped. `ruff format --check --line-length 120 .` → 456 files already formatted; `ruff check .` → all checks passed; `mypy --strict --ignore-missing-imports` clean on the family.
