### PR TITLE
docs(feature-group-patterns): document column-wise hook contract

### DIFF
--- a/docs/guides/feature-group-patterns/09-framework-specific.md
+++ b/docs/guides/feature-group-patterns/09-framework-specific.md
@@ -98,6 +98,59 @@ class MyFeaturePolars(MyFeatureBase):
         return {PolarsDataFrame}
 ```
 
+### Column-Wise Data Hooks
+
+A base built on `FeatureChainParserMixin` (Pattern 3) that touches columns directly, rather than returning a whole new frame, owes its framework subclasses the column-wise data hooks its `calculate_feature` calls, drawn from `_get_available_columns`, `_check_source_features_exist`, `_add_result_to_data`. The mixin defines all three as non-abstract classmethods that raise `NotImplementedError` naming the class and hook, so a framework subclass that skips one fails at compute time rather than at class-definition time.
+
+Declare which of the three your base's `calculate_feature` actually calls with `REQUIRED_COLUMNWISE_HOOKS`, normally set to one of two constants from `mloda.provider`:
+
+| Constant | Declares |
+|----------|----------|
+| `COLUMNWISE_HOOKS` | `_check_source_features_exist`, `_add_result_to_data` |
+| `COLUMN_DISCOVERY_HOOKS` | those two plus `_get_available_columns`, for a base that resolves column names against the data |
+
+```python
+from mloda.provider import COLUMN_DISCOVERY_HOOKS, FeatureChainParserMixin, FeatureGroup
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+class MyFeatureBase(FeatureChainParserMixin, FeatureGroup):
+    PREFIX_PATTERN = r"^.+__my_op$"
+    REQUIRED_COLUMNWISE_HOOKS = COLUMN_DISCOVERY_HOOKS
+
+
+class MyFeaturePandas(MyFeatureBase):
+    @classmethod
+    def compute_framework_rule(cls):
+        return {PandasDataFrame}
+
+    @classmethod
+    def _get_available_columns(cls, data):
+        return set(data.columns)
+
+    @classmethod
+    def _check_source_features_exist(cls, data, feature_names):
+        if set(feature_names) - set(data.columns):
+            raise ValueError(f"Missing source features, available: {list(data.columns)}")
+
+    @classmethod
+    def _add_result_to_data(cls, data, feature_name, result):
+        data[feature_name] = result
+        return data
+```
+
+Assert the contract holds in your own test suite instead of discovering a gap mid-run. `missing_columnwise_hooks` only checks the hooks a class declares, so pin the declaration too or a class that never sets `REQUIRED_COLUMNWISE_HOOKS` passes vacuously:
+
+```python
+from mloda.provider import COLUMN_DISCOVERY_HOOKS, missing_columnwise_hooks
+
+def test_my_feature_pandas_implements_its_hooks():
+    assert MyFeaturePandas.REQUIRED_COLUMNWISE_HOOKS == COLUMN_DISCOVERY_HOOKS
+    assert missing_columnwise_hooks(MyFeaturePandas) == []
+```
+
+A hook that is not a `@classmethod` or `@staticmethod` counts as missing: `cls._hook(data, ...)` passes the class into the first parameter, so a plain function never receives the data. Assert `missing_columnwise_hooks` on the framework-bound class, not the base: the base declares the contract but implements none of it itself, so it reports every hook it declares as missing.
+
 ## Combines With
 
 - **Chained** (Pattern 3): Different implementations per framework

--- a/docs/guides/feature-group-patterns/12-calculate-feature.md
+++ b/docs/guides/feature-group-patterns/12-calculate-feature.md
@@ -152,6 +152,8 @@ def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
 
 `_resolve_operation(feature, config_key)` tries string-based parsing via `PREFIX_PATTERN` first, then falls back to `options.get(config_key)`. See [Chained Features](03-chained-features.md) for the full pattern.
 
+A base that writes into the caller's data rather than returning a new frame (Pattern 9) calls the column-wise data hooks from inside `calculate_feature` rather than accessing columns directly. See [Framework-Specific: Column-Wise Data Hooks](09-framework-specific.md#column-wise-data-hooks).
+
 ---
 
 ## Related


### PR DESCRIPTION
Pattern 9 documents the column-wise hook contract that a base built on FeatureChainParserMixin owes its framework subclasses when calculate_feature writes into the caller's data column by column, rather than returning a whole new frame.

Adds a "Column-Wise Data Hooks" section covering:
- the three hooks (_get_available_columns, _check_source_features_exist, _add_result_to_data) and why the mixin raises instead of using @abstractmethod
- the COLUMNWISE_HOOKS / COLUMN_DISCOVERY_HOOKS constants and REQUIRED_COLUMNWISE_HOOKS
- the missing_columnwise_hooks(cls) assertion for a plugin repo's own test suite, including the gap where an undeclared REQUIRED_COLUMNWISE_HOOKS passes vacuously
- why a hook that isn't a classmethod/staticmethod counts as unimplemented

Pattern 12 (calculate_feature) cross-links to the new section from where the hooks are actually invoked.

Docs only, no production code changes: the core dependency floor already ships the mixin-declared contract (mloda>=0.11.0), and none of the current registry feature-group families call these hooks yet.

Closes #367