### PR TITLE
feat(lint-docs): flag raw-dict PROPERTY_MAPPING in plugin source

### DIFF
--- a/docs/guides/feature-group-patterns/11-options.md
+++ b/docs/guides/feature-group-patterns/11-options.md
@@ -60,9 +60,9 @@ Use propagation sparingly; most context should remain local. Common use cases in
 
 ## PROPERTY_MAPPING value space
 
-A `PROPERTY_MAPPING` entry declares one parameter: its accepted values plus its metadata. Build every value with `property_spec(...)`. From mloda 0.11.0 that returns a typed `PropertySpec` and a raw dict raises `ValueError` at class definition; on mloda 0.10.0 it returns a plain dict, and `PropertySpec` is not importable there. Throughout this page the builder's `strict=` kwarg sets the spec field named `strict_validation`.
+A `PROPERTY_MAPPING` entry declares one parameter: its accepted values plus its metadata. Build every value with `property_spec(...)`, which returns a typed `PropertySpec`; a raw dict raises `ValueError` at class definition. Throughout this page the builder's `strict=` kwarg sets the spec field named `strict_validation`.
 
-A hand-written dict still works on 0.10.0, where it rejects unknown spec keys at class definition, which is where the renames `validation_function` to `element_validator` and `type_validator` to `match_guard` surface. The old flattened form, where accepted values sat among the spec's other keys, is gone.
+The old flattened form, where accepted values sat among the spec's other keys, is gone.
 
 ### Accepted values: `allowed_values`
 
@@ -80,7 +80,7 @@ PROPERTY_MAPPING = {
 }
 ```
 
-Pass a mapping of value to one-line docstring, or a `list`, `tuple`, `set` or `frozenset` of accepted values (materialized to a tuple). From mloda 0.11.0 those shapes are the whole declared type, which keeps a forgotten comma a typing error rather than a silent substring value space, so avoid a generator even though the runtime materializes one. A bare `str` is rejected outright, since membership would otherwise become a substring test.
+Pass a mapping of value to one-line docstring, or a `list`, `tuple`, `set` or `frozenset` of accepted values (materialized to a tuple). Those shapes are the whole declared type, which keeps a forgotten comma a typing error rather than a silent substring value space, so avoid a generator even though the runtime materializes one. A bare `str` is rejected outright, since membership would otherwise become a substring test.
 
 ### Builder: `property_spec`
 
@@ -102,13 +102,13 @@ PROPERTY_MAPPING = {
 
 `context` defaults to `True`, so `context=False` is how you declare a group-scoped key, one that lands in group options and therefore affects resolution and splitting. A caller who passes the key explicitly under `group=` or `context=` overrides that declaration.
 
-`property_spec` also accepts `element_validator`, `required_when`, and `match_guard`, plus `allow_explicit_none` and `deferred_binding` from mloda 0.11.0. `allow_explicit_none` makes an explicitly passed `None` count as present. `deferred_binding` exempts a key without a default from the name-path required-presence check, for values bound outside match-time name capture; it does not change config-path requiredness.
+`property_spec` also accepts `element_validator`, `required_when`, `match_guard`, `allow_explicit_none`, and `deferred_binding`. `allow_explicit_none` makes an explicitly passed `None` count as present. `deferred_binding` exempts a key without a default from the name-path required-presence check, for values bound outside match-time name capture; it does not change config-path requiredness.
 
-Version note on `default=None`: mloda 0.10.0 drops it, so the key stays required, and a hand-written dict entry is the only way to express an optional key with a `None` default there. From mloda 0.11.0, omitting `default` declares no default (the key is required) and `default=None` declares a default of `None`, which makes the key optional.
+Omitting `default` declares no default, so the key is required; `default=None` declares a default of `None`, which makes the key optional.
 
 ### Strict defaults are checked at construction
 
-A spec validates itself when it is built, so a `strict=True` `default` outside the accepted set (or one the key's `element_validator` rejects) raises `ValueError` from the `property_spec(...)` call, not from the `FeatureGroup` class definition that reads the mapping. The message names the spec's explanation and the rejected default; mloda 0.10.0 also lists the accepted values. A `default` of `None` is exempt (the conventional "unset" sentinel), and the check is a no-op under `strict=False`.
+A spec validates itself when it is built, so a `strict=True` `default` outside the accepted set (or one the key's `element_validator` rejects) raises `ValueError` from the `property_spec(...)` call, not from the `FeatureGroup` class definition that reads the mapping. The message names the spec's explanation and the rejected default. A `default` of `None` is exempt (the conventional "unset" sentinel), and the check is a no-op under `strict=False`.
 
 ## Validation and Conditional Requirements
 

--- a/docs/guides/feature-group-patterns/11-options.md
+++ b/docs/guides/feature-group-patterns/11-options.md
@@ -62,8 +62,6 @@ Use propagation sparingly; most context should remain local. Common use cases in
 
 A `PROPERTY_MAPPING` entry declares one parameter: its accepted values plus its metadata. Build every value with `property_spec(...)`, which returns a typed `PropertySpec`; a raw dict raises `ValueError` at class definition. Throughout this page the builder's `strict=` kwarg sets the spec field named `strict_validation`.
 
-The old flattened form, where accepted values sat among the spec's other keys, is gone.
-
 ### Accepted values: `allowed_values`
 
 `allowed_values` is the kwarg that declares a key's accepted value space:

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -17,6 +17,8 @@ DOCS_DIR = REPO_ROOT / "docs"
 # The orphan BFS is rooted at the guides index; docs-root files are linted but not part of that graph.
 GUIDES_DIR = DOCS_DIR / "guides"
 
+PLUGIN_SOURCE_DIR = REPO_ROOT / "mloda"
+
 INTERNAL_IMPORT_RE = re.compile(r"from mloda\.core\.")
 
 MD_LINK_RE = re.compile(r"\[.*?\]\((?!https?://|mailto:)([^)#\s]+\.md)(?:#([^)\s]+))?\)")
@@ -25,7 +27,7 @@ HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
 
 CODE_BLOCK_RE = re.compile(r"^```", re.MULTILINE)
 
-# Spec fields DefaultOptionKeys must not be used for: six are gone from the unreleased core, and ``explanation``
+# Spec fields DefaultOptionKeys must not be used for: six are gone from the current core, and ``explanation``
 # was never a member at all. ``context``, ``group`` and ``in_features`` survive and must never be flagged.
 RETIRED_SPEC_FIELDS = frozenset(
     {
@@ -278,15 +280,15 @@ def _property_mapping_value(node: ast.AST) -> ast.Dict | None:
     return None
 
 
-def _retired_key_error(md_file: Path, line: int, spelling: str) -> tuple[int, str]:
-    return line, f"{md_file}:{line}: retired spelling {spelling} (use property_spec(...) instead)"
+def _retired_key_error(path: Path, line: int, spelling: str) -> tuple[int, str]:
+    return line, f"{path}:{line}: retired spelling {spelling} (use property_spec(...) instead)"
 
 
-def _raw_dict_error(md_file: Path, line: int) -> tuple[int, str]:
-    return line, f"{md_file}:{line}: raw dict PROPERTY_MAPPING value (use property_spec(...) instead)"
+def _raw_dict_error(path: Path, line: int) -> tuple[int, str]:
+    return line, f"{path}:{line}: raw dict PROPERTY_MAPPING value (use property_spec(...) instead)"
 
 
-def _parsed_fence_errors(md_file: Path, offset: int, tree: ast.Module) -> list[tuple[int, str]]:
+def _parsed_fence_errors(path: Path, offset: int, tree: ast.Module) -> list[tuple[int, str]]:
     """Collect (file line, message) pairs from a parsed fence."""
     found: list[tuple[int, str]] = []
     for node in ast.walk(tree):
@@ -297,13 +299,13 @@ def _parsed_fence_errors(md_file: Path, offset: int, tree: ast.Module) -> list[t
             and node.value.id == OPTION_KEYS_NAME
         ):
             spelling = f"{OPTION_KEYS_NAME}.{node.attr}"
-            found.append(_retired_key_error(md_file, offset + node.lineno, spelling))
+            found.append(_retired_key_error(path, offset + node.lineno, spelling))
         mapping = _property_mapping_value(node)
         if mapping is None:
             continue
         for value in mapping.values:
             if isinstance(value, ast.Dict):
-                found.append(_raw_dict_error(md_file, offset + value.lineno))
+                found.append(_raw_dict_error(path, offset + value.lineno))
     return found
 
 
@@ -341,9 +343,23 @@ def check_retired_property_spec_spellings(md_file: Path, content: str) -> list[s
     return [message for _, message in sorted(found, key=lambda item: item[0])]
 
 
+def check_source_property_mapping(py_file: Path, content: str) -> list[str]:
+    """Same checks as ``check_retired_property_spec_spellings``, applied directly to a whole .py file;
+    unlike the markdown-fence path, a file that fails to parse yields no findings (no textual fallback)."""
+    tree = _parse_python(content)
+    if tree is None:
+        return []
+    found = _parsed_fence_errors(py_file, 0, tree)
+    return [message for _, message in sorted(found, key=lambda item: item[0])]
+
+
 def main() -> int:
     if not DOCS_DIR.is_dir():
         print(f"Docs directory not found: {DOCS_DIR}")
+        return 1
+
+    if not PLUGIN_SOURCE_DIR.is_dir():
+        print(f"Plugin source directory not found: {PLUGIN_SOURCE_DIR}")
         return 1
 
     all_errors: list[str] = []
@@ -371,6 +387,10 @@ def main() -> int:
         content = md_file.read_text(encoding="utf-8")
         link_errors.extend(check_relative_links_and_anchors(md_file, content))
         all_errors.extend(check_bare_fence_openers(md_file, content))
+
+    for py_file in sorted(PLUGIN_SOURCE_DIR.rglob("*.py")):
+        content = py_file.read_text(encoding="utf-8")
+        all_errors.extend(check_source_property_mapping(py_file, content))
 
     all_errors.extend(link_errors)
 

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -133,6 +133,9 @@ def test_broken_link_suppresses_orphan_cascade(
     _write(tmp_path / "guides" / "plugins" / "a.md", "# A\n")
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -151,6 +154,9 @@ def test_docs_root_link_error_does_not_suppress_guides_orphan_check(
     _write(tmp_path / "packaging.md", "# Packaging\n\n[Missing](missing.md)\n")
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -168,6 +174,9 @@ def test_clean_tree_runs_orphan_check(
     _write(tmp_path / "orphan.md", "# Orphan\n")
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path)
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -185,6 +194,9 @@ def test_main_flags_broken_link_outside_guides(
     _write(tmp_path / "packaging.md", "# Packaging\n\n[Missing](missing.md)\n")
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -202,6 +214,9 @@ def test_main_flags_bare_fence_outside_guides(
     _write(tmp_path / "releasing.md", "# Releasing\n\n```\nuv build\n```\n")
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -220,6 +235,9 @@ def test_orphan_check_stays_scoped_to_guides(
     _write(tmp_path / "packaging.md", "# Packaging\n")
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -328,8 +346,8 @@ def test_check_internal_imports_ignores_prose_match(tmp_path: Path) -> None:
     assert lint_docs.check_internal_imports(md_file, content) == []
 
 
-# Spec-field spellings that DefaultOptionKeys must not be used for: they are gone from the unreleased core,
-# and ``explanation`` was never a member at all (the attribute access already raises AttributeError on 0.10.0).
+# Spec-field spellings that DefaultOptionKeys must not be used for: none of them are members of the
+# current DefaultOptionKeys, and ``explanation`` was never a member at all.
 RETIRED_SPEC_FIELDS = [
     "explanation",
     "allowed_values",
@@ -581,6 +599,9 @@ def test_main_reports_retired_property_spec_spellings(
     )
     monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path)
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -603,6 +624,9 @@ def test_main_flags_broken_link_in_top_level_markdown(
     monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", guides)
     monkeypatch.setattr(lint_docs, "REPO_ROOT", tmp_path)
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -623,6 +647,9 @@ def test_main_flags_bare_fence_in_top_level_markdown(
     monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", guides)
     monkeypatch.setattr(lint_docs, "REPO_ROOT", tmp_path)
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 1
@@ -642,6 +669,9 @@ def test_main_orphan_check_ignores_top_level_markdown(
     monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", guides)
     monkeypatch.setattr(lint_docs, "REPO_ROOT", tmp_path)
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     out = capsys.readouterr().out
     assert rc == 0
@@ -661,6 +691,9 @@ def test_main_reads_markdown_as_utf8(
     monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
     monkeypatch.setattr(lint_docs, "GUIDES_DIR", guides)
     monkeypatch.setattr(lint_docs, "REPO_ROOT", tmp_path)
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
     rc = lint_docs.main()
     assert rc == 0
 
@@ -669,3 +702,127 @@ def test_missing_root_index_uses_relative_path(tmp_path: Path) -> None:
     errors = lint_docs.find_orphan_guides(tmp_path)
     assert len(errors) == 1
     assert str(tmp_path) not in errors[0]
+
+
+# check_source_property_mapping: same checks as check_retired_property_spec_spellings, applied
+# directly to a whole .py file's content (no markdown fence extraction, offset always 0).
+
+
+def test_plugin_source_dir_is_repo_mloda_root() -> None:
+    """PLUGIN_SOURCE_DIR is the mloda/ package root scanned for source-level checks."""
+    assert lint_docs.PLUGIN_SOURCE_DIR == _REPO_ROOT / "mloda"
+    assert lint_docs.PLUGIN_SOURCE_DIR.is_dir()
+
+
+def test_check_source_property_mapping_flags_raw_dict_value(tmp_path: Path) -> None:
+    py_file = tmp_path / "base.py"
+    content = (
+        'PROPERTY_MAPPING = {\n    "operation_type": {\n        "explanation": "Arithmetic operation",\n    },\n}\n'
+    )
+    _write(py_file, content)
+    errors = lint_docs.check_source_property_mapping(py_file, content)
+    assert len(errors) == 1
+    # The nested dict literal opens on line 2; the error must point there, not at the
+    # PROPERTY_MAPPING assignment line.
+    assert errors[0].startswith(f"{py_file}:2:")
+    assert "property_spec" in errors[0]
+
+
+def test_check_source_property_mapping_accepts_property_spec_values(tmp_path: Path) -> None:
+    """No false positive when every PROPERTY_MAPPING value is a property_spec(...) call."""
+    py_file = tmp_path / "base.py"
+    content = (
+        "PROPERTY_MAPPING = {\n"
+        '    "operation_type": property_spec(\n'
+        '        "Arithmetic operation",\n'
+        "        strict=True,\n"
+        '        allowed_values={"add": "Addition", "sub": "Subtraction"},\n'
+        '        default="add",\n'
+        "    ),\n"
+        "}\n"
+    )
+    _write(py_file, content)
+    assert lint_docs.check_source_property_mapping(py_file, content) == []
+
+
+def test_check_source_property_mapping_flags_retired_option_key(tmp_path: Path) -> None:
+    """The retired-spelling check is exhaustively field-tested against RETIRED_SPEC_FIELDS for
+    check_retired_property_spec_spellings above; check_source_property_mapping delegates to the
+    same underlying walk, so one representative field is enough to prove the delegation works."""
+    py_file = tmp_path / "base.py"
+    content = "key = DefaultOptionKeys.allowed_values\n"
+    _write(py_file, content)
+    errors = lint_docs.check_source_property_mapping(py_file, content)
+    assert len(errors) == 1
+    assert "DefaultOptionKeys.allowed_values" in errors[0]
+    assert "retired" in errors[0].lower()
+    assert errors[0].startswith(f"{py_file}:1:")
+
+
+def test_check_source_property_mapping_accepts_surviving_option_key(tmp_path: Path) -> None:
+    """``context`` still exists on DefaultOptionKeys; see the note on the retired-key test above
+    for why one representative field suffices here."""
+    py_file = tmp_path / "base.py"
+    content = "key = DefaultOptionKeys.context\n"
+    _write(py_file, content)
+    assert lint_docs.check_source_property_mapping(py_file, content) == []
+
+
+def test_check_source_property_mapping_returns_empty_for_syntax_error(tmp_path: Path) -> None:
+    """A .py file that fails to parse yields no findings; unlike the markdown-fence path, there is no
+    textual fallback scan. The fixture carries a retired DefaultOptionKeys spelling that a textual
+    fallback (``_textual_retired_option_keys``) would catch if it were wired in, so this actually
+    distinguishes the two behaviors rather than passing regardless."""
+    py_file = tmp_path / "broken.py"
+    content = "if True\n    x = DefaultOptionKeys.explanation\n"
+    _write(py_file, content)
+    assert lint_docs.check_source_property_mapping(py_file, content) == []
+
+
+def test_main_reports_raw_dict_in_plugin_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    docs = tmp_path / "docs"
+    _write(docs / "index.md", "# Root\n")
+    plugin_src = tmp_path / "plugin_src"
+    _write(
+        plugin_src / "a" / "b" / "base.py",
+        'PROPERTY_MAPPING = {\n    "operation_type": {\n        "explanation": "Arithmetic operation",\n    },\n}\n',
+    )
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", docs)
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", plugin_src)
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "raw dict PROPERTY_MAPPING" in out
+    assert "base.py" in out
+
+
+def test_check_source_property_mapping_has_no_findings_in_real_plugin_source() -> None:
+    """Regression guard: production PROPERTY_MAPPING declarations are property_spec(...) calls,
+    not raw dicts, and plugin source uses no retired DefaultOptionKeys spelling."""
+    findings = [
+        error
+        for py_file in sorted(lint_docs.PLUGIN_SOURCE_DIR.rglob("*.py"))
+        for error in lint_docs.check_source_property_mapping(py_file, py_file.read_text(encoding="utf-8"))
+    ]
+    assert findings == []
+
+
+def test_main_reports_missing_plugin_source_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    docs = tmp_path / "docs"
+    _write(docs / "guides" / "index.md", "# Root\n")
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", docs)
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", docs / "guides")
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", tmp_path / "does_not_exist")
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Plugin source directory not found" in out

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
     pytest mloda/enterprise/ -v -n 2
 
 [testenv:lint-docs]
-description = Check docs for broken links and internal imports
+description = Check docs for broken links/imports and plugin source for raw-dict PROPERTY_MAPPING
 # Needs skip_install, which the lock runner ignores.
 runner = uv-venv-runner
 skip_install = true


### PR DESCRIPTION
## Summary

Finishes the two follow-up items left after the data-operations PROPERTY_MAPPING migration to typed `property_spec()` specs: the options guide still described dual raw-dict/typed-spec behavior across mloda 0.10.0 and 0.11.0, and the doc linter's raw-dict/retired-spelling detector only ever looked at markdown code fences, never real plugin source. As a side effect, the guide rewrite also clears out the last remaining pre-0.11.0 dict-contract language and legacy field names two separate issues had flagged.

## Related issues

Closes #325
Closes #409
Closes #408

## Changes

- Collapses the dual-version prose in `docs/guides/feature-group-patterns/11-options.md` now that the registry requires `mloda>=0.11.0,<0.12.0`: a raw dict always raises `ValueError`, `default=None` always declares an optional key, and the strict-default rejection message never lists accepted values. This also removes the guide's last references to the retired `validation_function`/`type_validator` field names and the "checked at import time" framing.
- Extends `scripts/lint_docs.py` with `check_source_property_mapping`, reusing the existing AST helpers against whole `.py` files under `mloda/` instead of markdown fences, so a new raw-dict `PROPERTY_MAPPING` or retired `DefaultOptionKeys` spelling in plugin source now fails `tox -e lint-docs` the same way it already did for guide examples.
- Adds a `PLUGIN_SOURCE_DIR.is_dir()` guard mirroring the existing `DOCS_DIR` one, so a missing or renamed scan root fails loudly instead of silently reporting "All docs OK."

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature / new plugin (`feat:`)
- [x] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [x] `uv run tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`)
- [x] Tests added or updated for the change
- [x] Documentation updated where relevant
- [x] `pyproject.toml` not edited by hand (regenerated from `config/` via `scripts/generate_pyproject.py` if dependencies changed)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)