### PR TITLE
fix: raise leaf dependency floors to the py.typed marker release

### DIFF
--- a/config/packages.toml
+++ b/config/packages.toml
@@ -53,15 +53,15 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-example-a]
 description = "Example A FeatureGroup extending community example base"
-# Floor 0.2.6: 0.2.0 through 0.2.3 never reached PyPI, and 0.2.4/0.2.5 lack the base module the variants import.
-dependencies = ["mloda-community-example>=0.2.6"]
+# Floor 0.4.1: first release of mloda-community-example shipping the py.typed marker.
+dependencies = ["mloda-community-example>=0.4.1"]
 path = "mloda/community/feature_groups/example/example_a"
 published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-example-b]
 description = "Example B FeatureGroup extending community example base"
-dependencies = ["mloda-community-example>=0.2.6"]
+dependencies = ["mloda-community-example>=0.4.1"]
 path = "mloda/community/feature_groups/example/example_b"
 entry_point_groups = ["mloda.feature_groups"]
 
@@ -90,7 +90,7 @@ path = "mloda/enterprise/extenders/example"
 entry_point_groups = ["mloda.extenders"]
 
 # --- Data Operations ---
-# Leaf floors are 0.4.0, the first release shipping the shared guard helpers; policy in docs/packaging.md.
+# Leaf floors are 0.4.1, the first release of mloda-community-data-operations shipping the py.typed marker; policy in docs/packaging.md.
 
 [packages.mloda-community-data-operations]
 description = "Shared base classes for data operation feature groups"
@@ -102,7 +102,7 @@ py_typed = true
 
 [packages.mloda-community-aggregation]
 description = "Aggregation feature group (reduce, partition_by, one row per group)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/aggregation"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -110,7 +110,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-rank]
 description = "Rank feature group (row_number, rank, dense_rank, percent_rank, ntile, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/rank"
 published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
@@ -118,7 +118,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-offset]
 description = "Offset feature group (lag, lead, diff, pct_change, first_value, last_value, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/offset"
 published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
@@ -126,7 +126,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-window-aggregation]
 description = "Window aggregation feature group (broadcast, partition_by, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -134,7 +134,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-frame-aggregate]
 description = "Frame aggregate feature group (rolling, cumulative, expanding, time window, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate"
 published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas>=2.2"], all = ["polars", "pandas>=2.2", "duckdb"] }
@@ -142,7 +142,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-scalar-aggregate]
 description = "Scalar aggregate feature group (single-column global aggregate broadcast)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -150,7 +150,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-scalar-arithmetic]
 description = "Scalar arithmetic feature group (element-wise column op constant: add, subtract, multiply, divide)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -158,7 +158,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-point-arithmetic]
 description = "Point arithmetic feature group (element-wise two-column op: add, subtract, multiply, divide; PyArrow-reference null/IEEE-754 semantics on divide-by-zero; SQLite returns NULL)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -166,21 +166,21 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-datetime]
 description = "Datetime extraction feature group (element-wise, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/datetime"
 published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-string]
 description = "String operation feature group (element-wise, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/string"
 published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-binning]
 description = "Binning feature group (equal-width, quantile, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/binning"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -188,7 +188,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-percentile]
 description = "Percentile feature group (PERCENTILE_CONT, partition_by, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/percentile"
 published = true
 optional_dependencies = { duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
@@ -196,7 +196,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-time-bucketization]
 description = "Time bucketization feature group (floor, ceil, round a timestamp to a bucket interval, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/time_bucketization"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -204,7 +204,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-ffill]
 description = "Forward-fill feature group (ffill a value column across time gaps, per partition, ordered by time, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ffill"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -212,7 +212,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-ema]
 description = "EMA feature group (exponential moving average, adjust=False, null-skipping recurrence, per partition, row-preserving; pandas/polars native, pyarrow/duckdb/sqlite reject)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ema"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -220,7 +220,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-sessionization]
 description = "Sessionization feature group (gap-threshold session id on an ordered timestamp, per partition, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/sessionization"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -228,7 +228,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-resample]
 description = "Resample feature group (collapse events onto a regular time grid: floor to bucket, group, aggregate; one row per non-empty bucket, row-changing)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_changing/resample"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }

--- a/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Aggregation feature group (reduce, partition_by, one row per group)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Resample feature group (collapse events onto a regular time grid: floor to bucket, group, aggregate; one row per non-empty bucket, row-changing)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Binning feature group (equal-width, quantile, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Datetime extraction feature group (element-wise, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "EMA feature group (exponential moving average, adjust=False, null-skipping recurrence, per partition, row-preserving; pandas/polars native, pyarrow/duckdb/sqlite reject)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Forward-fill feature group (ffill a value column across time gaps, per partition, ordered by time, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Frame aggregate feature group (rolling, cumulative, expanding, time window, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Offset feature group (lag, lead, diff, pct_change, first_value, last_value, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Percentile feature group (PERCENTILE_CONT, partition_by, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Point arithmetic feature group (element-wise two-column op: add, subtract, multiply, divide; PyArrow-reference null/IEEE-754 semantics on divide-by-zero; SQLite returns NULL)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Rank feature group (row_number, rank, dense_rank, percent_rank, ntile, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Scalar aggregate feature group (single-column global aggregate broadcast)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Scalar arithmetic feature group (element-wise column op constant: add, subtract, multiply, divide)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Sessionization feature group (gap-threshold session id on an ordered timestamp, per partition, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Time bucketization feature group (floor, ceil, round a timestamp to a bucket interval, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Window aggregation feature group (broadcast, partition_by, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/string/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/string/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "String operation feature group (element-wise, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/example/example_a/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_a/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Example A FeatureGroup extending community example base"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-example>=0.2.6"]
+dependencies = ["mloda-community-example>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/example/example_b/pyproject.toml
+++ b/mloda/community/feature_groups/example/example_b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Example B FeatureGroup extending community example base"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-example>=0.2.6"]
+dependencies = ["mloda-community-example>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/tests/script_loader.py
+++ b/tests/script_loader.py
@@ -15,3 +15,8 @@ def load_script(name: str, path: Path) -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def version_tuple(version: str) -> tuple[int, ...]:
+    """Comparable form of a numeric release version."""
+    return tuple(int(part) for part in version.split("."))

--- a/tests/test_end2end/test_py_typed_markers.py
+++ b/tests/test_end2end/test_py_typed_markers.py
@@ -18,12 +18,13 @@ else:
 
 import pytest
 
-from tests.script_loader import load_script
+from tests.script_loader import load_script, version_tuple
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _GEN_PATH = _REPO_ROOT / "scripts" / "generate_pyproject.py"
 _VERIFY_BUILDS_PATH = _REPO_ROOT / "scripts" / "verify_builds.py"
 _PUBLISHED_PACKAGES_PATH = _REPO_ROOT / "scripts" / "published_packages.py"
+_VERIFY_FLOOR_INSTALLS_PATH = _REPO_ROOT / "scripts" / "verify_floor_installs.py"
 
 # The bundle distributions, always part of the released set.
 _BUNDLES = ["mloda-registry", "mloda-testing", "mloda-community", "mloda-enterprise"]
@@ -38,6 +39,7 @@ _MARKER_FLOORS = {"mloda-community-data-operations": "0.4.1", "mloda-community-e
 
 gen = load_script("generate_pyproject", _GEN_PATH)
 vb = load_script("verify_builds", _VERIFY_BUILDS_PATH)
+vf = load_script("verify_floor_installs", _VERIFY_FLOOR_INSTALLS_PATH)
 
 
 def _packages() -> dict[str, dict[str, Any]]:
@@ -189,18 +191,30 @@ def test_every_published_distribution_has_a_typed_ancestor(pkg_name: str) -> Non
     )
 
 
-def _version_tuple(version: str) -> tuple[int, ...]:
-    """Plain dotted version to a comparable tuple; declared floors are always X.Y.Z, so no PEP 440 parser needed."""
-    return tuple(int(part) for part in version.split("."))
+def test_marker_floors_cover_exactly_the_non_bundle_typed_packages() -> None:
+    """_MARKER_FLOORS must track _TYPED_PACKAGES minus the bundles: those are the only "shared base" typed
+    packages leaves declare a dependency floor on. If a third typed base is ever added to _TYPED_PACKAGES
+    without a matching _MARKER_FLOORS entry, this must fail instead of the floor-enforcement test below
+    silently covering fewer packages than it should."""
+    assert set(_MARKER_FLOORS) == set(_TYPED_PACKAGES) - set(_BUNDLES), (
+        f"_MARKER_FLOORS {sorted(_MARKER_FLOORS)} must equal _TYPED_PACKAGES minus _BUNDLES "
+        f"{sorted(set(_TYPED_PACKAGES) - set(_BUNDLES))}"
+    )
 
 
 def _declared_floor(dep: str, base_name: str) -> str | None:
-    """The '>=' version floor a dependency string declares on ``base_name``, or None if it names another package."""
-    match = re.match(r"([A-Za-z0-9._-]+)\s*>=\s*([0-9.]+)", dep.strip())
-    if not match:
+    """The '>=' version floor a dependency string declares on ``base_name``, or None if it names another package
+    (or names ``base_name`` without a '>=' floor). Reuses verify_floor_installs' DEP_NAME_RE/FLOOR_RE so extras
+    markers (e.g. "pkg[all]>=0.4.0") and other PEP 508 spellings parse the same way here as they do there."""
+    requirement = dep.strip()
+    name_match = vf.DEP_NAME_RE.match(requirement)
+    if not name_match:
         return None
-    name = re.sub(r"[-_.]+", "-", match.group(1)).lower()
-    return match.group(2) if name == base_name else None
+    name = re.sub(r"[-_.]+", "-", name_match.group(1)).lower()
+    if name != base_name:
+        return None
+    floor_match = vf.FLOOR_RE.search(requirement)
+    return floor_match.group(1) if floor_match else None
 
 
 def _leaves_with_marker_floor_dependency() -> list[tuple[str, str, str]]:
@@ -216,6 +230,11 @@ def _leaves_with_marker_floor_dependency() -> list[tuple[str, str, str]]:
                 floor = _declared_floor(dep, base_name)
                 if floor is not None:
                     found.append((pkg_name, base_name, floor))
+    assert found, (
+        "expected at least one configured, non-typed package to declare a '>=' floor on a _MARKER_FLOORS base; "
+        "an empty result here would silently skip test_leaf_dependency_floor_meets_py_typed_marker instead of "
+        "failing it"
+    )
     return found
 
 
@@ -224,7 +243,7 @@ def test_leaf_dependency_floor_meets_py_typed_marker(pkg_name: str, base_name: s
     """A leaf's declared floor on its typed base must be at or above the base release that first shipped py.typed,
     or an environment can resolve an older, unmarked base and the leaf silently installs untyped."""
     required = _MARKER_FLOORS[base_name]
-    assert _version_tuple(declared_floor) >= _version_tuple(required), (
+    assert version_tuple(declared_floor) >= version_tuple(required), (
         f"{pkg_name}: declares '{base_name}>={declared_floor}', but {base_name}'s py.typed marker first shipped "
         f"in {required}; bump config/packages.toml to '{base_name}>={required}' for {pkg_name}"
     )

--- a/tests/test_end2end/test_py_typed_markers.py
+++ b/tests/test_end2end/test_py_typed_markers.py
@@ -32,6 +32,9 @@ _BUNDLES = ["mloda-registry", "mloda-testing", "mloda-community", "mloda-enterpr
 # module path, so the two ancestor markers also type the leaf distributions shipped from below them.
 _TYPED_PACKAGES = [*_BUNDLES, "mloda-community-data-operations", "mloda-community-example"]
 
+# Confirmed by inspecting the published wheels directly: py.typed first appears in each base's 0.4.1 wheel.
+_MARKER_FLOORS = {"mloda-community-data-operations": "0.4.1", "mloda-community-example": "0.4.1"}
+
 
 gen = load_script("generate_pyproject", _GEN_PATH)
 vb = load_script("verify_builds", _VERIFY_BUILDS_PATH)
@@ -183,6 +186,47 @@ def test_every_published_distribution_has_a_typed_ancestor(pkg_name: str) -> Non
         f"{pkg_name} ({pkg_path}) ships untyped: none of its own or dependency-reachable packages carries a "
         f"py.typed at or above that path. It needs either 'py_typed = true' plus a committed "
         f"{pkg_path}/py.typed, or a dependency on a package that already ships an ancestor marker."
+    )
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Plain dotted version to a comparable tuple; declared floors are always X.Y.Z, so no PEP 440 parser needed."""
+    return tuple(int(part) for part in version.split("."))
+
+
+def _declared_floor(dep: str, base_name: str) -> str | None:
+    """The '>=' version floor a dependency string declares on ``base_name``, or None if it names another package."""
+    match = re.match(r"([A-Za-z0-9._-]+)\s*>=\s*([0-9.]+)", dep.strip())
+    if not match:
+        return None
+    name = re.sub(r"[-_.]+", "-", match.group(1)).lower()
+    return match.group(2) if name == base_name else None
+
+
+def _leaves_with_marker_floor_dependency() -> list[tuple[str, str, str]]:
+    """(leaf_pkg_name, base_pkg_name, declared_floor) for every configured, non-typed package depending on one of
+    _MARKER_FLOORS' keys."""
+    packages = _packages()
+    found: list[tuple[str, str, str]] = []
+    for pkg_name, cfg in packages.items():
+        if pkg_name in _TYPED_PACKAGES:
+            continue
+        for dep in cfg.get("dependencies", []):
+            for base_name in _MARKER_FLOORS:
+                floor = _declared_floor(dep, base_name)
+                if floor is not None:
+                    found.append((pkg_name, base_name, floor))
+    return found
+
+
+@pytest.mark.parametrize("pkg_name,base_name,declared_floor", _leaves_with_marker_floor_dependency())
+def test_leaf_dependency_floor_meets_py_typed_marker(pkg_name: str, base_name: str, declared_floor: str) -> None:
+    """A leaf's declared floor on its typed base must be at or above the base release that first shipped py.typed,
+    or an environment can resolve an older, unmarked base and the leaf silently installs untyped."""
+    required = _MARKER_FLOORS[base_name]
+    assert _version_tuple(declared_floor) >= _version_tuple(required), (
+        f"{pkg_name}: declares '{base_name}>={declared_floor}', but {base_name}'s py.typed marker first shipped "
+        f"in {required}; bump config/packages.toml to '{base_name}>={required}' for {pkg_name}"
     )
 
 

--- a/tests/test_end2end/test_verify_floor_installs.py
+++ b/tests/test_end2end/test_verify_floor_installs.py
@@ -16,7 +16,7 @@ else:
 
 import pytest
 
-from tests.script_loader import load_script
+from tests.script_loader import load_script, version_tuple
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT_PATH = _REPO_ROOT / "scripts" / "verify_floor_installs.py"
@@ -54,11 +54,6 @@ def _internal_floor_pairs() -> Callable[[dict[str, dict[str, Any]]], list[Any]]:
 def _load_toml(path: Path) -> dict[str, Any]:
     with open(path, "rb") as f:
         return tomllib.load(f)
-
-
-def _version_tuple(version: str) -> tuple[int, ...]:
-    """Comparable form of a numeric release version."""
-    return tuple(int(part) for part in version.split("."))
 
 
 def _synthetic_packages(
@@ -191,7 +186,7 @@ def test_real_floors_are_numeric_and_at_most_the_workspace_version() -> None:
         assert len(parts) == 3 and all(part.isdigit() for part in parts), (
             f"{pair.package}: floor {pair.floor!r} on {pair.dependency} is not three dot-separated integers"
         )
-        assert _version_tuple(pair.floor) <= _version_tuple(workspace), (
+        assert version_tuple(pair.floor) <= version_tuple(workspace), (
             f"{pair.package}: floors {pair.dependency} at {pair.floor}, above the workspace version {workspace}; "
             "per docs/packaging.md that floor is undeclarable"
         )
@@ -202,7 +197,7 @@ def test_data_operations_floors_point_at_a_released_version() -> None:
     pairs = [pair for pair in _real_pairs() if pair.dependency == _DEP]
     assert pairs, f"expected published leaves flooring {_DEP} in config/packages.toml"
     for pair in pairs:
-        assert _version_tuple(pair.floor) >= _DATA_OPERATIONS_FIRST_RELEASE, (
+        assert version_tuple(pair.floor) >= _DATA_OPERATIONS_FIRST_RELEASE, (
             f"{pair.package}: floors {_DEP} at {pair.floor}, which was never released; the first release "
             "shipping the shared guard helpers is 0.4.0, so an install at the floor could not import"
         )
@@ -228,7 +223,7 @@ def test_example_a_floors_the_oldest_usable_example_release() -> None:
     pairs = [pair for pair in _real_pairs() if pair.package == "mloda-community-example-a"]
     assert pairs, "expected mloda-community-example-a to floor an in-repo distribution"
     for pair in pairs:
-        assert _version_tuple(pair.floor) >= _EXAMPLE_FIRST_RELEASE, (
+        assert version_tuple(pair.floor) >= _EXAMPLE_FIRST_RELEASE, (
             f"mloda-community-example-a: floors {pair.dependency} at {pair.floor}; the oldest usable "
             "mloda-community-example release is 0.2.6"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -380,7 +380,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -430,7 +430,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -538,7 +538,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -582,7 +582,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -638,7 +638,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-example", specifier = ">=0.2.6" },
+    { name = "mloda-community-example", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -660,7 +660,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-example", specifier = ">=0.2.6" },
+    { name = "mloda-community-example", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -726,7 +726,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -772,7 +772,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'", specifier = ">=2.2" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2" },
@@ -816,7 +816,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -860,7 +860,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -908,7 +908,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -954,7 +954,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1002,7 +1002,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1052,7 +1052,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1102,7 +1102,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1152,7 +1152,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1180,7 +1180,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1224,7 +1224,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1274,7 +1274,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },


### PR DESCRIPTION
## Summary

The 17 data-operations leaf packages and the two example leaf packages (`mloda-community-example-a`/`-b`) floor their dependency on their typed base at a version that predates the base's PEP 561 `py.typed` marker. An environment that resolves an older, unmarked base then installs an untyped leaf, and mypy reports a confusing `import-untyped` error pointing at the leaf instead of the real cause (the missing marker in the base).

Verified directly against the published PyPI wheels for both bases: `0.4.0` ships no `py.typed`, `0.4.1` is the first release that does, for both `mloda-community-data-operations` and `mloda-community-example`.

## Changes

- `config/packages.toml`: raised the 17 data-operations leaf floors from `>=0.4.0` to `>=0.4.1`, and the two example leaf floors from `>=0.2.6` to `>=0.4.1`. Updated the explanatory comments to record the py.typed marker release as the binding reason.
- Regenerated the affected `pyproject.toml` files and `uv.lock`. `uv sync --all-extras` still resolves (the new floor sits well below the workspace version).
- Added `test_leaf_dependency_floor_meets_py_typed_marker` to `tests/test_end2end/test_py_typed_markers.py`, parametrized over every leaf discovered from config that depends on a typed base, so a floor below the marker release now fails the test suite instead of only being documented.
- Hardened the new test's dependency-string parsing to reuse `scripts/verify_floor_installs.py`'s existing regexes (covers extras markers and other PEP 508 spellings, not just the exact strings present today), added a guard against the parametrization silently collecting zero cases, and added a companion test pinning the marker-floor set to the typed-package set. Deduplicated a small version-comparison helper shared between two test files.

## Test plan

- [x] `tox` (full gate: pytest, ruff format, ruff check, mypy --strict, bandit) passes
- [x] `uv sync --all-extras` resolves
- [x] `python scripts/generate_pyproject.py` produces no drift