### PR TITLE
refactor(data_operations): hoist the repeated family base-class boilerplate

### DIFF
--- a/docs/guides/data-operation-patterns/10-adding-new-operation.md
+++ b/docs/guides/data-operation-patterns/10-adding-new-operation.md
@@ -56,10 +56,42 @@ The base class owns:
 
 - The feature-name regex.
 - The loop over `features.features`.
-- Extraction of source column, operation, and any options from `Options(context=...)`.
 - Delegation to a per-framework `_compute` hook.
 
-Existing bases to crib from: `row_preserving/binning/base.py` (simple), `row_preserving/window_aggregation/base.py` (with `partition_by`/`order_by`/masks). They compose `FeatureChainParserMixin` to parse the suffix of the feature name; copy that detail verbatim from the closest existing base.
+Source-column extraction, the ordering reads and the op-type accessors are inherited, not written. Mix in the one that matches your operation, always **last** in the bases (inserting it earlier shifts `__mro__.index()` for every ancestor behind it, and core reads that index as link specificity in `resolve_links`), and declare the attributes that drive it. Both rules are checked at class creation: a mixin listed before another base, or a driving attribute you never declared, raises `TypeError` on import.
+
+| Mixin | Gives you | Declare |
+|---|---|---|
+| `SingleSourceMixin` | `_single_source_features`, `_single_source_input_features` | `MIN_IN_FEATURES`, `MAX_IN_FEATURES`, `SOURCE_LABEL`, `ENFORCE_MIN_IN_FEATURES`, `ENFORCE_MAX_IN_FEATURES`, `VALIDATE_IN_FEATURE_COUNT` |
+| `PartitionedSourceMixin` | the above plus `_extract_partition_by` | `PARTITION_BY` |
+| `OrderedSourceMixin` | the above plus `_extract_order_by` | `ORDER_BY`, `ORDER_BY_DEFAULTS_TO_SOURCE` |
+| `OpTypeAccessorMixin` | `_extract_op_type`, `_resolve_op_type` | `_op_type_key()`, `OP_TYPE_LABEL` |
+
+`SOURCE_LABEL` is only the noun the arity and ordering errors name your family with (unset, they name the class). What turns the checks on is `ENFORCE_MIN_IN_FEATURES` / `ENFORCE_MAX_IN_FEATURES`, and the bounds they read are core's `MIN_IN_FEATURES` / `MAX_IN_FEATURES`, so declare all four or the family accepts any number of source features. `ORDER_BY_DEFAULTS_TO_SOURCE` decides the other contract: leave it `False` and a missing `order_by` raises, set it `True` (sessionization) and the ordering falls back to the source column. `_op_type_key` is a classmethod rather than a constant so that a subclass overriding your family's option-key constant changes the key that is read.
+
+Core owns `_extract_source_features` and `input_features` and resolves them before an appended mixin, so those two stay one-line delegators in your class:
+
+```python
+class YourOpFeatureGroup(RejectionReasonMixin, FeatureGroup, OrderedSourceMixin):
+    MIN_IN_FEATURES = 1
+    MAX_IN_FEATURES = 1
+
+    SOURCE_LABEL = "your_op"
+    ENFORCE_MIN_IN_FEATURES = True
+    ENFORCE_MAX_IN_FEATURES = True
+
+    PARTITION_BY = "partition_by"
+    ORDER_BY = "order_by"
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return self._single_source_input_features(options, feature_name)
+
+    @classmethod
+    def _extract_source_features(cls, feature: Feature) -> list[str]:
+        return cls._single_source_features(feature)
+```
+
+Existing bases to crib from: `row_preserving/datetime/base.py` or `row_preserving/scalar_aggregate/base.py` for the plain case, `row_preserving/ema/base.py` or `row_preserving/ffill/base.py` for the ordered one. `row_preserving/binning/base.py` and `row_preserving/sessionization/base.py` hand-write `input_features` where their contract differs from the mixin default, each with a comment saying why. `row_preserving/window_aggregation/base.py` predates the mixins and reads `partition_by` / `order_by` from `options` directly: crib its masks, not its extraction.
 
 ---
 
@@ -215,6 +247,7 @@ class YourOpTestBase(MaskTestMixin, DataOpsTestBase):
 ## Checklist
 
 - [ ] Base class with `PREFIX_PATTERN`, `calculate_feature`, and an abstract `_compute` hook.
+- [ ] The matching extraction mixin appended last, with its driving attributes declared.
 - [ ] PyArrow implementation first; it is the reference.
 - [ ] Test base in `mloda/testing/.../{your_op}.py` with inherited test methods.
 - [ ] One framework implementation per target framework, each respecting row-preserving if applicable.

--- a/mloda/community/feature_groups/data_operations/aggregation_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation_base.py
@@ -1,29 +1,20 @@
 """Shared skeleton for the aggregation feature-group families.
 
-The aggregation, window-aggregation, scalar-aggregate, and frame-aggregate
-families share the same aggregation-type extraction machinery: they parse the
-same aggregation names out of the feature name or options, validate them against
-a canonical aggregation-type table, and declare INT64 for counting ops. Issue
-#246 had this logic duplicated across the families' ``base.py`` files.
-
-``AggregationFeatureGroupBase`` holds the identical parts, mirroring the
-``ArithmeticFeatureGroupBase`` consolidation from issue #214. The families
-subclass it and override ``AGGREGATION_TYPES`` (so each family advertises its
-own supported set / descriptions) and ``_COUNTING_AGG_TYPES`` (which agg types
-produce an integer count), plus the family-specific bits (operand count,
-matching, PROPERTY_MAPPING). Per-backend computation lives in the backend
-modules.
+The aggregation, window-aggregation, scalar-aggregate, and frame-aggregate families share the same
+aggregation-type extraction machinery, so ``AggregationFeatureGroupBase`` holds it. The families
+subclass it and override ``AGGREGATION_TYPES`` (each family advertises its own supported set) and
+``_COUNTING_AGG_TYPES`` (which agg types produce an integer count), plus the family-specific bits
+(operand count, matching, PROPERTY_MAPPING). Per-backend computation lives in the backend modules.
 """
 
 from __future__ import annotations
 
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, op_token_value
+from mloda.community.feature_groups.data_operations.base import OpTypeAccessorMixin, RejectionReasonMixin
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 
 AGGREGATION_TYPES: dict[str, str] = {
@@ -47,8 +38,10 @@ AGGREGATION_TYPES: dict[str, str] = {
 }
 
 
-class AggregationFeatureGroupBase(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup):
+class AggregationFeatureGroupBase(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup, OpTypeAccessorMixin):
     AGGREGATION_TYPE = "aggregation_type"
+
+    OP_TYPE_LABEL = "aggregation type"
 
     #: Canonical aggregation-type table. Subclasses override to advertise their
     #: own supported set / descriptions.
@@ -59,6 +52,11 @@ class AggregationFeatureGroupBase(SubtypeCapabilityHook, RejectionReasonMixin, F
     _COUNTING_AGG_TYPES: frozenset[str] = frozenset({"count", "nunique"})
 
     @classmethod
+    def _op_type_key(cls) -> str:
+        """The option key the aggregation type falls back to, read live so an override of it applies."""
+        return cls.AGGREGATION_TYPE
+
+    @classmethod
     def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
         """Validate that the parsed aggregation type is in AGGREGATION_TYPES."""
         return operation_config in cls.AGGREGATION_TYPES
@@ -66,36 +64,17 @@ class AggregationFeatureGroupBase(SubtypeCapabilityHook, RejectionReasonMixin, F
     @classmethod
     def get_aggregation_type(cls, feature_name: str) -> str:
         """Extract the aggregation type from a feature name string."""
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract aggregation type from feature name: {feature_name}")
+        return cls._extract_op_type(feature_name)
 
     @classmethod
     def _extract_aggregation_type(cls, feature: Feature) -> str:
         """Extract aggregation type from feature (string-based or config-based)."""
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        agg_type = feature.options.get(cls.AGGREGATION_TYPE)
-        if agg_type is None:
-            raise ValueError(f"Could not extract aggregation type for {feature_name}")
-        return op_token_value(agg_type)
+        return cls._extract_op_type(feature.name, feature.options)
 
     @classmethod
     def _resolve_agg_type(cls, feature_name: str, options: Options) -> str | None:
         """Resolve the aggregation type from the feature name or options; None if unresolvable."""
-        try:
-            operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, cls._get_prefix_patterns())
-        except ValueError:
-            return None
-        if operation_config is not None:
-            return operation_config
-        agg_type = options.get(cls.AGGREGATION_TYPE)
-        return None if agg_type is None else op_token_value(agg_type)
+        return cls._resolve_op_type(feature_name, options)
 
     @classmethod
     def _capability_subtype(cls, feature_name: str, options: Options) -> str | None:

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import re
 import reprlib
-from collections.abc import Callable
+from collections.abc import Callable, Container
 from enum import Enum
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import FeatureGroup
 
 T = TypeVar("T")
 
@@ -222,6 +224,18 @@ def is_parametric_suffix(suffix: str) -> bool:
     return _PARAMETRIC_SUFFIX_PATTERN.fullmatch(suffix) is not None
 
 
+def is_supported_op_type(value: object, fixed_types: Container[str], parametric_families: tuple[str, ...]) -> bool:
+    """True for one of ``fixed_types``, or a ``{family}_{N}`` token of a parametric family with N >= 1."""
+    if not isinstance(value, str):
+        return False
+    if value in fixed_types:
+        return True
+    return any(
+        value.startswith(f"{family}_") and is_parametric_suffix(value[len(family) + 1 :])
+        for family in parametric_families
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shared rejection-reason reporting
 # ---------------------------------------------------------------------------
@@ -326,3 +340,223 @@ class RejectionReasonMixin(FeatureChainParserMixin):
             return bool(guard(value))
         except (TypeError, ValueError, AttributeError):
             return False
+
+
+# ---------------------------------------------------------------------------
+# Shared source-column and operation-type plumbing
+# ---------------------------------------------------------------------------
+
+if TYPE_CHECKING:
+    # Borrowed for type checking only. Inheriting the chain-parser API at runtime would move
+    # FeatureChainParserMixin and FeatureGroup in every family's __mro__, and core reads that
+    # index as link specificity (resolve_links._inheritance_distance).
+    _ChainParserApi = FeatureChainParserMixin
+else:
+    _ChainParserApi = object
+
+
+def _own_names(cls: type) -> frozenset[str]:
+    """Every non-dunder name the class itself defines."""
+    return frozenset(name for name in vars(cls) if not name.startswith("__"))
+
+
+#: Names core resolves BEFORE an appended mixin at runtime, so a mixin defining one would be dead code.
+_CORE_OWNED_NAMES = frozenset(
+    name for klass in (*FeatureChainParserMixin.__mro__, *FeatureGroup.__mro__) for name in _own_names(klass)
+)
+
+
+class _MixinContract(_ChainParserApi):
+    """Class-creation guard for the accessor mixins below: what mypy --strict cannot see.
+
+    ``_ChainParserApi`` is FeatureChainParserMixin while type checking and ``object`` at runtime, so a
+    type checker puts these mixins AHEAD of core in the ``__mro__`` while CPython puts them BEHIND it.
+    A mixin name core also owns therefore type-checks as the winner while being dead at runtime; a bare
+    annotation (``PARTITION_BY: str``) is a declaration to mypy that does not exist at runtime; and a
+    mixin not listed last moves the ancestors behind it. Each raises here, naming class and attribute.
+    """
+
+    #: Names a mixin reads off the mixing class without defining them itself.
+    REQUIRED_ATTRS: ClassVar[tuple[str, ...]] = ()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if cls.__module__ == __name__:
+            shadowed = sorted(_own_names(cls) & _CORE_OWNED_NAMES)
+            if shadowed:
+                raise TypeError(f"{cls.__name__} defines {shadowed[0]!r}, which core owns and resolves first")
+            return
+        appended = tuple(
+            base for base in cls.__bases__ if base.__module__ == __name__ and issubclass(base, _MixinContract)
+        )
+        if appended and cls.__bases__[-len(appended) :] != appended:
+            raise TypeError(
+                f"{cls.__name__} must list {appended[0].__name__} last in its bases, so every other "
+                f"ancestor keeps its __mro__ index (core reads that index as link specificity)"
+            )
+        declared = frozenset(name for base in cls.__mro__ if base.__module__ != __name__ for name in _own_names(base))
+        for mixin in cls.__mro__:
+            if mixin.__module__ != __name__:
+                continue
+            for attr in vars(mixin).get("REQUIRED_ATTRS", ()):
+                if attr not in declared:
+                    raise TypeError(f"{cls.__name__} must declare {attr!r}, which {mixin.__name__} reads at runtime")
+
+
+class SingleSourceMixin(_MixinContract):
+    """One source column per feature: the name-or-in_features read and its arity errors.
+
+    Mix in LAST so appending leaves every existing ancestor at its current ``__mro__`` index (see
+    ``_ChainParserApi`` above). Core owns ``_extract_source_features`` and ``input_features`` and
+    resolves both BEFORE an appended mixin, so a family delegates those two explicitly.
+    """
+
+    #: Family name rendered in the arity and ordering errors; None renders the class name instead.
+    SOURCE_LABEL: ClassVar[str | None] = None
+
+    #: Reject an empty ``in_features`` instead of returning an empty source list.
+    ENFORCE_MIN_IN_FEATURES: ClassVar[bool] = False
+
+    #: Report more than MAX_IN_FEATURES sources as a family arity error instead of leaving it to core.
+    ENFORCE_MAX_IN_FEATURES: ClassVar[bool] = False
+
+    #: Run core's in-feature count check on the ``in_features`` branch of ``_single_source_input_features``.
+    VALIDATE_IN_FEATURE_COUNT: ClassVar[bool] = True
+
+    @classmethod
+    def _source_label(cls) -> str:
+        """The noun the arity and ordering errors name the family with."""
+        return cls.SOURCE_LABEL or cls.__name__
+
+    @classmethod
+    def _source_from_name(cls, feature_name: str) -> str | None:
+        """The source column encoded in the feature name, or None when the name encodes none."""
+        _operation_config, source_feature = FeatureChainParser.parse_feature_name(
+            feature_name, cls._get_prefix_patterns()
+        )
+        # The parser returns both halves or neither (a match without a source raises), so an
+        # empty source is always the no-match case.
+        return source_feature or None
+
+    @classmethod
+    def _single_source_features(cls, feature: Feature) -> list[str]:
+        """The one source column, from the feature name when it encodes one, else from ``in_features``."""
+        source_feature = cls._source_from_name(feature.name)
+        if source_feature is not None:
+            return [source_feature]
+
+        source_names = [str(f.name) for f in feature.options.get_in_features()]
+        cls._validate_source_arity(source_names)
+        return source_names
+
+    @classmethod
+    def _validate_source_arity(cls, source_names: list[str]) -> None:
+        """Reject an ``in_features`` list outside the family's arity."""
+        if cls.ENFORCE_MIN_IN_FEATURES and len(source_names) < cls.MIN_IN_FEATURES:
+            raise ValueError(
+                f"{cls._source_label()} requires at least {cls.MIN_IN_FEATURES} source feature, "
+                f"but got {len(source_names)} (in_features is empty)."
+            )
+        cls._reject_extra_sources(source_names)
+
+    @classmethod
+    def _reject_extra_sources(cls, source_names: list[str]) -> None:
+        """Reject more than MAX_IN_FEATURES source columns."""
+        maximum = cls.MAX_IN_FEATURES
+        if not cls.ENFORCE_MAX_IN_FEATURES or maximum is None or len(source_names) <= maximum:
+            return
+        raise ValueError(
+            f"{cls._source_label()} supports at most {maximum} source feature, "
+            f"but got {len(source_names)}: {source_names}"
+        )
+
+    def _single_source_input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        """The one input Feature the name encodes, else the ``in_features`` set."""
+        source_feature = self._source_from_name(str(feature_name))
+        if source_feature is not None:
+            return {Feature(source_feature)}
+
+        in_features_set = options.get_in_features()
+        if self.VALIDATE_IN_FEATURE_COUNT:
+            self._validate_in_feature_count(list(in_features_set), str(feature_name))
+        return set(in_features_set)
+
+
+class PartitionedSourceMixin(SingleSourceMixin):
+    """SingleSourceMixin plus the PARTITION_BY read, split out so no family inherits an accessor it cannot honour."""
+
+    REQUIRED_ATTRS = ("PARTITION_BY",)
+
+    PARTITION_BY: str
+
+    @classmethod
+    def _extract_partition_by(cls, feature: Feature) -> list[str]:
+        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
+        partition_by = feature.options.get(cls.PARTITION_BY)
+        if partition_by is None:
+            return []
+        return list(partition_by)
+
+
+class OrderedSourceMixin(PartitionedSourceMixin):
+    """PartitionedSourceMixin plus the ORDER_BY read, for the families that declare both keys."""
+
+    REQUIRED_ATTRS = ("ORDER_BY",)
+
+    ORDER_BY: str
+
+    #: Order by the source column when ``order_by`` is absent; False makes the key required.
+    ORDER_BY_DEFAULTS_TO_SOURCE: ClassVar[bool] = False
+
+    @classmethod
+    def _extract_order_by(cls, feature: Feature, source_col: str | None = None) -> str:
+        """Return ``order_by``, falling back to ``source_col`` only for a family whose contract defaults to it."""
+        order_by = option_value(feature.options, cls.ORDER_BY, column_ref_value)
+        if order_by is not None:
+            return order_by
+        if cls.ORDER_BY_DEFAULTS_TO_SOURCE and source_col is not None:
+            return source_col
+        raise ValueError(f"{cls._source_label()} requires an 'order_by' column in Options context.")
+
+
+class OpTypeAccessorMixin(_MixinContract):
+    """One operation-type token per feature: the name-first read, its options fallback, and their errors.
+
+    Mix in LAST, like SingleSourceMixin. Families keep their own accessor names as delegators, so a
+    subclass override of e.g. ``_resolve_agg_type`` still wins at every call site.
+    """
+
+    REQUIRED_ATTRS = ("_op_type_key", "OP_TYPE_LABEL")
+
+    #: Noun rendered in the extraction errors (e.g. ``"rank type"``).
+    OP_TYPE_LABEL: ClassVar[str]
+
+    @classmethod
+    def _op_type_key(cls) -> str:
+        """The option key the token falls back to; a family returns its own constant so overriding it stays live."""
+        raise NotImplementedError(f"{cls.__name__} must return its operation-type option key from _op_type_key")
+
+    @classmethod
+    def _extract_op_type(cls, feature_name: str, options: Options | None = None) -> str:
+        """The type the name encodes, else the one in ``options`` when a caller passes them; raises on neither."""
+        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, cls._get_prefix_patterns())
+        if operation_config is not None:
+            return operation_config
+        if options is None:
+            raise ValueError(f"Could not extract {cls.OP_TYPE_LABEL} from feature name: {feature_name}")
+        op_type = options.get(cls._op_type_key())
+        if op_type is None:
+            raise ValueError(f"Could not extract {cls.OP_TYPE_LABEL} for {feature_name}")
+        return op_token_value(op_type)
+
+    @classmethod
+    def _resolve_op_type(cls, feature_name: str, options: Options) -> str | None:
+        """The same read as _extract_op_type, with every miss (an unparsable name included) reported as None."""
+        try:
+            operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, cls._get_prefix_patterns())
+        except ValueError:
+            return None
+        if operation_config is not None:
+            return operation_config
+        op_type = options.get(cls._op_type_key())
+        return None if op_type is None else op_token_value(op_type)

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -46,6 +46,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.base import (
+    PartitionedSourceMixin,
     RejectionReasonMixin,
     always_required,
     column_ref_value,
@@ -118,7 +119,7 @@ def _is_valid_resample_op(value: object) -> bool:
     return True
 
 
-class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup, PartitionedSourceMixin):
     """Base class for resample operations that CHANGE the row count.
 
     Subclasses must implement ``_compute_resample`` (the backend-specific
@@ -129,6 +130,11 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
+
+    SOURCE_LABEL = "resample"
+    ENFORCE_MIN_IN_FEATURES = True
+    ENFORCE_MAX_IN_FEATURES = True
+    VALIDATE_IN_FEATURE_COUNT = False
 
     PARTITION_BY = "partition_by"
     TIME_COLUMN = "time_column"
@@ -161,12 +167,7 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        source_feature = self._source_from_name(str(feature_name))
-        if source_feature is not None:
-            return {Feature(source_feature)}
-
-        in_features_set = options.get_in_features()
-        return set(in_features_set)
+        return self._single_source_input_features(options, feature_name)
 
     # -- Name / token parsing ----------------------------------------------
 
@@ -174,10 +175,10 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
     def _source_from_name(cls, feature_name: str) -> str | None:
         """Return the source column from a ``{src}__resample_...`` name, else None.
 
-        Permissive on purpose: it splits on the LAST ``__resample_`` marker so
-        that invalid-unit / invalid-agg / n=0 feature names (e.g.
-        ``value__resample_1_century_mean``) still yield the source column and
-        the raw token, letting ``_parse_resample_op`` raise the SPECIFIC error.
+        Overrides the mixin's pattern-based read on purpose: splitting on the LAST
+        ``__resample_`` marker lets invalid-unit / invalid-agg / n=0 names (e.g.
+        ``value__resample_1_century_mean``) still yield the source column and the raw
+        token, so ``_parse_resample_op`` can raise the SPECIFIC error.
         """
         marker = f"__{_RESAMPLE_MARKER}_"
         idx = feature_name.rfind(marker)
@@ -199,32 +200,7 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        """Extract and validate the single source feature.
-
-        Name-based extraction is tried first; otherwise the source comes from
-        ``in_features``. Raises ``ValueError`` if more than one source feature
-        is supplied (MAX_IN_FEATURES=1).
-        """
-        source_feature = cls._source_from_name(feature.name)
-        if source_feature is not None:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        source_names: list[str] = [str(f.name) for f in in_features_set]
-
-        if len(source_names) < cls.MIN_IN_FEATURES:
-            raise ValueError(
-                f"resample requires at least {cls.MIN_IN_FEATURES} source feature, "
-                f"but got {len(source_names)} (in_features is empty)."
-            )
-
-        if len(source_names) > cls.MAX_IN_FEATURES:
-            raise ValueError(
-                f"resample supports at most {cls.MAX_IN_FEATURES} source feature, but got {len(source_names)}: "
-                f"{source_names}"
-            )
-
-        return source_names
+        return cls._single_source_features(feature)
 
     @classmethod
     def _extract_resample_op(cls, feature: Feature) -> str:
@@ -236,14 +212,6 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
         if op is None:
             raise ValueError(f"Could not extract resample op for {feature.name}")
         return op_token_value(op)
-
-    @classmethod
-    def _extract_partition_by(cls, feature: Feature) -> list[str]:
-        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
 
     @classmethod
     def _extract_time_column(cls, feature: Feature) -> str:

--- a/mloda/community/feature_groups/data_operations/row_preserving/arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/arithmetic/base.py
@@ -1,19 +1,12 @@
 """Shared skeleton for the arithmetic feature-group families.
 
-The point-arithmetic and scalar-arithmetic families share the same
-arithmetic-op extraction and numeric-source contract: they parse the same four
-operation names (``add``/``subtract``/``multiply``/``divide``) out of the
-feature name or options, and they reject non-numeric source columns with the
-same error format. Issue #214 had this logic duplicated byte-for-byte across
-the two families' ``base.py`` files.
-
-``ArithmeticFeatureGroupBase`` holds the identical parts. The families subclass
-it and override ``OPERATION_LABEL`` (so the rejection message names the right
-operation) plus the family-specific bits (operand count, constant handling,
-PROPERTY_MAPPING). Per-backend numeric introspection lives in
-``numeric_source``; the per-backend mixins supply the
-``_non_numeric_descriptor`` hook consumed by the
-``_assert_source_column_is_numeric`` template defined here.
+The point-arithmetic and scalar-arithmetic families share the same arithmetic-op extraction and
+numeric-source contract, so ``ArithmeticFeatureGroupBase`` holds it. The families subclass it and
+override ``OPERATION_LABEL`` (so the rejection message names the right operation) plus the
+family-specific bits (operand count, constant handling, PROPERTY_MAPPING). Per-backend numeric
+introspection lives in ``numeric_source``; the per-backend mixins supply the
+``_non_numeric_descriptor`` hook consumed by the ``_assert_source_column_is_numeric`` template
+defined here.
 """
 
 from __future__ import annotations
@@ -21,10 +14,9 @@ from __future__ import annotations
 from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.provider import FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, op_token_value
+from mloda.community.feature_groups.data_operations.base import OpTypeAccessorMixin, RejectionReasonMixin
 
 ARITHMETIC_OP_NAMES: frozenset[str] = frozenset({"add", "subtract", "multiply", "divide"})
 
@@ -32,12 +24,19 @@ ARITHMETIC_OP_NAMES: frozenset[str] = frozenset({"add", "subtract", "multiply", 
 SQL_ARITHMETIC_OPS: dict[str, str] = {"add": "+", "subtract": "-", "multiply": "*", "divide": "/"}
 
 
-class ArithmeticFeatureGroupBase(RejectionReasonMixin, FeatureGroup):
+class ArithmeticFeatureGroupBase(RejectionReasonMixin, FeatureGroup, OpTypeAccessorMixin):
     ARITHMETIC_OP = "arithmetic_op"
+
+    OP_TYPE_LABEL = "arithmetic operation"
 
     #: Operation label used in the numeric-source rejection message.
     #: Subclasses override with ``"point arithmetic"`` / ``"scalar arithmetic"``.
     OPERATION_LABEL: str = ""
+
+    @classmethod
+    def _op_type_key(cls) -> str:
+        """The option key the arithmetic op falls back to, read live so an override of it applies."""
+        return cls.ARITHMETIC_OP
 
     @classmethod
     def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
@@ -45,23 +44,11 @@ class ArithmeticFeatureGroupBase(RejectionReasonMixin, FeatureGroup):
 
     @classmethod
     def get_arithmetic_op(cls, feature_name: str) -> str:
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract arithmetic operation from feature name: {feature_name}")
+        return cls._extract_op_type(feature_name)
 
     @classmethod
     def _extract_arithmetic_op(cls, feature: Feature) -> str:
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        op = feature.options.get(cls.ARITHMETIC_OP)
-        if op is None:
-            raise ValueError(f"Could not extract arithmetic operation for {feature_name}")
-        return op_token_value(op)
+        return cls._extract_op_type(feature.name, feature.options)
 
     @classmethod
     def _raise_non_numeric_source(cls, source_col: str, got: object) -> None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -13,6 +13,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 from mloda.community.feature_groups.data_operations.base import (
     RejectionReasonMixin,
+    SingleSourceMixin,
     is_op_token,
     is_positive_int,
     op_token_value,
@@ -25,7 +26,7 @@ BINNING_OPS = {
 }
 
 
-class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup, SingleSourceMixin):
     PREFIX_PATTERN = r".*__(bin|qbin)_[1-9]\d*$"
 
     MIN_IN_FEATURES = 1
@@ -101,12 +102,11 @@ class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return None
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        # Not _single_source_input_features: binning also runs core's count check on the name branch.
         _feature_name = str(feature_name)
 
-        prefix_patterns = self._get_prefix_patterns()
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
-
-        if operation_config is not None and source_feature is not None and source_feature:
+        source_feature = self._source_from_name(_feature_name)
+        if source_feature is not None:
             in_features = [Feature(source_feature)]
             self._validate_in_feature_count(in_features, _feature_name)
             return set(in_features)
@@ -117,16 +117,7 @@ class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup):
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-
-        if operation_config is not None and source_feature is not None and source_feature:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        return [str(f.name) for f in in_features_set]
+        return cls._single_source_features(feature)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
@@ -6,12 +6,16 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
-from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, is_op_token, op_token_value
+from mloda.community.feature_groups.data_operations.base import (
+    OpTypeAccessorMixin,
+    RejectionReasonMixin,
+    SingleSourceMixin,
+    is_op_token,
+)
 
 DATETIME_OPS = {
     "year": "Extract year from datetime",
@@ -26,7 +30,7 @@ DATETIME_OPS = {
 }
 
 
-class DateTimeFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class DateTimeFeatureGroup(RejectionReasonMixin, FeatureGroup, SingleSourceMixin, OpTypeAccessorMixin):
     """Base class for element-wise datetime extraction operations.
 
     Extracts scalar integer components from datetime columns. The output
@@ -89,6 +93,8 @@ class DateTimeFeatureGroup(RejectionReasonMixin, FeatureGroup):
 
     DATETIME_OP = "datetime_op"
 
+    OP_TYPE_LABEL = "datetime operation"
+
     PROPERTY_MAPPING = {
         DATETIME_OP: {
             "explanation": "Datetime component extracted from the source column",
@@ -109,24 +115,17 @@ class DateTimeFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return operation_config in DATETIME_OPS
 
     @classmethod
+    def _op_type_key(cls) -> str:
+        """The option key the datetime operation falls back to, read live so an override of it applies."""
+        return cls.DATETIME_OP
+
+    @classmethod
     def get_datetime_op(cls, feature_name: str) -> str:
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract datetime operation from feature name: {feature_name}")
+        return cls._extract_op_type(feature_name)
 
     @classmethod
     def _extract_datetime_op(cls, feature: Feature) -> str:
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        op = feature.options.get(cls.DATETIME_OP)
-        if op is None:
-            raise ValueError(f"Could not extract datetime operation for {feature_name}")
-        return op_token_value(op)
+        return cls._extract_op_type(feature.name, feature.options)
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:
@@ -135,30 +134,11 @@ class DateTimeFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return DataType.INT64
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        _feature_name = str(feature_name)
-
-        prefix_patterns = self._get_prefix_patterns()
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
-
-        if operation_config is not None and source_feature is not None and source_feature:
-            return {Feature(source_feature)}
-
-        in_features_set = options.get_in_features()
-        self._validate_in_feature_count(list(in_features_set), _feature_name)
-        return set(in_features_set)
+        return self._single_source_input_features(options, feature_name)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-
-        if operation_config is not None and source_feature is not None and source_feature:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        return [str(f.name) for f in in_features_set]
+        return cls._single_source_features(feature)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
@@ -43,27 +43,31 @@ from __future__ import annotations
 from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.base import (
+    OrderedSourceMixin,
     RejectionReasonMixin,
     always_required,
-    column_ref_value,
     is_column_ref,
 )
 
 
-class EmaFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class EmaFeatureGroup(RejectionReasonMixin, FeatureGroup, OrderedSourceMixin):
     """Base class for exponential-moving-average operations that preserve row count."""
 
     PREFIX_PATTERN = r".*__ema_\d+$"
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
+
+    SOURCE_LABEL = "ema"
+    ENFORCE_MIN_IN_FEATURES = True
+    ENFORCE_MAX_IN_FEATURES = True
+    VALIDATE_IN_FEATURE_COUNT = False
 
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
@@ -89,48 +93,11 @@ class EmaFeatureGroup(RejectionReasonMixin, FeatureGroup):
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        _feature_name = str(feature_name)
-
-        prefix_patterns = self._get_prefix_patterns()
-        _operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
-
-        if source_feature:
-            return {Feature(source_feature)}
-
-        in_features_set = options.get_in_features()
-        return set(in_features_set)
+        return self._single_source_input_features(options, feature_name)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        """Extract and validate the single source feature.
-
-        Returns a one-element list containing the source column name. Raises
-        ``ValueError`` if more than one source feature is found, since EMA
-        supports at most one source column.
-        """
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-
-        _operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-
-        if source_feature:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        source_names: list[str] = [str(f.name) for f in in_features_set]
-
-        if len(source_names) < cls.MIN_IN_FEATURES:
-            raise ValueError(
-                f"ema requires at least {cls.MIN_IN_FEATURES} source feature, "
-                f"but got {len(source_names)} (in_features is empty)."
-            )
-
-        if len(source_names) > cls.MAX_IN_FEATURES:
-            raise ValueError(
-                f"ema supports at most {cls.MAX_IN_FEATURES} source feature, but got {len(source_names)}: {source_names}"
-            )
-
-        return source_names
+        return cls._single_source_features(feature)
 
     @classmethod
     def _extract_span(cls, feature: Feature) -> int:
@@ -143,22 +110,6 @@ class EmaFeatureGroup(RejectionReasonMixin, FeatureGroup):
         if span <= 0:
             raise ValueError(f"ema span must be a positive integer (span > 0), got {span} in {name!r}.")
         return span
-
-    @classmethod
-    def _extract_partition_by(cls, feature: Feature) -> list[str]:
-        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
-
-    @classmethod
-    def _extract_order_by(cls, feature: Feature) -> str:
-        """Return the required ``order_by`` column."""
-        order_by = feature.options.get(cls.ORDER_BY)
-        if order_by is None:
-            raise ValueError("ema requires an 'order_by' column in Options context.")
-        return column_ref_value(order_by)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
@@ -34,21 +34,20 @@ from __future__ import annotations
 from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.base import (
+    OrderedSourceMixin,
     RejectionReasonMixin,
     always_required,
-    column_ref_value,
     is_column_ref,
 )
 
 
-class FfillFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class FfillFeatureGroup(RejectionReasonMixin, FeatureGroup, OrderedSourceMixin):
     """Base class for forward-fill-by-time operations that preserve row count.
 
     ffill is a single-op operation (no op/unit matrix). All backends support it
@@ -59,6 +58,11 @@ class FfillFeatureGroup(RejectionReasonMixin, FeatureGroup):
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
+
+    SOURCE_LABEL = "ffill"
+    ENFORCE_MIN_IN_FEATURES = True
+    ENFORCE_MAX_IN_FEATURES = True
+    VALIDATE_IN_FEATURE_COUNT = False
 
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
@@ -84,64 +88,11 @@ class FfillFeatureGroup(RejectionReasonMixin, FeatureGroup):
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        _feature_name = str(feature_name)
-
-        prefix_patterns = self._get_prefix_patterns()
-        _operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
-
-        if source_feature:
-            return {Feature(source_feature)}
-
-        in_features_set = options.get_in_features()
-        return set(in_features_set)
+        return self._single_source_input_features(options, feature_name)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        """Extract and validate the single source feature.
-
-        Returns a one-element list containing the source column name. Raises
-        ``ValueError`` if more than one source feature is found, since ffill
-        supports at most one source column.
-        """
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-
-        _operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-
-        if source_feature:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        source_names: list[str] = [str(f.name) for f in in_features_set]
-
-        if len(source_names) < cls.MIN_IN_FEATURES:
-            raise ValueError(
-                f"ffill requires at least {cls.MIN_IN_FEATURES} source feature, "
-                f"but got {len(source_names)} (in_features is empty)."
-            )
-
-        if len(source_names) > cls.MAX_IN_FEATURES:
-            raise ValueError(
-                f"ffill supports at most {cls.MAX_IN_FEATURES} source feature, but got {len(source_names)}: {source_names}"
-            )
-
-        return source_names
-
-    @classmethod
-    def _extract_partition_by(cls, feature: Feature) -> list[str]:
-        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
-
-    @classmethod
-    def _extract_order_by(cls, feature: Feature) -> str:
-        """Return the required ``order_by`` column."""
-        order_by = feature.options.get(cls.ORDER_BY)
-        if order_by is None:
-            raise ValueError("ffill requires an 'order_by' column in Options context.")
-        return column_ref_value(order_by)
+        return cls._single_source_features(feature)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -6,18 +6,18 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.base import (
+    OpTypeAccessorMixin,
     RejectionReasonMixin,
     column_ref_value,
     is_column_ref,
     is_in_features_value,
     is_op_token,
     is_parametric_suffix,
-    op_token_value,
+    is_supported_op_type,
     option_value,
 )
 
@@ -33,19 +33,10 @@ _PARAMETRIC_OFFSET_FAMILIES: tuple[str, ...] = ("lag", "lead", "diff", "pct_chan
 
 def _is_supported_offset_type(value: object) -> bool:
     """Fixed offset types plus parametric lag_N / lead_N / diff_N / pct_change_N with N >= 1."""
-    if not isinstance(value, str):
-        return False
-    if value in _OFFSET_TYPES:
-        return True
-    for family in _PARAMETRIC_OFFSET_FAMILIES:
-        prefix = f"{family}_"
-        if value.startswith(prefix):
-            if is_parametric_suffix(value[len(prefix) :]):
-                return True
-    return False
+    return is_supported_op_type(value, _OFFSET_TYPES, _PARAMETRIC_OFFSET_FAMILIES)
 
 
-class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup, OpTypeAccessorMixin):
     """Base class for offset operations that preserve row count.
 
     Offset operations access values at a fixed offset from the current row
@@ -118,6 +109,8 @@ class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
     OFFSET_TYPE = "offset_type"
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
+
+    OP_TYPE_LABEL = "offset type"
 
     # Aliases of the module tables the validator reads: overriding them in a subclass has no
     # effect, per-backend narrowing belongs in SubtypeCapabilityHook.
@@ -193,26 +186,19 @@ class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return True
 
     @classmethod
+    def _op_type_key(cls) -> str:
+        """The option key the offset type falls back to, read live so an override of it applies."""
+        return cls.OFFSET_TYPE
+
+    @classmethod
     def get_offset_type(cls, feature_name: str) -> str:
         """Extract the offset type from a feature name string."""
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract offset type from feature name: {feature_name}")
+        return cls._extract_op_type(feature_name)
 
     @classmethod
     def _extract_offset_type(cls, feature: Feature) -> str:
         """Extract offset type from feature (string-based or config-based)."""
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        offset_type = feature.options.get(cls.OFFSET_TYPE)
-        if offset_type is None:
-            raise ValueError(f"Could not extract offset type for {feature_name}")
-        return op_token_value(offset_type)
+        return cls._extract_op_type(feature.name, feature.options)
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
@@ -13,6 +13,7 @@ from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.base import (
     RejectionReasonMixin,
+    SingleSourceMixin,
     is_scalar_number,
     scalar_number_value,
 )
@@ -39,7 +40,7 @@ def _is_unit_interval_element(value: object) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool) and 0.0 <= value <= 1.0
 
 
-class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup, SingleSourceMixin):
     """Base class for percentile operations that preserve row count.
 
     Computes a percentile over a partitioned group using PERCENTILE_CONT
@@ -78,6 +79,9 @@ class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
+
+    SOURCE_LABEL = "Percentile"
+    ENFORCE_MAX_IN_FEATURES = True
 
     PERCENTILE = "percentile"
     PARTITION_BY = "partition_by"
@@ -199,45 +203,11 @@ class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return percentile
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        """Parse input features from feature name or options."""
-        _feature_name = str(feature_name)
-
-        prefix_patterns = self._get_prefix_patterns()
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
-
-        if operation_config is not None and source_feature is not None and source_feature:
-            return {Feature(source_feature)}
-
-        in_features_set = options.get_in_features()
-        self._validate_in_feature_count(list(in_features_set), _feature_name)
-        return set(in_features_set)
+        return self._single_source_input_features(options, feature_name)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        """Extract and validate the single source feature for percentile.
-
-        Returns a one-element list containing the source column name.
-        Raises ValueError if more than one source feature is found, since
-        this package only supports single-column percentile computation.
-        """
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-
-        if operation_config is not None and source_feature is not None and source_feature:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        source_names: list[str] = [str(f.name) for f in in_features_set]
-
-        if len(source_names) > cls.MAX_IN_FEATURES:
-            raise ValueError(
-                f"Percentile supports at most {cls.MAX_IN_FEATURES} source feature, "
-                f"but got {len(source_names)}: {source_names}"
-            )
-
-        return source_names
+        return cls._single_source_features(feature)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -6,20 +6,20 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 from mloda.community.feature_groups.data_operations.base import (
+    OpTypeAccessorMixin,
     RejectionReasonMixin,
     column_ref_value,
     is_column_ref,
     is_in_features_value,
     is_op_token,
     is_parametric_suffix,
-    op_token_value,
+    is_supported_op_type,
     option_value,
 )
 
@@ -37,19 +37,10 @@ _PARAMETRIC_RANK_FAMILIES: tuple[str, ...] = ("ntile", "top", "bottom")
 
 def _is_supported_rank_type(value: object) -> bool:
     """Fixed rank types plus parametric ntile_N / top_N / bottom_N with N >= 1."""
-    if not isinstance(value, str):
-        return False
-    if value in _RANK_TYPES:
-        return True
-    for family in _PARAMETRIC_RANK_FAMILIES:
-        prefix = f"{family}_"
-        if value.startswith(prefix):
-            if is_parametric_suffix(value[len(prefix) :]):
-                return True
-    return False
+    return is_supported_op_type(value, _RANK_TYPES, _PARAMETRIC_RANK_FAMILIES)
 
 
-class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup):
+class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup, OpTypeAccessorMixin):
     """Base class for rank operations that preserve row count.
 
     Rank operations assign a rank or position to each row within a
@@ -135,6 +126,8 @@ class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
 
+    OP_TYPE_LABEL = "rank type"
+
     # Aliases of the module tables the validator reads: overriding them in a subclass has no
     # effect, per-backend narrowing belongs in SubtypeCapabilityHook.
     RANK_TYPES = _RANK_TYPES
@@ -213,38 +206,24 @@ class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup
         return True
 
     @classmethod
+    def _op_type_key(cls) -> str:
+        """The option key the rank type falls back to, read live so an override of it applies."""
+        return cls.RANK_TYPE
+
+    @classmethod
     def get_rank_type(cls, feature_name: str) -> str:
         """Extract the rank type from a feature name string."""
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract rank type from feature name: {feature_name}")
+        return cls._extract_op_type(feature_name)
 
     @classmethod
     def _extract_rank_type(cls, feature: Feature) -> str:
         """Extract rank type from feature (string-based or config-based)."""
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        rank_type = feature.options.get(cls.RANK_TYPE)
-        if rank_type is None:
-            raise ValueError(f"Could not extract rank type for {feature_name}")
-        return op_token_value(rank_type)
+        return cls._extract_op_type(feature.name, feature.options)
 
     @classmethod
     def _resolve_rank_type(cls, feature_name: str, options: Options) -> str | None:
         """Resolve the rank type from the feature name or options; None if unresolvable."""
-        try:
-            operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, cls._get_prefix_patterns())
-        except ValueError:
-            return None
-        if operation_config is not None:
-            return operation_config
-        rank_type = options.get(cls.RANK_TYPE)
-        return None if rank_type is None else op_token_value(rank_type)
+        return cls._resolve_op_type(feature_name, options)
 
     @classmethod
     def _capability_subtype(cls, feature_name: str, options: Options) -> str | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 from typing import Any, ClassVar
 
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
@@ -23,7 +22,7 @@ from mloda.provider import DefaultOptionKeys
 
 from mloda.community.feature_groups.data_operations.aggregation_base import AggregationFeatureGroupBase
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
-from mloda.community.feature_groups.data_operations.base import is_op_token
+from mloda.community.feature_groups.data_operations.base import SingleSourceMixin, is_op_token
 
 AGGREGATION_TYPES = {
     "sum": "Sum of values",
@@ -42,11 +41,14 @@ AGGREGATION_TYPES = {
 }
 
 
-class ScalarAggregateFeatureGroup(AggregationFeatureGroupBase):
+class ScalarAggregateFeatureGroup(AggregationFeatureGroupBase, SingleSourceMixin):
     PREFIX_PATTERN = r".*__([\w]+)_scalar$"
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
+
+    SOURCE_LABEL = "Scalar aggregate"
+    ENFORCE_MAX_IN_FEATURES = True
 
     AGGREGATION_TYPES = AGGREGATION_TYPES
 
@@ -77,44 +79,11 @@ class ScalarAggregateFeatureGroup(AggregationFeatureGroupBase):
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        _feature_name = str(feature_name)
-
-        prefix_patterns = self._get_prefix_patterns()
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
-
-        if operation_config is not None and source_feature is not None and source_feature:
-            return {Feature(source_feature)}
-
-        in_features_set = options.get_in_features()
-        self._validate_in_feature_count(list(in_features_set), _feature_name)
-        return set(in_features_set)
+        return self._single_source_input_features(options, feature_name)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        """Extract and validate the single source feature for aggregation.
-
-        Returns a one-element list containing the source column name.
-        Raises ValueError if more than one source feature is found, since
-        this package only supports single-column aggregation.
-        """
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-
-        if operation_config is not None and source_feature is not None and source_feature:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        source_names: list[str] = [str(f.name) for f in in_features_set]
-
-        if len(source_names) > cls.MAX_IN_FEATURES:
-            raise ValueError(
-                f"Scalar aggregate supports at most {cls.MAX_IN_FEATURES} source feature, "
-                f"but got {len(source_names)}: {source_names}"
-            )
-
-        return source_names
+        return cls._single_source_features(feature)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
@@ -30,6 +29,7 @@ from mloda.provider import DefaultOptionKeys
 
 from mloda.community.feature_groups.data_operations.row_preserving.arithmetic.base import ArithmeticFeatureGroupBase
 from mloda.community.feature_groups.data_operations.base import (
+    SingleSourceMixin,
     is_number_element,
     is_op_token,
     is_scalar_number,
@@ -44,12 +44,14 @@ ARITHMETIC_OPERATIONS: dict[str, str] = {
 }
 
 
-class ScalarArithmeticFeatureGroup(ArithmeticFeatureGroupBase):
+class ScalarArithmeticFeatureGroup(ArithmeticFeatureGroupBase, SingleSourceMixin):
     PREFIX_PATTERN = r".*__([\w]+)_constant$"
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
+    SOURCE_LABEL = "Scalar arithmetic"
+    ENFORCE_MAX_IN_FEATURES = True
     OPERATION_LABEL = "scalar arithmetic"
     CONSTANT = "constant"
 
@@ -76,44 +78,11 @@ class ScalarArithmeticFeatureGroup(ArithmeticFeatureGroupBase):
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        _feature_name = str(feature_name)
-
-        prefix_patterns = self._get_prefix_patterns()
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
-
-        if operation_config and source_feature:
-            return {Feature(source_feature)}
-
-        in_features_set = options.get_in_features()
-        self._validate_in_feature_count(list(in_features_set), _feature_name)
-        return set(in_features_set)
+        return self._single_source_input_features(options, feature_name)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        """Extract and validate the single source feature for the arithmetic op.
-
-        Returns a one-element list containing the source column name.
-        Raises ValueError if more than one source feature is found, since
-        this package only supports single-column arithmetic.
-        """
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-
-        if operation_config and source_feature:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        source_names: list[str] = [str(f.name) for f in in_features_set]
-
-        if len(source_names) > cls.MAX_IN_FEATURES:
-            raise ValueError(
-                f"Scalar arithmetic supports at most {cls.MAX_IN_FEATURES} source feature, "
-                f"but got {len(source_names)}: {source_names}"
-            )
-
-        return source_names
+        return cls._single_source_features(feature)
 
     @classmethod
     def _extract_constant(cls, feature: Feature) -> int | float:

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
@@ -47,13 +47,16 @@ from __future__ import annotations
 from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, column_ref_value, is_column_ref
+from mloda.community.feature_groups.data_operations.base import (
+    OrderedSourceMixin,
+    RejectionReasonMixin,
+    is_column_ref,
+)
 
 # Supported sessionization units mapped to their length in seconds. The four
 # keys also define the units accepted by the feature-name regex.
@@ -103,13 +106,18 @@ def _sessionize_threshold_seconds(n: int, unit: str) -> int:
     return n * SESSIONIZATION_UNITS[unit]
 
 
-class SessionizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class SessionizationFeatureGroup(RejectionReasonMixin, FeatureGroup, OrderedSourceMixin):
     """Base class for gap-threshold sessionization operations that preserve row count."""
 
     PREFIX_PATTERN = r".*__sessionize_\d+_(?:minute|hour|day|week)$"
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
+
+    SOURCE_LABEL = "sessionize"
+    ENFORCE_MIN_IN_FEATURES = True
+    ENFORCE_MAX_IN_FEATURES = True
+    ORDER_BY_DEFAULTS_TO_SOURCE = True
 
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
@@ -134,55 +142,19 @@ class SessionizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        _feature_name = str(feature_name)
-
-        prefix_patterns = self._get_prefix_patterns()
-        _operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
-
-        if source_feature:
+        # Not _single_source_input_features: the Options branch reports the family arity error
+        # (MAX only, so an empty in_features still resolves) instead of core's count check.
+        source_feature = self._source_from_name(str(feature_name))
+        if source_feature is not None:
             return {Feature(source_feature)}
 
         in_features_set = options.get_in_features()
-        source_names = [str(f.name) for f in in_features_set]
-        if len(source_names) > self.MAX_IN_FEATURES:
-            raise ValueError(
-                f"sessionize supports at most {self.MAX_IN_FEATURES} source feature, "
-                f"but got {len(source_names)}: {source_names}"
-            )
+        self._reject_extra_sources([str(f.name) for f in in_features_set])
         return set(in_features_set)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        """Extract and validate the single source feature.
-
-        Returns a one-element list containing the source column name. Raises
-        ``ValueError`` if more than one source feature is found, since
-        sessionize supports at most one source column.
-        """
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-
-        _operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-
-        if source_feature:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        source_names: list[str] = [str(f.name) for f in in_features_set]
-
-        if len(source_names) < cls.MIN_IN_FEATURES:
-            raise ValueError(
-                f"sessionize requires at least {cls.MIN_IN_FEATURES} source feature, "
-                f"but got {len(source_names)} (in_features is empty)."
-            )
-
-        if len(source_names) > cls.MAX_IN_FEATURES:
-            raise ValueError(
-                f"sessionize supports at most {cls.MAX_IN_FEATURES} source feature, "
-                f"but got {len(source_names)}: {source_names}"
-            )
-
-        return source_names
+        return cls._single_source_features(feature)
 
     @classmethod
     def _extract_threshold_token(cls, feature: Feature) -> str:
@@ -193,22 +165,6 @@ class SessionizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
         except IndexError as exc:
             raise ValueError(f"Could not extract a sessionize token from feature name {name!r}.") from exc
         return f"sessionize_{token}"
-
-    @classmethod
-    def _extract_partition_by(cls, feature: Feature) -> list[str]:
-        """Return ``partition_by`` as a list (defaulting to ``[]`` when absent)."""
-        partition_by = feature.options.get(cls.PARTITION_BY)
-        if partition_by is None:
-            return []
-        return list(partition_by)
-
-    @classmethod
-    def _extract_order_by(cls, feature: Feature, source_col: str) -> str:
-        """Return ``order_by``, defaulting to the source timestamp column when absent."""
-        order_by = feature.options.get(cls.ORDER_BY)
-        if order_by is None:
-            return source_col
-        return column_ref_value(order_by)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
@@ -38,13 +38,17 @@ from __future__ import annotations
 from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import DefaultOptionKeys, FeatureGroup
 
-from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, is_op_token, op_token_value
+from mloda.community.feature_groups.data_operations.base import (
+    OpTypeAccessorMixin,
+    RejectionReasonMixin,
+    SingleSourceMixin,
+    is_op_token,
+)
 
 TIME_BUCKETIZATION_OPS: dict[str, str] = {
     "floor": "Round timestamp down to the start of the enclosing bucket",
@@ -107,7 +111,7 @@ def _parse_bucket_op(token: str) -> tuple[str, int, str]:
     return op, n, unit
 
 
-class TimeBucketizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class TimeBucketizationFeatureGroup(RejectionReasonMixin, FeatureGroup, SingleSourceMixin, OpTypeAccessorMixin):
     """Base class for element-wise timestamp bucketization.
 
     Subclasses must implement ``_compute_bucket`` (the backend-specific
@@ -122,7 +126,13 @@ class TimeBucketizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
+    SOURCE_LABEL = "Time bucketization"
+    ENFORCE_MIN_IN_FEATURES = True
+    ENFORCE_MAX_IN_FEATURES = True
+
     BUCKET_OP = "bucket_op"
+
+    OP_TYPE_LABEL = "bucket op"
 
     @staticmethod
     def _is_valid_bucket_op_value(value: Any) -> bool:
@@ -174,72 +184,26 @@ class TimeBucketizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return True
 
     @classmethod
+    def _op_type_key(cls) -> str:
+        """The option key the bucket op falls back to, read live so an override of it applies."""
+        return cls.BUCKET_OP
+
+    @classmethod
     def get_bucket_op(cls, feature_name: str) -> str:
         """Extract the full op token from a string-pattern feature name."""
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract bucket op from feature name: {feature_name}")
+        return cls._extract_op_type(feature_name)
 
     @classmethod
     def _extract_bucket_op(cls, feature: Feature) -> str:
         """Extract the op token from the feature name or from Options."""
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        op = feature.options.get(cls.BUCKET_OP)
-        if op is None:
-            raise ValueError(f"Could not extract bucket op for {feature_name}")
-        return op_token_value(op)
+        return cls._extract_op_type(feature.name, feature.options)
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        _feature_name = str(feature_name)
-
-        prefix_patterns = self._get_prefix_patterns()
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
-
-        if operation_config and source_feature:
-            return {Feature(source_feature)}
-
-        in_features_set = options.get_in_features()
-        self._validate_in_feature_count(list(in_features_set), _feature_name)
-        return set(in_features_set)
+        return self._single_source_input_features(options, feature_name)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:
-        """Extract and validate the single source feature.
-
-        Returns a one-element list containing the source column name.
-        Raises ValueError if more than one source feature is found, since
-        time bucketization only supports a single source column.
-        """
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-
-        if operation_config and source_feature:
-            return [source_feature]
-
-        in_features_set = feature.options.get_in_features()
-        source_names: list[str] = [str(f.name) for f in in_features_set]
-
-        if len(source_names) < cls.MIN_IN_FEATURES:
-            raise ValueError(
-                f"Time bucketization requires at least {cls.MIN_IN_FEATURES} source feature, "
-                f"but got {len(source_names)} (in_features is empty)."
-            )
-
-        if len(source_names) > cls.MAX_IN_FEATURES:
-            raise ValueError(
-                f"Time bucketization supports at most {cls.MAX_IN_FEATURES} source feature, "
-                f"but got {len(source_names)}: {source_names}"
-            )
-
-        return source_names
+        return cls._single_source_features(feature)
 
     @staticmethod
     def _raise_non_timestamp_source(source_col: str, got: object) -> None:

--- a/mloda/community/feature_groups/data_operations/string/base.py
+++ b/mloda/community/feature_groups/data_operations/string/base.py
@@ -6,10 +6,13 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.provider import DefaultOptionKeys, FeatureGroup
-from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, is_op_token, op_token_value
+from mloda.community.feature_groups.data_operations.base import (
+    OpTypeAccessorMixin,
+    RejectionReasonMixin,
+    is_op_token,
+)
 
 STRING_OPS = {
     "upper": "Convert string to uppercase",
@@ -20,7 +23,7 @@ STRING_OPS = {
 }
 
 
-class StringFeatureGroup(RejectionReasonMixin, FeatureGroup):
+class StringFeatureGroup(RejectionReasonMixin, FeatureGroup, OpTypeAccessorMixin):
     """Base class for element-wise string operations that preserve row count.
 
     String operations transform a single string column element by element.
@@ -65,6 +68,8 @@ class StringFeatureGroup(RejectionReasonMixin, FeatureGroup):
 
     STRING_OP = "string_op"
 
+    OP_TYPE_LABEL = "string operation"
+
     PROPERTY_MAPPING = {
         STRING_OP: {
             "explanation": "String operation applied to the source column",
@@ -90,26 +95,19 @@ class StringFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return operation_config in STRING_OPS
 
     @classmethod
+    def _op_type_key(cls) -> str:
+        """The option key the string operation falls back to, read live so an override of it applies."""
+        return cls.STRING_OP
+
+    @classmethod
     def get_string_op(cls, feature_name: str) -> str:
         """Extract the string operation from a pattern-based feature name."""
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        raise ValueError(f"Could not extract string operation from feature name: {feature_name}")
+        return cls._extract_op_type(feature_name)
 
     @classmethod
     def _extract_string_op(cls, feature: Feature) -> str:
         """Extract string operation from feature (string-based or config-based)."""
-        feature_name = feature.name
-        prefix_patterns = cls._get_prefix_patterns()
-        operation_config, _ = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
-        if operation_config is not None:
-            return operation_config
-        op = feature.options.get(cls.STRING_OP)
-        if op is None:
-            raise ValueError(f"Could not extract string operation for {feature_name}")
-        return op_token_value(op)
+        return cls._extract_op_type(feature.name, feature.options)
 
     @classmethod
     def return_data_type_rule(cls, feature: Feature) -> DataType | None:


### PR DESCRIPTION
## What

The data-operation family bases each re-implemented the same skeleton: the single-source read from either the feature name or `in_features`, its arity errors, the `partition_by` / `order_by` accessors, and the op-type accessors. The copies differed only in the family noun spelled into their error strings.

Four mixins in `data_operations/base.py` now own that logic, driven by declarative class attributes:

| Mixin | Owns | Used by |
| --- | --- | --- |
| `SingleSourceMixin` | name-or-`in_features` read, arity errors | 10 families |
| `PartitionedSourceMixin` | adds `partition_by` | resample |
| `OrderedSourceMixin` | adds `order_by` | ema, ffill, sessionization |
| `OpTypeAccessorMixin` | op-type name/options accessors | 7 families |

Core owns the names `_extract_source_features` and `input_features` and resolves them ahead of an appended mixin, so families keep one-line delegators for those two. Everything else is inherited.

## Line count

| | Lines |
| --- | --- |
| Removed from the family bases | -595 |
| Added back (delegators, attributes) | +192 |
| Shared mixins and their guard | +235 |
| Guide | +25 |
| **Net** | **-135** |

## Behaviour

Unchanged. Every rendered error message is byte-identical, including the per-family capitalisation (`ema`, `ffill`, `sessionize`, `resample`, `Percentile`, `Scalar aggregate`, `Scalar arithmetic`, `Time bucketization`).

This was verified by differential rather than by assertion: every family base's observable behaviour was dumped from a worktree pinned at the merge base and compared against this branch, recording exact exception text rather than pass or fail. No path that previously worked behaves differently.

No ancestor's `__mro__` index moves. Only `object` shifts, which link resolution never looks up.

## Why the class-creation guard

Three constraints the mixins rest on are invisible to mypy, so they are enforced at class creation instead of described in a comment:

- A mixin may not define a name core owns. At runtime core resolves ahead of an appended mixin and wins; mypy linearizes these classes differently and reports the mixin's method as the winner. Moving `input_features` into a mixin as an "obvious cleanup" would therefore pass type checking and silently change runtime behaviour.
- A family must list its mixin last, so no ancestor index moves.
- A family must actually define the attributes its mixin reads. A bare annotation satisfies mypy but does not exist at runtime, so the attribute raises `AttributeError` on first use.

The third is not hypothetical: an earlier revision of this change gave six families inherited accessors whose backing constants they never declared, and the full suite stayed green because nothing calls them.

## Out of scope

The per-operation `_compute_<op>` stubs stay. Folding the typed abstract signatures into one generic hook would remove roughly 140 more lines, but `mypy --strict` would stop checking each backend against its operation's real parameter list. Not worth trading for line count.

`example_feature_names` and `calculate_feature` were examined and left alone: both are per-family vocabulary or per-family compute wiring, so hoisting them relocates data rather than removing it.

## Gate

`tox` green: 4889 passed, 205 skipped, `ruff format --check`, `ruff check`, `mypy --strict` across 456 files, bandit.
