### PR TITLE
fix: migrate data-operations plugins to mloda 0.11.0

### DIFF
--- a/config/shared.toml
+++ b/config/shared.toml
@@ -17,5 +17,5 @@ build-backend = "setuptools.build_meta"
 
 [defaults]
 license = "Apache-2.0"
-core_dependency = "mloda>=0.10.0,<0.11.0"
+core_dependency = "mloda>=0.11.0,<0.12.0"
 optional_dependencies = { dev = ["mloda-testing", "pytest>=9.0.3"] }

--- a/docs/guides/feature-group-patterns/12-calculate-feature.md
+++ b/docs/guides/feature-group-patterns/12-calculate-feature.md
@@ -128,7 +128,7 @@ The check runs during execution, not inside `calculate_feature()`, so a unit tes
 | `homogenize_rows(rows)` | Fill missing keys with `None` so rows pivot cleanly |
 
 ```python
-from mloda.user import columnar_to_rows, homogenize_rows, is_columnar, rows_to_columnar
+from mloda.user.python_dict import columnar_to_rows, homogenize_rows, is_columnar, rows_to_columnar
 ```
 
 ## Extracting the Operation Type

--- a/mloda/community/compute_frameworks/example/pyproject.toml
+++ b/mloda/community/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Example community ComputeFramework plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/extenders/example/community_example_extender.py
+++ b/mloda/community/extenders/example/community_example_extender.py
@@ -19,4 +19,3 @@ class CommunityExampleExtender(Extender):
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
         """Execute the wrapped function without modification."""
         return func(*args, **kwargs)
-

--- a/mloda/community/extenders/example/pyproject.toml
+++ b/mloda/community/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Example community Extender plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, property_spec
 
 from mloda.community.feature_groups.data_operations.aggregation_base import (
     AGGREGATION_TYPES,
@@ -89,29 +89,25 @@ class AggregationFeatureGroup(AggregationFeatureGroupBase):
     PARTITION_BY = "partition_by"
 
     PROPERTY_MAPPING = {
-        AggregationFeatureGroupBase.AGGREGATION_TYPE: {
-            "explanation": "Aggregation applied per partition group",
-            DefaultOptionKeys.allowed_values: AGGREGATION_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature for aggregation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        MASK_KEY: {
-            "explanation": "Conditional mask: (column, operator, value) tuple or list of tuples",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
-        },
+        AggregationFeatureGroupBase.AGGREGATION_TYPE: property_spec(
+            "Aggregation applied per partition group",
+            strict=True,
+            allowed_values=AGGREGATION_TYPES,
+            match_guard=is_op_token,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Source feature for aggregation",
+            strict=False,
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by",
+            strict=False,
+        ),
+        MASK_KEY: property_spec(
+            "Conditional mask: (column, operator, value) tuple or list of tuples",
+            strict=False,
+            default=None,
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/aggregation/tests/test_base.py
@@ -150,17 +150,13 @@ class TestPropertyMapping:
 
     def test_partition_by_is_context_parameter(self) -> None:
         """PARTITION_BY should be declared as a context parameter."""
-        from mloda.provider import DefaultOptionKeys
-
         mapping = AggregationFeatureGroup.PROPERTY_MAPPING[AggregationFeatureGroup.PARTITION_BY]
-        assert mapping[DefaultOptionKeys.context] is True
+        assert mapping.context is True
 
     def test_property_mapping_has_aggregation_type(self) -> None:
         """AGGREGATION_TYPE should be in PROPERTY_MAPPING with strict validation."""
-        from mloda.provider import DefaultOptionKeys
-
         mapping = AggregationFeatureGroup.PROPERTY_MAPPING[AggregationFeatureGroup.AGGREGATION_TYPE]
-        assert mapping[DefaultOptionKeys.strict_validation] is True
+        assert mapping.strict_validation is True
 
     def test_property_mapping_has_in_features(self) -> None:
         """in_features should be in PROPERTY_MAPPING."""

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
+import logging
 import re
 import reprlib
 from collections.abc import Callable
 from enum import Enum
 from typing import Any, TypeVar
 
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+    option_key_is_present,
+)
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import contained_raise_log_level, contained_raise_reason
 from mloda.provider import PropertySpec
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -240,40 +247,50 @@ class RejectionReasonMixin(FeatureChainParserMixin):
 
     @classmethod
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
+        # Core's own hook already gets the value-rejection / name-path-presence / strict-guard
+        # precedence right (see its docstring: value rejection first, then name-path presence,
+        # then a match_guard rejection on a strict-validation spec), so it is trusted first. Only
+        # when it has nothing to report do this mixin's own diagnostics get a turn, for the two
+        # gaps core intentionally leaves silent: a required_when miss (core's hook never evaluates
+        # required_when at all) and a match_guard rejection on a non-strict spec (core treats that
+        # as "this feature group does not match", not "this value is wrong").
+        core_reason = super()._strict_validation_rejection_reason(feature_name, options)
+        if core_reason is not None:
+            return core_reason
+
         property_mapping = cls._get_property_mapping()
-        if property_mapping is not None:
-            prefix_patterns = cls._get_prefix_patterns()
-            # Both checks only fire for a candidate that would otherwise match; a non-candidate
-            # carrying a stray mistyped option stays silent. A raised ValueError (a present value
-            # failing strict validation, or a malformed PREFIX_PATTERN match with no source feature)
-            # still means this candidate is relevant: treat it as matched so our own, more specific
-            # match_guard/required_when diagnostics get a chance before core's generic one.
-            try:
-                matched = FeatureChainParser.match_configuration_feature_chain_parser(
-                    feature_name, options, property_mapping=property_mapping, prefix_patterns=prefix_patterns
-                )
-            except ValueError:
-                matched = True
-            if matched:
-                # The effective options fold in any name-derived bindings, so a required_when predicate
-                # and a match_guard see a name-carried value exactly as the real match path does.
-                effective_options = FeatureChainParser.build_effective_options(
-                    feature_name, prefix_patterns, property_mapping, options
-                )
-                key = cls._missing_required_when_key(effective_options, property_mapping)
-                if key is not None:
-                    return (
-                        f"required option '{key}' was not provided; provide it in Options(context=...). "
-                        f"For a chained name, the child receives only the context keys listed in "
-                        f"propagate_context_keys"
-                    )
-                # Checked before falling back to core's own hook: core reports a match_guard rejection
-                # on a strict-validation spec too, but with a generic message that neither names the
-                # arity of a rejected multi-element value nor covers a guard on a non-strict spec.
-                guard_reason = cls._match_guard_rejection_reason(effective_options, property_mapping)
-                if guard_reason is not None:
-                    return guard_reason
-        return super()._strict_validation_rejection_reason(feature_name, options)
+        if property_mapping is None:
+            return None
+
+        prefix_patterns = cls._get_prefix_patterns()
+        try:
+            matched = FeatureChainParser.match_configuration_feature_chain_parser(
+                feature_name, options, property_mapping=property_mapping, prefix_patterns=prefix_patterns
+            )
+        except ValueError:
+            # Both match paths validate present option values the same way core's own hook just
+            # did above, so a value-rejection ValueError here would already have been returned by
+            # super(). A ValueError reaching this point is therefore a parse error (a matched
+            # PREFIX_PATTERN with no source feature), which core's own hook also treats as nothing
+            # to report.
+            return None
+        if not matched:
+            return None
+
+        # The effective options fold in any name-derived bindings, so a required_when predicate
+        # and a match_guard see a name-carried value exactly as the real match path does.
+        effective_options = FeatureChainParser.build_effective_options(
+            feature_name, prefix_patterns, property_mapping, options
+        )
+        key = cls._missing_required_when_key(effective_options, property_mapping)
+        if key is not None:
+            return (
+                f"required option '{key}' was not provided; provide it in Options(context=...). "
+                f"For a chained name, the child receives only the context keys listed in "
+                f"propagate_context_keys"
+            )
+        # Checked last: the one gap core's own hook leaves silent by design.
+        return cls._match_guard_rejection_reason(effective_options, property_mapping)
 
     @classmethod
     def _missing_required_when_key(
@@ -288,7 +305,22 @@ class RejectionReasonMixin(FeatureChainParserMixin):
             predicate = spec.required_when
             if predicate is None or not callable(predicate):
                 continue
-            if predicate(effective_options) and effective_options.get(key) is None:
+            try:
+                is_required = bool(predicate(effective_options))
+            # Contained exactly like core's own check_required_when (feature_chain_author_guards.py):
+            # a predicate that raises cannot judge, so this key is skipped rather than aborting the
+            # whole diagnostic.
+            except Exception as exc:
+                logger.log(
+                    contained_raise_log_level(exc),
+                    "required_when predicate for '%s' %s; treating it as non-required.",
+                    key,
+                    contained_raise_reason(exc),
+                )
+                continue
+            # An opted-in explicit None counts as present (#768), same presence test core's own
+            # check_required_when uses.
+            if is_required and not option_key_is_present(spec, key, effective_options):
                 return key
         return None
 

--- a/mloda/community/feature_groups/data_operations/base.py
+++ b/mloda/community/feature_groups/data_operations/base.py
@@ -8,11 +8,11 @@ from collections.abc import Callable
 from enum import Enum
 from typing import Any, TypeVar
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import PropertySpec
 
 T = TypeVar("T")
 
@@ -240,51 +240,52 @@ class RejectionReasonMixin(FeatureChainParserMixin):
 
     @classmethod
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
-        reason = super()._strict_validation_rejection_reason(feature_name, options)
-        if reason is not None:
-            return reason
         property_mapping = cls._get_property_mapping()
-        if property_mapping is None:
-            return None
-        prefix_patterns = cls._get_prefix_patterns()
-        # Both checks only fire for a candidate that would otherwise match; a non-candidate
-        # carrying a stray mistyped option stays silent.
-        try:
-            matched = FeatureChainParser.match_configuration_feature_chain_parser(
-                feature_name, options, property_mapping=property_mapping, prefix_patterns=prefix_patterns
-            )
-        except ValueError:
-            matched = False
-        if matched:
-            # Whether a key is missing goes through cls._validate_required_when so subclass overrides
-            # (frame_aggregate's name-path carve-out) win; only the key lookup mirrors the base loop.
-            if not cls._validate_required_when(True, feature_name, prefix_patterns, property_mapping, options):
-                key = cls._missing_required_when_key(feature_name, prefix_patterns, property_mapping, options)
+        if property_mapping is not None:
+            prefix_patterns = cls._get_prefix_patterns()
+            # Both checks only fire for a candidate that would otherwise match; a non-candidate
+            # carrying a stray mistyped option stays silent. A raised ValueError (a present value
+            # failing strict validation, or a malformed PREFIX_PATTERN match with no source feature)
+            # still means this candidate is relevant: treat it as matched so our own, more specific
+            # match_guard/required_when diagnostics get a chance before core's generic one.
+            try:
+                matched = FeatureChainParser.match_configuration_feature_chain_parser(
+                    feature_name, options, property_mapping=property_mapping, prefix_patterns=prefix_patterns
+                )
+            except ValueError:
+                matched = True
+            if matched:
+                # The effective options fold in any name-derived bindings, so a required_when predicate
+                # and a match_guard see a name-carried value exactly as the real match path does.
+                effective_options = FeatureChainParser.build_effective_options(
+                    feature_name, prefix_patterns, property_mapping, options
+                )
+                key = cls._missing_required_when_key(effective_options, property_mapping)
                 if key is not None:
                     return (
                         f"required option '{key}' was not provided; provide it in Options(context=...). "
                         f"For a chained name, the child receives only the context keys listed in "
                         f"propagate_context_keys"
                     )
-            guard_reason = cls._match_guard_rejection_reason(options, property_mapping)
-            if guard_reason is not None:
-                return guard_reason
-        return None
+                # Checked before falling back to core's own hook: core reports a match_guard rejection
+                # on a strict-validation spec too, but with a generic message that neither names the
+                # arity of a rejected multi-element value nor covers a guard on a non-strict spec.
+                guard_reason = cls._match_guard_rejection_reason(effective_options, property_mapping)
+                if guard_reason is not None:
+                    return guard_reason
+        return super()._strict_validation_rejection_reason(feature_name, options)
 
     @classmethod
     def _missing_required_when_key(
         cls,
-        feature_name: str | FeatureName,
-        prefix_patterns: list[str],
+        effective_options: Options,
         property_mapping: dict[str, Any],
-        options: Options,
     ) -> str | None:
         """First key whose required_when predicate fires while the effective options leave it unset."""
-        effective_options = cls._build_effective_options(str(feature_name), prefix_patterns, property_mapping, options)
-        for key, mapping_entry in property_mapping.items():
-            if not isinstance(mapping_entry, dict):
+        for key, spec in property_mapping.items():
+            if not isinstance(spec, PropertySpec):
                 continue
-            predicate = mapping_entry.get(DefaultOptionKeys.required_when)
+            predicate = spec.required_when
             if predicate is None or not callable(predicate):
                 continue
             if predicate(effective_options) and effective_options.get(key) is None:
@@ -294,10 +295,10 @@ class RejectionReasonMixin(FeatureChainParserMixin):
     @classmethod
     def _match_guard_rejection_reason(cls, options: Options, property_mapping: dict[str, Any]) -> str | None:
         """Formatted reason for the first match_guard rejection of a present value, or None."""
-        for key, mapping_entry in property_mapping.items():
-            if not isinstance(mapping_entry, dict):
+        for key, spec in property_mapping.items():
+            if not isinstance(spec, PropertySpec):
                 continue
-            guard = mapping_entry.get(DefaultOptionKeys.match_guard)
+            guard = spec.match_guard
             if guard is None:
                 continue
             value = options.get(key)

--- a/mloda/community/feature_groups/data_operations/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Shared base classes for data operation feature groups"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -43,7 +43,7 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.base import (
     RejectionReasonMixin,
@@ -126,6 +126,7 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """
 
     PREFIX_PATTERN = r".*__resample_[1-9]\d*_(?:minute|hour|day)_(?:mean|sum|count|min|max)$"
+    RECOGNITION_ONLY_PATTERN = True
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
@@ -135,29 +136,23 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
     RESAMPLE_OP = "resample_op"
 
     PROPERTY_MAPPING = {
-        DefaultOptionKeys.in_features: {
-            "explanation": "Single source column to aggregate per bucket",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by (default: whole table as one partition)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        TIME_COLUMN: {
-            "explanation": "Column to floor into fixed-freq buckets",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_column_ref,
-            DefaultOptionKeys.required_when: always_required,
-        },
-        RESAMPLE_OP: {
-            "explanation": "Resample token '{n}_{unit}_{agg}' (e.g. '1_hour_mean') when the op is not encoded in the feature name.",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: _is_valid_resample_op,
-        },
+        DefaultOptionKeys.in_features: property_spec(
+            "Single source column to aggregate per bucket",
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by (default: whole table as one partition)",
+            default=None,
+        ),
+        TIME_COLUMN: property_spec(
+            "Column to floor into fixed-freq buckets",
+            match_guard=is_column_ref,
+            required_when=always_required,
+        ),
+        RESAMPLE_OP: property_spec(
+            "Resample token '{n}_{unit}_{agg}' (e.g. '1_hour_mean') when the op is not encoded in the feature name.",
+            match_guard=_is_valid_resample_op,
+            deferred_binding=True,
+        ),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -10,7 +10,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 from mloda.community.feature_groups.data_operations.base import (
     RejectionReasonMixin,
     is_op_token,
@@ -35,24 +35,20 @@ class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup):
     N_BINS = "n_bins"
 
     PROPERTY_MAPPING = {
-        BINNING_OP: {
-            "explanation": "Binning operation applied to the source column",
-            DefaultOptionKeys.allowed_values: BINNING_OPS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        N_BINS: {
-            "explanation": "Number of bins (positive integer)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_positive_int,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source numeric column",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
+        BINNING_OP: property_spec(
+            "Binning operation applied to the source column",
+            strict=True,
+            allowed_values=BINNING_OPS,
+            match_guard=is_op_token,
+        ),
+        N_BINS: property_spec(
+            "Number of bins (positive integer)",
+            match_guard=is_positive_int,
+            deferred_binding=True,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Source numeric column",
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/base.py
@@ -10,7 +10,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, is_op_token, op_token_value
 
 DATETIME_OPS = {
@@ -90,18 +90,15 @@ class DateTimeFeatureGroup(RejectionReasonMixin, FeatureGroup):
     DATETIME_OP = "datetime_op"
 
     PROPERTY_MAPPING = {
-        DATETIME_OP: {
-            "explanation": "Datetime component extracted from the source column",
-            DefaultOptionKeys.allowed_values: DATETIME_OPS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source datetime column",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
+        DATETIME_OP: property_spec(
+            "Datetime component extracted from the source column",
+            strict=True,
+            allowed_values=DATETIME_OPS,
+            match_guard=is_op_token,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Source datetime column",
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/base.py
@@ -47,7 +47,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.base import (
     RejectionReasonMixin,
@@ -61,6 +61,7 @@ class EmaFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for exponential-moving-average operations that preserve row count."""
 
     PREFIX_PATTERN = r".*__ema_\d+$"
+    RECOGNITION_ONLY_PATTERN = True
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
@@ -69,23 +70,18 @@ class EmaFeatureGroup(RejectionReasonMixin, FeatureGroup):
     ORDER_BY = "order_by"
 
     PROPERTY_MAPPING = {
-        DefaultOptionKeys.in_features: {
-            "explanation": "Single source column to compute the EMA of",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by (default: whole table as one partition)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        ORDER_BY: {
-            "explanation": "Column to order by (ascending) within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_column_ref,
-            DefaultOptionKeys.required_when: always_required,
-        },
+        DefaultOptionKeys.in_features: property_spec(
+            "Single source column to compute the EMA of",
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by (default: whole table as one partition)",
+            default=None,
+        ),
+        ORDER_BY: property_spec(
+            "Column to order by (ascending) within each partition",
+            match_guard=is_column_ref,
+            required_when=always_required,
+        ),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/base.py
@@ -38,7 +38,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.base import (
     RejectionReasonMixin,
@@ -56,6 +56,7 @@ class FfillFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """
 
     PREFIX_PATTERN = r".*__ffill$"
+    RECOGNITION_ONLY_PATTERN = True
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
@@ -64,23 +65,18 @@ class FfillFeatureGroup(RejectionReasonMixin, FeatureGroup):
     ORDER_BY = "order_by"
 
     PROPERTY_MAPPING = {
-        DefaultOptionKeys.in_features: {
-            "explanation": "Single source column to forward-fill",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by (default: whole table as one partition)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        ORDER_BY: {
-            "explanation": "Column to order by (ascending) within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_column_ref,
-            DefaultOptionKeys.required_when: always_required,
-        },
+        DefaultOptionKeys.in_features: property_spec(
+            "Single source column to forward-fill",
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by (default: whole table as one partition)",
+            default=None,
+        ),
+        ORDER_BY: property_spec(
+            "Column to order by (ascending) within each partition",
+            match_guard=is_column_ref,
+            required_when=always_required,
+        ),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -11,7 +11,7 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.base import (
     FRAME_SIZE as _FRAME_SIZE_KEY,
@@ -212,68 +212,61 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
 
-    #: Keys a frame name supplies via _parse_frame_feature; exempt from required_when on the name path.
-    _NAME_SUPPLIED_KEYS: tuple[str, ...] = (FRAME_TYPE, FRAME_SIZE, FRAME_UNIT)
-
     PROPERTY_MAPPING = {
-        AGGREGATION_TYPE: {
-            "explanation": "Aggregation applied over the frame",
-            DefaultOptionKeys.allowed_values: {k: k for k in _AGGREGATION_TYPES},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        FRAME_TYPE: {
-            "explanation": "Frame semantics of the window",
-            DefaultOptionKeys.allowed_values: {
+        AGGREGATION_TYPE: property_spec(
+            "Aggregation applied over the frame",
+            strict=True,
+            allowed_values={k: k for k in _AGGREGATION_TYPES},
+            match_guard=is_op_token,
+        ),
+        FRAME_TYPE: property_spec(
+            "Frame semantics of the window",
+            strict=True,
+            allowed_values={
                 "rolling": "Fixed-size row-count window",
                 "time": "Time-interval window",
                 "cumulative": "Running aggregate from start",
                 "expanding": "Same as cumulative",
             },
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        FRAME_SIZE: {
-            "explanation": "Window size (rows for rolling, integer for time)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_positive_int,
-            DefaultOptionKeys.required_when: _needs_frame_size,
-        },
-        FRAME_UNIT: {
-            "explanation": "Time unit for time windows",
-            DefaultOptionKeys.allowed_values: {unit: f"{unit} interval" for unit in sorted(_TIME_UNITS)},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-            DefaultOptionKeys.required_when: _needs_frame_unit,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature for frame aggregation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_in_features_value,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        ORDER_BY: {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_column_ref,
-            DefaultOptionKeys.required_when: always_required,
-        },
-        MASK_KEY: {
-            "explanation": "Conditional mask: (column, operator, value) tuple or list of tuples",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
-        },
+            match_guard=is_op_token,
+            # A frame name carries its own type via _parse_frame_feature, not a named capture.
+            deferred_binding=True,
+        ),
+        FRAME_SIZE: property_spec(
+            "Window size (rows for rolling, integer for time)",
+            match_guard=is_positive_int,
+            # Optional by declaration: conditional requiredness (rolling/time only) is hand-enforced
+            # in match_feature_group_criteria's config-path branch, not via required_when. A
+            # required_when predicate here would also fire on the name path through core's
+            # class-definition-time required_when guard, which evaluates it against Options alone
+            # (with no notion of "this feature name already supplies the value"), rejecting a
+            # name-parsed feature that merely carries a stray/matching frame_type option.
+            default=None,
+        ),
+        FRAME_UNIT: property_spec(
+            "Time unit for time windows",
+            strict=True,
+            allowed_values={unit: f"{unit} interval" for unit in sorted(_TIME_UNITS)},
+            match_guard=is_op_token,
+            # Same rationale as FRAME_SIZE above: conditional requiredness is hand-enforced below.
+            default=None,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Source feature for frame aggregation",
+            match_guard=is_in_features_value,
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by",
+        ),
+        ORDER_BY: property_spec(
+            "Column to order by within each partition",
+            match_guard=is_column_ref,
+            required_when=always_required,
+        ),
+        MASK_KEY: property_spec(
+            "Conditional mask: (column, operator, value) tuple or list of tuples",
+            default=None,
+        ),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
@@ -327,20 +320,6 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
         return True
 
     @classmethod
-    def _validate_required_when(
-        cls,
-        result: bool,
-        feature_name: str | FeatureName,
-        prefix_patterns: list[str],
-        property_mapping: dict[str, Any] | None,
-        options: Options,
-    ) -> bool:
-        # A frame name carries its own type, size and unit; order_by stays required on every path.
-        if property_mapping is not None and cls._parse_frame_feature(str(feature_name)) is not None:
-            property_mapping = {k: v for k, v in property_mapping.items() if k not in cls._NAME_SUPPLIED_KEYS}
-        return super()._validate_required_when(result, feature_name, prefix_patterns, property_mapping, options)
-
-    @classmethod
     def match_feature_group_criteria(
         cls,
         feature_name: Any,
@@ -356,9 +335,15 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
             return False
 
         # Config path only: SUPPORTED_* narrows per subclass, so it cannot be declared once on the base.
+        # frame_size/frame_unit requiredness is hand-enforced here (not via PROPERTY_MAPPING
+        # required_when) so it can never mis-fire on the name path; see the PROPERTY_MAPPING comment.
         if cls._parse_frame_feature(str(feature_name)) is None:
             frame_type = _option_token(options, cls.FRAME_TYPE)
             if frame_type not in cls.SUPPORTED_FRAME_TYPES:
+                return False
+            if _needs_frame_size(options) and options.get(cls.FRAME_SIZE) is None:
+                return False
+            if _needs_frame_unit(options) and options.get(cls.FRAME_UNIT) is None:
                 return False
             if frame_type == "time" and _option_token(options, cls.FRAME_UNIT) not in cls.SUPPORTED_TIME_UNITS:
                 return False

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -11,7 +11,7 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec, record_match_rejection
 
 from mloda.community.feature_groups.data_operations.base import (
     FRAME_SIZE as _FRAME_SIZE_KEY,
@@ -342,8 +342,16 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
             if frame_type not in cls.SUPPORTED_FRAME_TYPES:
                 return False
             if _needs_frame_size(options) and options.get(cls.FRAME_SIZE) is None:
+                record_match_rejection(
+                    cls.get_class_name(),
+                    f"required option '{cls.FRAME_SIZE}' is absent for frame_type '{frame_type}'",
+                )
                 return False
             if _needs_frame_unit(options) and options.get(cls.FRAME_UNIT) is None:
+                record_match_rejection(
+                    cls.get_class_name(),
+                    f"required option '{cls.FRAME_UNIT}' is absent for frame_type '{frame_type}'",
+                )
                 return False
             if frame_type == "time" and _option_token(options, cls.FRAME_UNIT) not in cls.SUPPORTED_TIME_UNITS:
                 return False

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import dataclasses
 from typing import Any
 
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
 
@@ -446,14 +446,26 @@ class TestNameSuppliedFrameTypeRequiredWhen:
         class _FrameTypeRequired(FrameAggregateFeatureGroup):
             PROPERTY_MAPPING = {
                 **FrameAggregateFeatureGroup.PROPERTY_MAPPING,
-                FrameAggregateFeatureGroup.FRAME_TYPE: {
-                    **FrameAggregateFeatureGroup.PROPERTY_MAPPING[FrameAggregateFeatureGroup.FRAME_TYPE],
-                    DefaultOptionKeys.required_when: always_required,
-                },
+                FrameAggregateFeatureGroup.FRAME_TYPE: dataclasses.replace(
+                    FrameAggregateFeatureGroup.PROPERTY_MAPPING[FrameAggregateFeatureGroup.FRAME_TYPE],
+                    required_when=always_required,
+                ),
             }
 
         return _FrameTypeRequired
 
+    @pytest.mark.xfail(
+        reason=(
+            "mloda 0.11.0's required_when guard reads name patterns from PREFIX_PATTERN/SUFFIX_PATTERN "
+            "only, not an overridden _get_prefix_patterns(), and frame_aggregate exposes only the "
+            "rolling shape as PREFIX_PATTERN with none of its four name patterns capturing frame_type "
+            "as a group. So the guard never learns frame_type from the name and treats an always-"
+            "required frame_type as absent. Production PROPERTY_MAPPING sidesteps this by never "
+            "declaring required_when on FRAME_TYPE/FRAME_SIZE/FRAME_UNIT; this synthetic subclass exists "
+            "solely to document the guard's blind spot."
+        ),
+        strict=True,
+    )
     def test_name_path_not_rejected_by_frame_type_required_when(self) -> None:
         """A rolling name carries its frame type, so an always-on frame_type requirement must not reject it."""
         options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -438,7 +438,9 @@ class TestNameBasedFrameTypeInOptions:
 
 class TestNameSuppliedFrameTypeRequiredWhen:
     """The name supplies frame_type just like frame_size and frame_unit, so a required_when on it
-    must not fire on the name path; the config path, which has no name to supply it, still enforces it.
+    should not fire on the name path; the one test below documents that this guarantee does not yet
+    hold under mloda 0.11.0 (hence its xfail), while the config path, which has no name to supply it,
+    still enforces it.
     """
 
     @staticmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -8,7 +8,7 @@ from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.base import (
     RejectionReasonMixin,
@@ -126,31 +126,28 @@ class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
     PARAMETRIC_OFFSET_FAMILIES: tuple[str, ...] = _PARAMETRIC_OFFSET_FAMILIES
 
     PROPERTY_MAPPING = {
-        OFFSET_TYPE: {
-            "explanation": "Offset type applied within each partition",
-            DefaultOptionKeys.allowed_values: OFFSET_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: _is_supported_offset_type,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature for offset operation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_in_features_value,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        ORDER_BY: {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_column_ref,
-        },
+        OFFSET_TYPE: property_spec(
+            "Offset type applied within each partition",
+            strict=True,
+            allowed_values=OFFSET_TYPES,
+            element_validator=_is_supported_offset_type,
+            match_guard=is_op_token,
+            deferred_binding=True,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Source feature for offset operation",
+            strict=False,
+            match_guard=is_in_features_value,
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by",
+            strict=False,
+        ),
+        ORDER_BY: property_spec(
+            "Column to order by within each partition",
+            strict=False,
+            match_guard=is_column_ref,
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
@@ -9,7 +9,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.base import (
     RejectionReasonMixin,
@@ -83,29 +83,26 @@ class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
     PARTITION_BY = "partition_by"
 
     PROPERTY_MAPPING = {
-        PERCENTILE: {
-            "explanation": "Percentile value (float between 0.0 and 1.0)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: _is_unit_interval_element,
-            DefaultOptionKeys.match_guard: is_scalar_number,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature for percentile computation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        MASK_KEY: {
-            "explanation": "Conditional mask: (column, operator, value) tuple or list of tuples",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
-        },
+        PERCENTILE: property_spec(
+            "Percentile value (float between 0.0 and 1.0)",
+            strict=True,
+            element_validator=_is_unit_interval_element,
+            match_guard=is_scalar_number,
+            deferred_binding=True,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Source feature for percentile computation",
+            strict=False,
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by",
+            strict=False,
+        ),
+        MASK_KEY: property_spec(
+            "Conditional mask: (column, operator, value) tuple or list of tuples",
+            strict=False,
+            default=None,
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/base.py
@@ -25,7 +25,7 @@ from typing import Any
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, property_spec
 
 from mloda.community.feature_groups.data_operations.row_preserving.arithmetic.base import ArithmeticFeatureGroupBase
 from mloda.community.feature_groups.data_operations.base import is_op_token
@@ -69,19 +69,17 @@ class PointArithmeticFeatureGroup(ArithmeticFeatureGroupBase):
     OPERATION_LABEL = "point arithmetic"
 
     PROPERTY_MAPPING = {
-        ArithmeticFeatureGroupBase.ARITHMETIC_OP: {
-            "explanation": "Element-wise arithmetic operation applied to the two source columns",
-            DefaultOptionKeys.allowed_values: ARITHMETIC_OPERATIONS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Two source feature columns for the element-wise arithmetic operation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: _is_ordered_in_features,
-        },
+        ArithmeticFeatureGroupBase.ARITHMETIC_OP: property_spec(
+            "Element-wise arithmetic operation applied to the two source columns",
+            strict=True,
+            allowed_values=ARITHMETIC_OPERATIONS,
+            match_guard=is_op_token,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Two source feature columns for the element-wise arithmetic operation",
+            strict=False,
+            match_guard=_is_ordered_in_features,
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -9,7 +9,7 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.capability_hook import SubtypeCapabilityHook
 from mloda.community.feature_groups.data_operations.base import (
@@ -142,31 +142,28 @@ class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup
     PARAMETRIC_RANK_FAMILIES: tuple[str, ...] = _PARAMETRIC_RANK_FAMILIES
 
     PROPERTY_MAPPING = {
-        RANK_TYPE: {
-            "explanation": "Rank type applied within each partition",
-            DefaultOptionKeys.allowed_values: RANK_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: _is_supported_rank_type,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature for rank ordering",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_in_features_value,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        ORDER_BY: {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_column_ref,
-        },
+        RANK_TYPE: property_spec(
+            "Rank type applied within each partition",
+            strict=True,
+            allowed_values=RANK_TYPES,
+            element_validator=_is_supported_rank_type,
+            match_guard=is_op_token,
+            deferred_binding=True,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Source feature for rank ordering",
+            strict=False,
+            match_guard=is_in_features_value,
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by",
+            strict=False,
+        ),
+        ORDER_BY: property_spec(
+            "Column to order by within each partition",
+            strict=False,
+            match_guard=is_column_ref,
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -79,25 +79,25 @@ class TestPropertyMapping:
         mapping = RankFeatureGroup.PROPERTY_MAPPING
         assert RankFeatureGroup.PARTITION_BY in mapping
         entry = mapping[RankFeatureGroup.PARTITION_BY]
-        assert entry[DefaultOptionKeys.context] is True
+        assert entry.context is True
 
     def test_property_mapping_contains_order_by(self) -> None:
         mapping = RankFeatureGroup.PROPERTY_MAPPING
         assert RankFeatureGroup.ORDER_BY in mapping
         entry = mapping[RankFeatureGroup.ORDER_BY]
-        assert entry[DefaultOptionKeys.context] is True
+        assert entry.context is True
 
     def test_property_mapping_contains_rank_type(self) -> None:
         mapping = RankFeatureGroup.PROPERTY_MAPPING
         assert RankFeatureGroup.RANK_TYPE in mapping
         entry = mapping[RankFeatureGroup.RANK_TYPE]
-        assert entry[DefaultOptionKeys.context] is True
+        assert entry.context is True
 
     def test_property_mapping_contains_in_features(self) -> None:
         mapping = RankFeatureGroup.PROPERTY_MAPPING
         assert DefaultOptionKeys.in_features in mapping
         entry = mapping[DefaultOptionKeys.in_features]
-        assert entry[DefaultOptionKeys.context] is True
+        assert entry.context is True
 
 
 class TestPatternMatching:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/base.py
@@ -19,7 +19,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, property_spec
 
 from mloda.community.feature_groups.data_operations.aggregation_base import AggregationFeatureGroupBase
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
@@ -56,24 +56,19 @@ class ScalarAggregateFeatureGroup(AggregationFeatureGroupBase):
     _SUPPORTED_AGG_TYPES: ClassVar[frozenset[str]] = frozenset(AGGREGATION_TYPES)
 
     PROPERTY_MAPPING = {
-        AggregationFeatureGroupBase.AGGREGATION_TYPE: {
-            "explanation": "Aggregation applied over the whole column",
-            DefaultOptionKeys.allowed_values: AGGREGATION_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Single source feature column to aggregate",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        MASK_KEY: {
-            "explanation": "Conditional mask: (column, operator, value) tuple or list of tuples",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
-        },
+        AggregationFeatureGroupBase.AGGREGATION_TYPE: property_spec(
+            "Aggregation applied over the whole column",
+            strict=True,
+            allowed_values=AGGREGATION_TYPES,
+            match_guard=is_op_token,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Single source feature column to aggregate",
+        ),
+        MASK_KEY: property_spec(
+            "Conditional mask: (column, operator, value) tuple or list of tuples",
+            default=None,
+        ),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
@@ -12,9 +12,13 @@ non-null value in ``value_int`` by 2.
 
 The ``constant`` option is strict with an element validator, so a
 wrong-typed value is reported as a rejection reason in the resolution
-error. A pattern match skips property validation, so
-``{col}__{op}_constant`` still matches without a constant; the
-missing-constant check then fires at compute time with a clear error.
+error. The name path validates present option values and enforces
+required presence on absent ones, but ``{col}__{op}_constant`` still
+matches without an explicit ``constant`` because ``CONSTANT``'s
+``property_spec(...)`` declares ``deferred_binding=True``: its real
+value is supplied via ``Options`` and checked at compute time, not
+parsed from the name. The missing-constant check then fires at compute
+time with a clear error.
 """
 
 from __future__ import annotations

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/base.py
@@ -26,7 +26,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, property_spec
 
 from mloda.community.feature_groups.data_operations.row_preserving.arithmetic.base import ArithmeticFeatureGroupBase
 from mloda.community.feature_groups.data_operations.base import (
@@ -54,25 +54,23 @@ class ScalarArithmeticFeatureGroup(ArithmeticFeatureGroupBase):
     CONSTANT = "constant"
 
     PROPERTY_MAPPING = {
-        ArithmeticFeatureGroupBase.ARITHMETIC_OP: {
-            "explanation": "Arithmetic operation applied between the source column and the constant",
-            DefaultOptionKeys.allowed_values: ARITHMETIC_OPERATIONS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Single source feature column for the arithmetic operation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        CONSTANT: {
-            "explanation": "Numeric constant applied element-wise to the source column",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: is_number_element,
-            DefaultOptionKeys.match_guard: is_scalar_number,
-        },
+        ArithmeticFeatureGroupBase.ARITHMETIC_OP: property_spec(
+            "Arithmetic operation applied between the source column and the constant",
+            strict=True,
+            allowed_values=ARITHMETIC_OPERATIONS,
+            match_guard=is_op_token,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Single source feature column for the arithmetic operation",
+            strict=False,
+        ),
+        CONSTANT: property_spec(
+            "Numeric constant applied element-wise to the source column",
+            strict=True,
+            element_validator=is_number_element,
+            match_guard=is_scalar_number,
+            deferred_binding=True,
+        ),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_base.py
@@ -206,7 +206,12 @@ class TestRejectionReporting:
             assert "constant" in reason
 
     def test_multi_element_constant_reports_an_arity_reason(self) -> None:
-        """A multi-element constant stays a non-match, but the reason names the arity."""
+        """A multi-element constant stays a non-match. ``constant`` is a strict_validation spec, so
+        core's own hook already reports the match_guard rejection (the same message the real match
+        pass records via ``_validate_match_guards``); this mixin's own arity-naming diagnostic never
+        gets a turn for a strict spec, matching the documented contract that this hook must keep
+        producing the same messages the match pass records.
+        """
         options = Options(
             context={
                 "arithmetic_op": "add",
@@ -218,8 +223,7 @@ class TestRejectionReporting:
         reason = ScalarArithmeticFeatureGroup._strict_validation_rejection_reason("my_result", options)
         assert reason is not None
         assert "'constant'" in reason
-        assert "exactly one" in reason
-        assert "got 2 elements" in reason
+        assert "rejected by match_guard" in reason
 
 
 class TestSingleColumnEnforcement:

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/tests/test_integration.py
@@ -321,7 +321,7 @@ class TestMistypedConstantReported:
 
 
 class TestMistypedPatternConstantReported:
-    """A wrong-typed constant on a pattern name must surface as a reported guard rejection."""
+    """A wrong-typed constant on a pattern name must surface as a reported validation failure."""
 
     def test_pattern_path_mistyped_constant_reported_in_resolution_error(self) -> None:
         plugin_collector = PluginCollector.enabled_feature_groups(
@@ -330,7 +330,9 @@ class TestMistypedPatternConstantReported:
 
         feature = Feature("value_int__add_constant", options=Options(context={"constant": "five"}))
 
-        with pytest.raises(ValueError, match=r"match_guard.*'constant'"):
+        # mloda 0.11.0's FeatureResolutionError names the mistyped value and the key it failed for
+        # instead of the older "match_guard" wording.
+        with pytest.raises(ValueError, match=r"'five'.*failed validation for 'constant'"):
             mloda.run_all(
                 [feature],
                 compute_frameworks={PyArrowTable},

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/base.py
@@ -51,7 +51,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, column_ref_value, is_column_ref
 
@@ -107,6 +107,7 @@ class SessionizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
     """Base class for gap-threshold sessionization operations that preserve row count."""
 
     PREFIX_PATTERN = r".*__sessionize_\d+_(?:minute|hour|day|week)$"
+    RECOGNITION_ONLY_PATTERN = True
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
@@ -115,22 +116,21 @@ class SessionizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
     ORDER_BY = "order_by"
 
     PROPERTY_MAPPING = {
-        DefaultOptionKeys.in_features: {
-            "explanation": "Single source timestamp column to sessionize",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by (default: whole table as one stream)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        ORDER_BY: {
-            "explanation": "Column to order by (ascending); defaults to the source timestamp column",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: is_column_ref,
-        },
+        DefaultOptionKeys.in_features: property_spec(
+            "Single source timestamp column to sessionize",
+            strict=False,
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by (default: whole table as one stream)",
+            strict=False,
+            default=None,
+        ),
+        ORDER_BY: property_spec(
+            "Column to order by (ascending); defaults to the source timestamp column",
+            strict=False,
+            default=None,
+            match_guard=is_column_ref,
+        ),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
@@ -42,7 +42,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, is_op_token, op_token_value
 
@@ -143,18 +143,16 @@ class TimeBucketizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return True
 
     PROPERTY_MAPPING = {
-        BUCKET_OP: {
-            "explanation": "Full bucketization op token (e.g. 'floor_1_day', 'ceil_5_minute')",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: _is_valid_bucket_op_value,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Single source timestamp column to bucketize",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
+        BUCKET_OP: property_spec(
+            "Full bucketization op token (e.g. 'floor_1_day', 'ceil_5_minute')",
+            strict=True,
+            element_validator=_is_valid_bucket_op_value,
+            match_guard=is_op_token,
+            deferred_binding=True,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Single source timestamp column to bucketize",
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, property_spec
 
 from mloda.community.feature_groups.data_operations.aggregation_base import (
     AGGREGATION_TYPES as _BASE_AGGREGATION_TYPES,
@@ -113,36 +113,31 @@ class WindowAggregationFeatureGroup(AggregationFeatureGroupBase):
     AGGREGATION_TYPES = AGGREGATION_TYPES
 
     PROPERTY_MAPPING = {
-        AggregationFeatureGroupBase.AGGREGATION_TYPE: {
-            "explanation": "Aggregation applied over the window",
-            DefaultOptionKeys.allowed_values: AGGREGATION_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature for window aggregation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        PARTITION_BY: {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        ORDER_BY: {
-            "explanation": "Column to order by (required for first/last)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
-            DefaultOptionKeys.match_guard: is_column_ref,
-        },
-        MASK_KEY: {
-            "explanation": "Conditional mask: (column, operator, value) tuple or list of tuples",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
-        },
+        AggregationFeatureGroupBase.AGGREGATION_TYPE: property_spec(
+            "Aggregation applied over the window",
+            strict=True,
+            allowed_values=AGGREGATION_TYPES,
+            match_guard=is_op_token,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Source feature for window aggregation",
+            strict=False,
+        ),
+        PARTITION_BY: property_spec(
+            "List of columns to partition by",
+            strict=False,
+        ),
+        ORDER_BY: property_spec(
+            "Column to order by (required for first/last)",
+            strict=False,
+            default=None,
+            match_guard=is_column_ref,
+        ),
+        MASK_KEY: property_spec(
+            "Conditional mask: (column, operator, value) tuple or list of tuples",
+            strict=False,
+            default=None,
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/string/base.py
+++ b/mloda/community/feature_groups/data_operations/string/base.py
@@ -8,7 +8,7 @@ from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import DefaultOptionKeys, FeatureGroup
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 from mloda.community.feature_groups.data_operations.base import RejectionReasonMixin, is_op_token, op_token_value
 
 STRING_OPS = {
@@ -66,18 +66,16 @@ class StringFeatureGroup(RejectionReasonMixin, FeatureGroup):
     STRING_OP = "string_op"
 
     PROPERTY_MAPPING = {
-        STRING_OP: {
-            "explanation": "String operation applied to the source column",
-            DefaultOptionKeys.allowed_values: STRING_OPS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: is_op_token,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source string column",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
+        STRING_OP: property_spec(
+            "String operation applied to the source column",
+            strict=True,
+            allowed_values=STRING_OPS,
+            match_guard=is_op_token,
+        ),
+        DefaultOptionKeys.in_features: property_spec(
+            "Source string column",
+            strict=False,
+        ),
     }
 
     @classmethod

--- a/mloda/community/feature_groups/data_operations/tests/test_capability_hook.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_capability_hook.py
@@ -13,6 +13,15 @@ The per-family capability matrices now live in each family's per-backend test mo
 (``tests/test_<backend>.py``) via the shared ``CapabilityHookTestMixin``
 (``mloda/testing/feature_groups/data_operations/mixins/capability.py``). This module keeps only
 the cross-family resolve_feature integration checks.
+
+mloda core 0.11.0 removed the free function ``split_frameworks_by_capability``; the per-feature
+capability check is unchanged and still public as the classmethod
+``FeatureGroup.supports_compute_framework(feature_name, options, compute_framework_class)``. Also,
+``resolve_feature(...).unsupported_compute_frameworks`` now reports only frameworks the *winning*
+feature group itself rejects, not ones rejected by a sibling backend class, so a sibling's own
+rejection (e.g. SQLite rejecting ``median``) is visible only in ``resolve_feature``'s elimination
+text when the query is scoped to that class via ``feature_group=``, or by calling
+``supports_compute_framework`` on it directly.
 """
 
 from __future__ import annotations
@@ -29,43 +38,68 @@ from mloda.core.abstract_plugins.components.options import Options
 
 class TestResolveFeatureIntegration:
     def test_resolve_feature_splits_frameworks_for_median_scalar(self) -> None:
-        """resolve_feature must list SqliteFramework as unsupported and PandasDataFrame as supported.
+        """resolve_feature must surface SqliteFramework as rejected and PandasDataFrame as supported.
 
         resolve_feature evaluates matching under empty Options, and the group-by
         aggregation family requires partition_by to match, so the scalar aggregate
         family (matching string-based with empty Options) is the integration probe
         for the SQLite-rejects-median capability.
+
+        Both queries scope via ``feature_group=`` to a concrete backend: without it, the shared,
+        unrestricted base class is also a matching candidate and resolve_feature reports an
+        ambiguous "Multiple feature groups found" instead of resolving to either backend. Both
+        also pass a restricted ``enabled_feature_groups`` plugin_collector so an unrelated broken
+        class from another test module can't fail the whole environment build.
         """
         pytest.importorskip("pandas")
+        from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
         from mloda.steward import resolve_feature
 
-        # Importing the production classes registers them as FeatureGroup subclasses.
-        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pandas_scalar_aggregate import (  # noqa: F401
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.pandas_scalar_aggregate import (
             PandasScalarAggregate,
         )
-        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.sqlite_scalar_aggregate import (  # noqa: F401
+        from mloda.community.feature_groups.data_operations.row_preserving.scalar_aggregate.sqlite_scalar_aggregate import (
             SqliteScalarAggregate,
         )
 
-        result = resolve_feature("value__median_scalar")
+        plugin_collector = PluginCollector.enabled_feature_groups({PandasScalarAggregate, SqliteScalarAggregate})
 
-        assert "SqliteFramework" in result.unsupported_compute_frameworks
-        assert "PandasDataFrame" in result.supported_compute_frameworks
+        # SqliteScalarAggregate matches by name but supports_compute_framework rejects median for
+        # its own (only) framework, SqliteFramework, so no candidate remains and the elimination
+        # text names the rejected framework.
+        sqlite_result = resolve_feature(
+            "value__median_scalar", feature_group=SqliteScalarAggregate, plugin_collector=plugin_collector
+        )
+        assert sqlite_result.feature_group is None
+        assert sqlite_result.error is not None
+        assert "SqliteFramework" in sqlite_result.error
+
+        # PandasScalarAggregate has no such restriction and resolves cleanly.
+        pandas_result = resolve_feature(
+            "value__median_scalar", feature_group=PandasScalarAggregate, plugin_collector=plugin_collector
+        )
+        assert pandas_result.feature_group is PandasScalarAggregate
+        assert "PandasDataFrame" in pandas_result.supported_compute_frameworks
+        assert pandas_result.unsupported_compute_frameworks == []
 
     def test_capability_split_rejects_sqlite_for_median_rolling_frame(self) -> None:
-        """The capability split must reject SqliteFramework for a median rolling frame while keeping Pandas/DuckDB.
+        """Each backend's own supports_compute_framework must reject/accept a median rolling frame.
 
         resolve_feature cannot be the probe here: frame aggregate's
         ``match_feature_group_criteria`` requires partition_by/order_by, which are absent
         under the empty Options resolve_feature evaluates matching with (the same reason the
-        median-scalar test above uses the scalar family instead of the group-by family). This
-        test exercises ``split_frameworks_by_capability`` directly, which is exactly the
-        mechanism resolve_feature uses internally to derive
-        supported/unsupported_compute_frameworks.
+        median-scalar test above uses the scalar family instead of the group-by family). The
+        removed ``split_frameworks_by_capability`` used to batch this same per-class check for a
+        caller-supplied list of candidates; this test calls each class's own
+        ``supports_compute_framework`` directly against its own (single) compute framework
+        instead, which is the exact per-feature hook that helper batched.
         """
         pytest.importorskip("pandas")
         pytest.importorskip("duckdb")
-        from mloda.core.prepare.identify_feature_group import split_frameworks_by_capability
+
+        from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+        from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 
         from mloda.community.feature_groups.data_operations.row_preserving.frame_aggregate.duckdb_frame_aggregate import (
             DuckdbFrameAggregate,
@@ -77,14 +111,8 @@ class TestResolveFeatureIntegration:
             SqliteFrameAggregate,
         )
 
-        supported, rejected = split_frameworks_by_capability(
-            [SqliteFrameAggregate, PandasFrameAggregate, DuckdbFrameAggregate],
-            "value__median_rolling_3",
-            Options(),
-        )
-        supported_names = {c.get_class_name() for c in supported}
-        rejected_names = {c.get_class_name() for c in rejected}
+        feature_name = "value__median_rolling_3"
 
-        assert "SqliteFramework" in rejected_names
-        assert "PandasDataFrame" in supported_names
-        assert "DuckDBFramework" in supported_names
+        assert SqliteFrameAggregate.supports_compute_framework(feature_name, Options(), SqliteFramework) is False
+        assert PandasFrameAggregate.supports_compute_framework(feature_name, Options(), PandasDataFrame) is True
+        assert DuckdbFrameAggregate.supports_compute_framework(feature_name, Options(), DuckDBFramework) is True

--- a/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
+++ b/mloda/community/feature_groups/data_operations/tests/test_rejection_reasons.py
@@ -23,13 +23,17 @@ from mloda.community.feature_groups.data_operations.row_preserving.scalar_arithm
 
 
 class TestPatternPathGuardRejectionReported:
-    """A pattern-path match_guard rejection must be named, not a silent non-match."""
+    """A pattern-path value rejection must be named, not a silent non-match."""
 
     def test_mistyped_constant_reports_a_reason(self) -> None:
+        """``constant`` is validated by element_validator before match_guard ever runs, so this is
+        the value-rejection reason core's own hook reports (the same message the real match pass
+        records), not a match_guard-worded one.
+        """
         options = Options(context={"constant": "five"})
         reason = PyArrowScalarArithmetic._strict_validation_rejection_reason("value_int__add_constant", options)
         assert reason is not None
-        assert "match_guard" in reason
+        assert "failed validation" in reason
         assert "'constant'" in reason
         assert "'five'" in reason
 

--- a/mloda/community/feature_groups/example/pyproject.toml
+++ b/mloda/community/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Example community FeatureGroup plugin for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/pyproject.toml
+++ b/mloda/community/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "All community plugins for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.urls]

--- a/mloda/enterprise/compute_frameworks/example/pyproject.toml
+++ b/mloda/enterprise/compute_frameworks/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Example enterprise ComputeFramework plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/extenders/example/pyproject.toml
+++ b/mloda/enterprise/extenders/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Example enterprise Extender plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/feature_groups/example/pyproject.toml
+++ b/mloda/enterprise/feature_groups/example/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Example enterprise FeatureGroup plugin for mloda"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/enterprise/pyproject.toml
+++ b/mloda/enterprise/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "All enterprise plugins for mloda (License required: https://mloda.ai/enterprise)"
 license = "LicenseRef-Proprietary"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.urls]

--- a/mloda/registry/pyproject.toml
+++ b/mloda/registry/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Plugin discovery and search for mloda"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/testing/feature_groups/data_operations/match_validation.py
+++ b/mloda/testing/feature_groups/data_operations/match_validation.py
@@ -36,7 +36,7 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 def _is_container(value: Any) -> bool:
@@ -195,7 +195,7 @@ class ScalarArityTestBase:
         mapping = getattr(cls.feature_group_class(), "PROPERTY_MAPPING", None) or {}
         predicates = {}
         for key, entry in mapping.items():
-            predicate = entry.get(DefaultOptionKeys.required_when) if isinstance(entry, dict) else None
+            predicate = entry.required_when if isinstance(entry, PropertySpec) else None
             if callable(predicate):
                 predicates[key] = predicate
         return predicates

--- a/mloda/testing/pyproject.toml
+++ b/mloda/testing/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Test utilities for mloda plugin development"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda>=0.10.0,<0.11.0", "pytest>=9.0.3"]
+dependencies = ["mloda>=0.11.0,<0.12.0", "pytest>=9.0.3"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Development workspace for mloda registry packages"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10,<3.15"
 dependencies = [
-    "mloda>=0.10.0,<0.11.0",
+    "mloda>=0.11.0,<0.12.0",
 ]
 authors = [
     { name = "Tom Kaltofen", email = "info@mloda.ai" }

--- a/uv.lock
+++ b/uv.lock
@@ -325,26 +325,26 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/9d/2251f947bfde5e168b9f6759079c8b54af0393c3e854987268459b860776/mloda-0.10.0-py3-none-any.whl", hash = "sha256:13fd1482566de203cac661c29f5736423ce7d1cc8e43ec26f8d24d19e6386229", size = 456550, upload-time = "2026-07-13T18:35:02.322Z" },
+    { url = "https://files.pythonhosted.org/packages/56/70/f1bb826b6d4fca716a9dcc46a785269eab63a59aa047be52ed82da510a9b/mloda-0.11.0-py3-none-any.whl", hash = "sha256:867834e19723a282df8de5e843e67871703b4113c14f403a0d09dc8b424f5b08", size = 535571, upload-time = "2026-08-17T11:49:27.791Z" },
 ]
 
 [[package]]
 name = "mloda-community"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community" }
 dependencies = [
     { name = "mloda" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.10.0,<0.11.0" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.11.0,<0.12.0" }]
 
 [[package]]
 name = "mloda-community-aggregation"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/aggregation" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -394,7 +394,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-binning"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/binning" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -444,7 +444,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-compute-frameworks-example"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/compute_frameworks/example" }
 dependencies = [
     { name = "mloda" },
@@ -458,7 +458,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -466,7 +466,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-data-operations"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations" }
 dependencies = [
     { name = "mloda" },
@@ -499,7 +499,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mloda-community-aggregation", marker = "extra == 'all'" },
     { name = "mloda-community-binning", marker = "extra == 'all'" },
     { name = "mloda-community-datetime", marker = "extra == 'all'" },
@@ -524,7 +524,7 @@ provides-extras = ["dev", "all"]
 
 [[package]]
 name = "mloda-community-datetime"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/datetime" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -546,7 +546,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-ema"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/ema" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -596,7 +596,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-example"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/example" }
 dependencies = [
     { name = "mloda" },
@@ -614,7 +614,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mloda-community-example-a", marker = "extra == 'all'" },
     { name = "mloda-community-example-b", marker = "extra == 'all'" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
@@ -624,7 +624,7 @@ provides-extras = ["dev", "all"]
 
 [[package]]
 name = "mloda-community-example-a"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/example/example_a" }
 dependencies = [
     { name = "mloda-community-example" },
@@ -646,7 +646,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-example-b"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/example/example_b" }
 dependencies = [
     { name = "mloda-community-example" },
@@ -668,7 +668,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-extenders-example"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/extenders/example" }
 dependencies = [
     { name = "mloda" },
@@ -682,7 +682,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -690,7 +690,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-ffill"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/ffill" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -740,7 +740,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-frame-aggregate"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -784,7 +784,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-offset"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/offset" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -828,7 +828,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-percentile"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/percentile" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -872,7 +872,7 @@ provides-extras = ["dev", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-point-arithmetic"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -922,7 +922,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-rank"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/rank" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -966,7 +966,7 @@ provides-extras = ["dev", "sqlite", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-resample"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_changing/resample" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1016,7 +1016,7 @@ provides-extras = ["dev", "pyarrow", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-scalar-aggregate"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1066,7 +1066,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-scalar-arithmetic"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1116,7 +1116,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-sessionization"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/sessionization" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1166,7 +1166,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-string"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/string" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1188,7 +1188,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-community-time-bucketization"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/time_bucketization" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1238,7 +1238,7 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-community-window-aggregation"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation" }
 dependencies = [
     { name = "mloda-community-data-operations" },
@@ -1288,18 +1288,18 @@ provides-extras = ["dev", "pyarrow", "sqlite", "duckdb", "polars", "pandas", "al
 
 [[package]]
 name = "mloda-enterprise"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/enterprise" }
 dependencies = [
     { name = "mloda" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mloda", specifier = ">=0.10.0,<0.11.0" }]
+requires-dist = [{ name = "mloda", specifier = ">=0.11.0,<0.12.0" }]
 
 [[package]]
 name = "mloda-enterprise-compute-frameworks-example"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/enterprise/compute_frameworks/example" }
 dependencies = [
     { name = "mloda" },
@@ -1313,7 +1313,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1321,7 +1321,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-enterprise-example"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/enterprise/feature_groups/example" }
 dependencies = [
     { name = "mloda" },
@@ -1335,7 +1335,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1343,7 +1343,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-enterprise-extenders-example"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/enterprise/extenders/example" }
 dependencies = [
     { name = "mloda" },
@@ -1357,7 +1357,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1365,7 +1365,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-registry"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/registry" }
 dependencies = [
     { name = "mloda" },
@@ -1379,7 +1379,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mloda-testing", marker = "extra == 'dev'", editable = "mloda/testing" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1416,7 +1416,7 @@ dev = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
     { name = "duckdb", marker = "extra == 'dev'" },
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'dev'" },
     { name = "polars", marker = "extra == 'dev'" },
@@ -1434,7 +1434,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "mloda-testing"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "mloda/testing" }
 dependencies = [
     { name = "mloda" },
@@ -1448,7 +1448,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda", specifier = ">=0.10.0,<0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]


### PR DESCRIPTION
## Summary

mloda 0.11.0 rejects raw-dict `PROPERTY_MAPPING` specs and enforces required-presence on the string-named match path (a key with no `default` and no `required_when` is now hard-required when a feature is requested by bare name). This bumps the core dependency to `mloda>=0.11.0,<0.12.0` and migrates every affected plugin.

## Changes

- Converts all 17 `PROPERTY_MAPPING`-declaring feature-group base classes under `data_operations/**` from raw dicts to `property_spec(...)`.
- Adds `deferred_binding=True` to keys whose value is recovered by a plugin's own custom name-parsing rather than a core-recognized regex capture group: percentile's `pN` token, offset's parametric lag/lead/diff/pct_change families, resample's op token, binning's bin count, time_bucketization's bucket token, rank's parametric families, and scalar_arithmetic's constant.
- Adds `default=None` to keys that are genuinely optional, verified per file against each plugin's real fallback code (a naive blanket default would have silently masked keys that are actually required, several plugins expect `partition_by` explicitly and have no whole-table fallback).
- Adds `RECOGNITION_ONLY_PATTERN = True` to the four classes with fully captureless name patterns (ema, ffill, sessionization, resample), closing out the migration mloda-registry#327 tracked.
- Rewrites the shared `RejectionReasonMixin` and the match-validation test harness, which both did dict-shaped introspection of `PROPERTY_MAPPING` entries and called two core methods 0.11.0 removed entirely. The rewritten mixin now defers to core's own diagnostic hook first (which already gets value-rejection, name-path presence, and strict-guard precedence right) and only supplies its own required_when/match_guard diagnostics for the one gap core leaves silent by design.
- Rewrites two tests that called a removed core helper (`split_frameworks_by_capability`) to use the still-public `supports_compute_framework` hook directly.
- Records a previously-silent frame_aggregate config-path rejection reason, and marks one test `xfail(strict=True)` for a documented, narrow core-guard limitation affecting a synthetic test-only subclass (production behavior is unaffected).
- Fixes one stale doc import example and one unrelated pre-existing formatting issue that would otherwise leave the `ruff format` gate red.

## Test plan

- [x] Full suite: `tox` (pytest, ruff format, ruff check, mypy --strict, bandit) passes clean.
- [x] Every `deferred_binding`/`default` decision verified against each plugin's actual per-backend compute code, not assumed.