### PR TITLE
fix: reject empty partition_by in OffsetFeatureGroup matching

### DIFF
--- a/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
+++ b/docs/guides/data-operation-patterns/07-percentile-rank-offset.md
@@ -2,7 +2,7 @@
 
 Three related row-preserving families for analytic windows: percentile (value-at-rank), rank (rank-of-value), and offset (shift-relative-to-row). They share naming and parameter conventions.
 
-**What**: Three feature groups that each compute a per-row analytic value within a partition. `partition_by` is required for all three — none has a whole-table fallback — unlike `ema`, `ffill`, `sessionization`, and `resample`, which treat `partition_by` as optional and fall back to the whole table when it's omitted.
+**What**: Three feature groups that each compute a per-row analytic value within a partition. `partition_by` is required for all three — none has a whole-table fallback — unlike `ema`, `ffill`, `sessionization`, and `resample`, which treat `partition_by` as optional and fall back to the whole table when it's omitted. `partition_by` must be present and non-empty; the matcher rejects the feature otherwise.
 **When**: You need percentiles, ranks, lags, or cumulative positions alongside the original rows.
 **Why**: These are the core analytic-window primitives that power feature engineering for time series and grouped analytics.
 **Where**: `mloda/community/feature_groups/data_operations/row_preserving/{percentile,rank,offset}/`.

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -175,6 +175,8 @@ class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
         partition_by = options.get(cls.PARTITION_BY)
         if not isinstance(partition_by, (list, tuple)):
             return False
+        if not partition_by:
+            return False
         if not all(isinstance(item, str) for item in partition_by):
             return False
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -132,6 +132,14 @@ class TestConfigValidation:
         options = Options(context={"partition_by": [123], "order_by": "value_int"})
         assert not OffsetFeatureGroup.match_feature_group_criteria("value_int__lag_1_offset", options, None)
 
+    def test_partition_by_rejects_empty_list(self) -> None:
+        options = Options(context={"partition_by": [], "order_by": "value_int"})
+        assert not OffsetFeatureGroup.match_feature_group_criteria("value_int__lag_1_offset", options, None)
+
+    def test_partition_by_rejects_empty_tuple(self) -> None:
+        options = Options(context={"partition_by": (), "order_by": "value_int"})
+        assert not OffsetFeatureGroup.match_feature_group_criteria("value_int__lag_1_offset", options, None)
+
     def test_order_by_rejects_non_string(self) -> None:
         options = Options(context={"partition_by": ["region"], "order_by": 123})
         assert not OffsetFeatureGroup.match_feature_group_criteria("value_int__lag_1_offset", options, None)

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_integration.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_integration.py
@@ -79,3 +79,7 @@ class TestIntegrationPluginDiscovery:
     def test_match_rejects_missing_order_by(self) -> None:
         options = Options(context={"partition_by": ["region"]})
         assert not ReferenceOffset.match_feature_group_criteria("value_int__lag_1_offset", options)
+
+    def test_match_rejects_empty_partition_by(self) -> None:
+        options = Options(context={"partition_by": [], "order_by": "value_int"})
+        assert not ReferenceOffset.match_feature_group_criteria("value_int__lag_1_offset", options)

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -276,7 +276,6 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
     def test_option_based_lag(self) -> None:
         """Option-based configuration (not string pattern) produces the same result as pattern."""
         from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-        from mloda.core.abstract_plugins.components.options import Options
         from mloda.user import Feature
 
         feature = Feature(
@@ -300,7 +299,6 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
     def test_unsupported_offset_type_raises(self) -> None:
         """Calling calculate_feature with an unknown offset type should raise ValueError."""
         from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-        from mloda.core.abstract_plugins.components.options import Options
         from mloda.user import Feature
 
         feature = Feature(
@@ -317,10 +315,15 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         with pytest.raises((ValueError, KeyError)):
             self.implementation_class().calculate_feature(self.test_data, fs)
 
+    # -- Matching tests -------------------------------------------------------
+
     def test_match_rejects_empty_partition_by(self) -> None:
         """Empty partition_by must be rejected at match time, not reach backend-specific compute."""
         options = Options(context={"partition_by": [], "order_by": "value_int"})
         assert not self.implementation_class().match_feature_group_criteria("value_int__lag_1_offset", options, None)
+
+        valid_options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
+        assert self.implementation_class().match_feature_group_criteria("value_int__lag_1_offset", valid_options, None)
 
     # -- Tier 3: Partition / order_by null tests ------------------------------
 

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -17,6 +17,7 @@ from typing import Any
 import pyarrow as pa
 import pytest
 
+from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import extract_column, make_feature_set
 from mloda.testing.feature_groups.data_operations.mixins.reserved_columns import ReservedColumnsTestMixin
@@ -315,6 +316,11 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         fs.add(feature)
         with pytest.raises((ValueError, KeyError)):
             self.implementation_class().calculate_feature(self.test_data, fs)
+
+    def test_match_rejects_empty_partition_by(self) -> None:
+        """Empty partition_by must be rejected at match time, not reach backend-specific compute."""
+        options = Options(context={"partition_by": [], "order_by": "value_int"})
+        assert not self.implementation_class().match_feature_group_criteria("value_int__lag_1_offset", options, None)
 
     # -- Tier 3: Partition / order_by null tests ------------------------------
 


### PR DESCRIPTION
## Summary

`OffsetFeatureGroup.match_feature_group_criteria` accepted `partition_by=[]` and let the request reach each backend's `calculate_feature`, where it broke differently per backend:

- Pandas: `ValueError: No group keys passed!`
- Polars: `ComputeError`
- SQLite: malformed SQL for `first_value`/`last_value` (an empty `WHERE  AND ...` predicate)
- DuckDB: silently computed a whole-table window instead of rejecting the request

`RankFeatureGroup` already rejects an empty `partition_by` at match time. This adds the same guard to `OffsetFeatureGroup`, so an empty `partition_by` is now a non-match on every backend, consistently, instead of a backend-specific runtime failure.

## Changes

- `offset/base.py`: add `if not partition_by: return False`, mirroring rank's existing guard.
- Regression tests: two unit tests on `OffsetFeatureGroup.match_feature_group_criteria` directly, one shared test in `OffsetTestBase` that runs once per backend (pandas, polars, duckdb, sqlite) since none of them override the matcher, and one integration-level test through the reference implementation.
- Docs: note in the percentile/rank/offset guide that an empty `partition_by` is rejected, mirroring the existing window-aggregation guide's wording.

## Test plan

- [x] `tox` (pytest, ruff format, ruff check, mypy --strict, bandit) passes
- [x] `python scripts/lint_docs.py` passes
- [x] New tests fail without the guard and pass with it