### PR TITLE
docs: fix partition_by requirement in percentile/rank/offset guide

### DIFF
--- a/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
+++ b/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
@@ -2,7 +2,7 @@
 
 Three related row-preserving families for analytic windows: percentile (value-at-rank), rank (rank-of-value), and offset (shift-relative-to-row). They share naming and parameter conventions.
 
-**What**: Three feature groups that each compute a per-row analytic value within an optional partition.
+**What**: Three feature groups that each compute a per-row analytic value within a partition. `partition_by` is required for all three — none has a whole-table fallback — unlike `ema`, `ffill`, `sessionization`, and `resample`, which treat `partition_by` as optional and fall back to the whole table when it's omitted.
 **When**: You need percentiles, ranks, lags, or cumulative positions alongside the original rows.
 **Why**: These are the core analytic-window primitives that power feature engineering for time series and grouped analytics.
 **Where**: `mloda/community/feature_groups/data_operations/row_preserving/{percentile,rank,offset}/`.


### PR DESCRIPTION
## Summary

The "What" line in `docs/guides/data-operation-patterns/07-percentile-rank-offset.md` said these three feature groups compute a value "within an optional partition," which is wrong: `partition_by` is a hard requirement for percentile, rank, and offset, with no whole-table fallback. Updated the line to say so, and contrasted it with the families that do have a whole-table fallback (`ema`, `ffill`, `sessionization`, `resample`).

Docs-only change, one line.

## Related issue

Closes #414

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature / new plugin (`feat:`)
- [x] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [x] `uv run tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`) — n/a, no code changed
- [x] Tests added or updated for the change — n/a, docs-only
- [x] Documentation updated where relevant
- [x] `pyproject.toml` not edited by hand
- [x] PR title follows Conventional Commits