### PR TITLE
fix: remove buggy uuid init overrides in example compute frameworks

### DIFF
--- a/mloda/community/compute_frameworks/example/community_example_compute_framework.py
+++ b/mloda/community/compute_frameworks/example/community_example_compute_framework.py
@@ -1,21 +1,7 @@
 """Community Example ComputeFramework implementation."""
 
-from uuid import UUID, uuid4
-
-from mloda.user import ParallelizationMode
-from mloda.steward import Extender
 from mloda.provider import ComputeFramework
 
 
 class CommunityExampleComputeFramework(ComputeFramework):
     """Community Example ComputeFramework for demonstrating plugin structure."""
-
-    def __init__(
-        self,
-        mode: ParallelizationMode = ParallelizationMode.SYNC,
-        children_if_root: frozenset[UUID] = frozenset(),
-        uuid: UUID = uuid4(),
-        function_extender: set[Extender] | None = None,
-    ) -> None:
-        """Initialize with default values for minimal instantiation."""
-        super().__init__(mode, children_if_root, uuid, function_extender)

--- a/mloda/community/compute_frameworks/example/tests/test_community_example_compute_framework.py
+++ b/mloda/community/compute_frameworks/example/tests/test_community_example_compute_framework.py
@@ -54,3 +54,11 @@ class TestCommunityExampleComputeFrameworkBasicFunctionality:
 
         instance = CommunityExampleComputeFramework()
         assert instance is not None
+
+    def test_default_instances_have_unique_uuid(self) -> None:
+        """Test that two default-constructed instances get distinct uuids."""
+        from mloda.community.compute_frameworks.example import CommunityExampleComputeFramework
+
+        instance1 = CommunityExampleComputeFramework()
+        instance2 = CommunityExampleComputeFramework()
+        assert instance1.uuid != instance2.uuid

--- a/mloda/enterprise/compute_frameworks/example/enterprise_example_compute_framework.py
+++ b/mloda/enterprise/compute_frameworks/example/enterprise_example_compute_framework.py
@@ -1,21 +1,7 @@
 """Enterprise Example ComputeFramework implementation."""
 
-from uuid import UUID, uuid4
-
-from mloda.user import ParallelizationMode
-from mloda.steward import Extender
 from mloda.provider import ComputeFramework
 
 
 class EnterpriseExampleComputeFramework(ComputeFramework):
     """Enterprise Example ComputeFramework for demonstrating plugin structure."""
-
-    def __init__(
-        self,
-        mode: ParallelizationMode = ParallelizationMode.SYNC,
-        children_if_root: frozenset[UUID] = frozenset(),
-        uuid: UUID = uuid4(),
-        function_extender: set[Extender] | None = None,
-    ) -> None:
-        """Initialize with default values for minimal instantiation."""
-        super().__init__(mode, children_if_root, uuid, function_extender)

--- a/mloda/enterprise/compute_frameworks/example/tests/test_enterprise_example_compute_framework.py
+++ b/mloda/enterprise/compute_frameworks/example/tests/test_enterprise_example_compute_framework.py
@@ -54,3 +54,11 @@ class TestEnterpriseExampleComputeFrameworkBasicFunctionality:
 
         instance = EnterpriseExampleComputeFramework()
         assert instance is not None
+
+    def test_default_instances_have_unique_uuid(self) -> None:
+        """Test that two default-constructed instances get distinct uuids."""
+        from mloda.enterprise.compute_frameworks.example import EnterpriseExampleComputeFramework
+
+        instance1 = EnterpriseExampleComputeFramework()
+        instance2 = EnterpriseExampleComputeFramework()
+        assert instance1.uuid != instance2.uuid


### PR DESCRIPTION
## Summary

The community and enterprise example ComputeFramework subclasses each redeclared `uuid: UUID = uuid4()` as a default argument in their own `__init__` override. Python evaluates default arguments once, at function-definition time, so every default-constructed instance of a class shared one frozen UUID.

mloda 0.11.0's `ComputeFramework.__init__` now defaults `uuid` to `None` and falls back to a fresh `uuid4()` per instance (also adding defaults for `mode` and `children_if_root`), so the overrides are redundant and can be deleted entirely, relying on the base class for correct minimal instantiation.

## Related issue

Closes #310

## Changes

- `mloda/community/compute_frameworks/example/community_example_compute_framework.py`: deleted the `__init__` override and now-unused imports.
- `mloda/enterprise/compute_frameworks/example/enterprise_example_compute_framework.py`: same.
- Added a regression test to each example's test file asserting two default-constructed instances get distinct `.uuid` values.

## Type of change

- [x] Bug fix (`fix:`)

## Checklist

- [x] `uv run tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`)
- [x] Tests added or updated for the change
- [ ] Documentation updated where relevant (none needed, no docs reference the buggy pattern)
- [x] `pyproject.toml` not edited by hand
- [x] PR title follows Conventional Commits