### PR TITLE
fix: raise data-operations leaf floors to 0.4.1

### DIFF
--- a/config/packages.toml
+++ b/config/packages.toml
@@ -90,7 +90,8 @@ path = "mloda/enterprise/extenders/example"
 entry_point_groups = ["mloda.extenders"]
 
 # --- Data Operations ---
-# Leaf floors are 0.4.1, the first release shipping the shared guard helpers and the py.typed marker; policy in docs/packaging.md.
+# Leaf floors are 0.4.1, the first release shipping the shared guard helpers and the py.typed
+# marker; policy in docs/packaging.md.
 
 [packages.mloda-community-data-operations]
 description = "Shared base classes for data operation feature groups"

--- a/config/packages.toml
+++ b/config/packages.toml
@@ -90,7 +90,7 @@ path = "mloda/enterprise/extenders/example"
 entry_point_groups = ["mloda.extenders"]
 
 # --- Data Operations ---
-# Leaf floors are 0.4.0, the first release shipping the shared guard helpers; policy in docs/packaging.md.
+# Leaf floors are 0.4.1, the first release shipping the shared guard helpers and the py.typed marker; policy in docs/packaging.md.
 
 [packages.mloda-community-data-operations]
 description = "Shared base classes for data operation feature groups"
@@ -102,7 +102,7 @@ py_typed = true
 
 [packages.mloda-community-aggregation]
 description = "Aggregation feature group (reduce, partition_by, one row per group)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/aggregation"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -110,7 +110,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-rank]
 description = "Rank feature group (row_number, rank, dense_rank, percent_rank, ntile, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/rank"
 published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
@@ -118,7 +118,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-offset]
 description = "Offset feature group (lag, lead, diff, pct_change, first_value, last_value, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/offset"
 published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
@@ -126,7 +126,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-window-aggregation]
 description = "Window aggregation feature group (broadcast, partition_by, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/window_aggregation"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -134,7 +134,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-frame-aggregate]
 description = "Frame aggregate feature group (rolling, cumulative, expanding, time window, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate"
 published = true
 optional_dependencies = { sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas>=2.2"], all = ["polars", "pandas>=2.2", "duckdb"] }
@@ -142,7 +142,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-scalar-aggregate]
 description = "Scalar aggregate feature group (single-column global aggregate broadcast)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -150,7 +150,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-scalar-arithmetic]
 description = "Scalar arithmetic feature group (element-wise column op constant: add, subtract, multiply, divide)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -158,7 +158,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-point-arithmetic]
 description = "Point arithmetic feature group (element-wise two-column op: add, subtract, multiply, divide; PyArrow-reference null/IEEE-754 semantics on divide-by-zero; SQLite returns NULL)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -166,21 +166,21 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-datetime]
 description = "Datetime extraction feature group (element-wise, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/datetime"
 published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-string]
 description = "String operation feature group (element-wise, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/string"
 published = true
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-binning]
 description = "Binning feature group (equal-width, quantile, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/binning"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -188,7 +188,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-percentile]
 description = "Percentile feature group (PERCENTILE_CONT, partition_by, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/percentile"
 published = true
 optional_dependencies = { duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["polars", "pandas", "duckdb"] }
@@ -196,7 +196,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-time-bucketization]
 description = "Time bucketization feature group (floor, ceil, round a timestamp to a bucket interval, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/time_bucketization"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -204,7 +204,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-ffill]
 description = "Forward-fill feature group (ffill a value column across time gaps, per partition, ordered by time, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ffill"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -212,7 +212,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-ema]
 description = "EMA feature group (exponential moving average, adjust=False, null-skipping recurrence, per partition, row-preserving; pandas/polars native, pyarrow/duckdb/sqlite reject)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/ema"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -220,7 +220,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-sessionization]
 description = "Sessionization feature group (gap-threshold session id on an ordered timestamp, per partition, row-preserving)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/sessionization"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
@@ -228,7 +228,7 @@ entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-resample]
 description = "Resample feature group (collapse events onto a regular time grid: floor to bucket, group, aggregate; one row per non-empty bucket, row-changing)"
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 path = "mloda/community/feature_groups/data_operations/row_changing/resample"
 published = true
 optional_dependencies = { pyarrow = ["pyarrow"], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -40,12 +40,12 @@ It sets `MLODA_REGISTRY_VERSION` and runs five tox envs:
 | `verify-floor-installs` | Each package's import surface loads with its internal dependency pinned to the declared floor |
 | `verify-typed-install` | A standalone leaf install is typed under mypy --strict |
 
-`verify-typed-install` stays red until the release that first ships the
-data-operations `py.typed` marker. `verify-floor-installs` is red for any package
-flagged published whose first release has not shipped yet (currently the five
-data-operations leaves first shipping with the next release), the same
+`verify-typed-install` stayed red until the release that first shipped the
+data-operations `py.typed` marker (0.4.1). `verify-floor-installs` is red for any
+package flagged published whose first release has not shipped yet, the same
 fails-until-release pattern `verify-published` has; distinct from the follow-up
-floor-bump red described in [packaging.md](packaging.md#cross-package-dependency-floors).
+floor-bump red described in [packaging.md](packaging.md#cross-package-dependency-floors),
+which recurs whenever a leaf starts importing something newer than its declared floor.
 
 ## Published packages
 

--- a/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/aggregation/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Aggregation feature group (reduce, partition_by, one row per group)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Resample feature group (collapse events onto a regular time grid: floor to bucket, group, aggregate; one row per non-empty bucket, row-changing)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Binning feature group (equal-width, quantile, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Datetime extraction feature group (element-wise, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ema/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "EMA feature group (exponential moving average, adjust=False, null-skipping recurrence, per partition, row-preserving; pandas/polars native, pyarrow/duckdb/sqlite reject)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/ffill/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Forward-fill feature group (ffill a value column across time gaps, per partition, ordered by time, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Frame aggregate feature group (rolling, cumulative, expanding, time window, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Offset feature group (lag, lead, diff, pct_change, first_value, last_value, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Percentile feature group (PERCENTILE_CONT, partition_by, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/point_arithmetic/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Point arithmetic feature group (element-wise two-column op: add, subtract, multiply, divide; PyArrow-reference null/IEEE-754 semantics on divide-by-zero; SQLite returns NULL)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Rank feature group (row_number, rank, dense_rank, percent_rank, ntile, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_aggregate/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Scalar aggregate feature group (single-column global aggregate broadcast)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/scalar_arithmetic/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Scalar arithmetic feature group (element-wise column op constant: add, subtract, multiply, divide)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/sessionization/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Sessionization feature group (gap-threshold session id on an ordered timestamp, per partition, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Time bucketization feature group (floor, ceil, round a timestamp to a bucket interval, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "Window aggregation feature group (broadcast, partition_by, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/mloda/community/feature_groups/data_operations/string/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/string/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.3"
 description = "String operation feature group (element-wise, row-preserving)"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "info@mloda.ai" }]
-dependencies = ["mloda-community-data-operations>=0.4.0"]
+dependencies = ["mloda-community-data-operations>=0.4.1"]
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]

--- a/tests/test_end2end/test_verify_floor_installs.py
+++ b/tests/test_end2end/test_verify_floor_installs.py
@@ -23,8 +23,9 @@ _SCRIPT_PATH = _REPO_ROOT / "scripts" / "verify_floor_installs.py"
 _SHARED_CONFIG = _REPO_ROOT / "config" / "shared.toml"
 _PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
 
-# First data-operations release shipping the shared guard helpers the leaves import; 0.3.3 never shipped.
-_DATA_OPERATIONS_FIRST_RELEASE = (0, 4, 0)
+# First data-operations release shipping the shared guard helpers the leaves import; 0.3.3 never shipped
+# and 0.4.0 predates the helpers.
+_DATA_OPERATIONS_FIRST_RELEASE = (0, 4, 1)
 
 # Oldest usable mloda-community-example release: 0.2.0 through 0.2.3 never reached PyPI, and
 # 0.2.4/0.2.5 lack the base module the variants import.
@@ -198,13 +199,13 @@ def test_real_floors_are_numeric_and_at_most_the_workspace_version() -> None:
 
 
 def test_data_operations_floors_point_at_a_released_version() -> None:
-    """0.3.3 was never released; 0.4.0 first shipped the shared guard helpers the leaves import."""
+    """0.3.3 was never released; 0.4.1 first shipped the shared guard helpers the leaves import."""
     pairs = [pair for pair in _real_pairs() if pair.dependency == _DEP]
     assert pairs, f"expected published leaves flooring {_DEP} in config/packages.toml"
     for pair in pairs:
         assert _version_tuple(pair.floor) >= _DATA_OPERATIONS_FIRST_RELEASE, (
             f"{pair.package}: floors {_DEP} at {pair.floor}, which was never released; the first release "
-            "shipping the shared guard helpers is 0.4.0, so an install at the floor could not import"
+            "shipping the shared guard helpers is 0.4.1, so an install at the floor could not import"
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -380,7 +380,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -430,7 +430,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -538,7 +538,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -582,7 +582,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -726,7 +726,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -772,7 +772,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'", specifier = ">=2.2" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2" },
@@ -816,7 +816,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -860,7 +860,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -908,7 +908,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -954,7 +954,7 @@ polars = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1002,7 +1002,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1052,7 +1052,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1102,7 +1102,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1152,7 +1152,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1180,7 +1180,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
@@ -1224,7 +1224,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },
@@ -1274,7 +1274,7 @@ pyarrow = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "mloda-community-data-operations", specifier = ">=0.4.0" },
+    { name = "mloda-community-data-operations", specifier = ">=0.4.1" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
     { name = "pandas", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'pandas'" },


### PR DESCRIPTION
## Summary

The 17 data-operations leaf packages floor `mloda-community-data-operations` at 0.4.0, but that release predates the shared guard helpers (`option_value`, `is_column_ref`, `is_scalar_number`, `positive_int_value`, `RejectionReasonMixin`, and others) and the `py.typed` marker the leaves now depend on. A floor-pinned install at 0.4.0 fails at import, and is untyped.

0.4.1 is the oldest published release containing every symbol the current leaves import from the data-operations base package, plus the marker. This raises every leaf floor to 0.4.1 and regenerates the pyprojects and lockfile.

Also corrects a stale guard in `tests/test_end2end/test_verify_floor_installs.py` and a stale claim in `docs/releasing.md` that both still named 0.4.0 as the release shipping the guard helpers.

## Verification

- Reproduced the current failure: installing `mloda-community-data-operations==0.4.0` alongside the published leaves raises `ImportError` for `RejectionReasonMixin`, `is_number_element`, and others.
- After the fix, `scripts/verify_floor_installs.py` and `scripts/verify_typed_install.py` both pass against the real published packages.
- Full `tox` gate passes (tests, ruff format/check, mypy --strict, bandit).

## Test plan

- [x] `tox`
- [x] `scripts/verify_floor_installs.py` against the currently published release
- [x] `scripts/verify_typed_install.py` against the currently published release