### PR TITLE
docs: sweep remaining mloda 0.10.0 references now that the floor is 0.11.0

### DIFF
--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -281,7 +281,7 @@ The spec declares the arity, not the caller. For membership and `element_validat
 - An empty container is present and vacuously valid: no element runs, and it still satisfies the required-presence check.
 - Both only see values in `Options`. A `PREFIX_PATTERN` match short-circuits property validation, so membership and `element_validator` never run on a name-parsed value, and `match_guard` is skipped when the option is absent. Constrain the string path with the regex itself (see [Return Data Type Rule](../data-operation-patterns/16-return-data-type-rule.md)).
 
-Migration: before mloda 0.10.0 a sequence was stringified, so a validator received `"('a', 'b')"` and behavior depended on whether the caller typed a list or a tuple. An `element_validator` that inspects a whole container (`isinstance(x, list) and all(...)`) must become a per-element rule, or move to `match_guard` if it genuinely is a whole-value check.
+An `element_validator` that inspects a whole container (`isinstance(x, list) and all(...)`) is a mistake: elements unpack one at a time, so write a per-element rule, or move to `match_guard` for a genuine whole-value check.
 
 ### When to Use Each Validation Approach
 

--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -281,7 +281,7 @@ The spec declares the arity, not the caller. For membership and `element_validat
 - An empty container is present and vacuously valid: no element runs, and it still satisfies the required-presence check.
 - Both only see values in `Options`. A `PREFIX_PATTERN` match short-circuits property validation, so membership and `element_validator` never run on a name-parsed value, and `match_guard` is skipped when the option is absent. Constrain the string path with the regex itself (see [Return Data Type Rule](../data-operation-patterns/16-return-data-type-rule.md)).
 
-An `element_validator` that inspects a whole container (`isinstance(x, list) and all(...)`) is a mistake: elements unpack one at a time, so write a per-element rule, or move to `match_guard` for a genuine whole-value check.
+An `element_validator` that assumes it receives the whole option value (`isinstance(x, list) and all(...)`) is a mistake: elements unpack one at a time, so write a per-element rule, or move to `match_guard` for a genuine whole-value check.
 
 ### When to Use Each Validation Approach
 

--- a/docs/guides/feature-group-patterns/15-filter-concepts.md
+++ b/docs/guides/feature-group-patterns/15-filter-concepts.md
@@ -50,37 +50,6 @@ global_filter.add_filter("status", FilterType.EQUAL, {"value": "active"})
 
 ---
 
-## Known Limitation: Filtering a Column the FeatureGroup Itself Outputs
-
-> **Warning (mloda 0.10.0):** Do not attach a `GlobalFilter` to a column that the producing FeatureGroup itself outputs. `GlobalFilter.unify_options()` copies every option of the requested feature, **context keys included**, into the filter feature's `group`. Since `Options` compares on `group` only, the filter feature no longer matches the requested one: the engine gives it a fresh UUID and schedules it as a separate calculable node. That fails in one of two ways:
->
-> - The filter node runs with everything in `options.group` and an empty `options.context`, so a FeatureGroup that reads its runtime parameters from `options.context` raises (typically a `ValueError` for the missing key).
-> - If the options are passed so the two batches merge, the filter twin displaces the requested feature and the filtered column is silently missing from the result.
->
-> Reproduced on a root FeatureGroup, but nothing in the engine limits it to root groups. Tracked in [mloda#712](https://github.com/mloda-ai/mloda/issues/712).
-
-Until that is fixed, pass the threshold as a plain option and filter inline:
-
-```python
-class RetrievalFeature(FeatureGroup):
-    @classmethod
-    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        max_distance = features.get_options_key("max_distance")
-
-        hits = [h for h in search(...) if h.distance <= max_distance]
-        # Columnar, so an empty hit list still carries the schema.
-        return {
-            "retrieval__doc_id": [h.doc_id for h in hits],
-            "retrieval__distance": [h.distance for h in hits],
-        }
-```
-
-Filtering is the most likely way to produce a legitimately empty result, so a FeatureGroup that filters inline must be able to express "zero rows with schema". See [Empty Results](12-calculate-feature.md#empty-results).
-
-Filtering a FeatureGroup's **input** columns, the normal case shown above, is unaffected.
-
----
-
 ## Time Filters
 
 ```python

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -39,6 +39,7 @@ keeps its own, higher, independent floor: it is the dev-only workspace package,
 is never published, declares no `license`, and its floor is Dependabot-managed.
 
 ```toml
+# Illustrative values; see config/shared.toml for the current ones.
 [project]
 version = "0.4.0"
 requires-python = ">=3.10,<3.15"

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -47,7 +47,7 @@ authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
 
 [defaults]
 license = "Apache-2.0"
-core_dependency = "mloda>=0.10.0,<0.11.0"
+core_dependency = "mloda>=0.11.0,<0.12.0"
 optional_dependencies = { dev = ["mloda-testing", "pytest>=9.0.3"] }
 ```
 


### PR DESCRIPTION
## Summary

A few doc mentions of mloda 0.10.0 were left behind after the registry's core dependency floor moved to `mloda>=0.11.0,<0.12.0`.

- `docs/guides/feature-group-patterns/14-feature-matching.md`: collapsed the "before mloda 0.10.0" migration note to unconditional 0.11.0+ guidance on `element_validator` scope.
- `docs/guides/feature-group-patterns/15-filter-concepts.md`: removed the "Known Limitation" warning about `GlobalFilter` on a FeatureGroup's own output column. The underlying engine bug (mloda#712) was fixed by mloda#715, which shipped in mloda 0.11.0, so the limitation no longer applies at the current floor. Verified against the installed 0.11.0 package and with a live repro of both previously-documented failure modes.
- `docs/packaging.md`: marked the illustrative `config/shared.toml` example as illustrative-only and updated its `core_dependency` value so it matches the current floor.

## Test plan

- [x] `tox -e lint-docs`
- [x] `tox -e registry`
- [x] `tox` (full gate: tests, ruff format/check, mypy --strict, bandit)