### PR TITLE
docs: sweep remaining below-floor mloda version qualifiers in guides

### DIFF
--- a/docs/guides/data-operation-patterns/framework-support-matrix.md
+++ b/docs/guides/data-operation-patterns/framework-support-matrix.md
@@ -60,7 +60,7 @@ Unsupported combinations are also rejected at match time when running a pipeline
 
 ## Not in this matrix: joins
 
-This matrix only covers data-operation feature groups (single-source column transforms). Joins are a separate concern handled by the compute frameworks' merge engines in core, not by registry feature groups, so they do not appear above. The **as-of (point-in-time) join** added in mloda 0.8.0 has its own per-backend support table and a worked example in [Links and joins](../feature-group-patterns/08-links-joins.md#as-of-point-in-time-joins).
+This matrix only covers data-operation feature groups (single-source column transforms). Joins are a separate concern handled by the compute frameworks' merge engines in core, not by registry feature groups, so they do not appear above. The **as-of (point-in-time) join** has its own per-backend support table and a worked example in [Links and joins](../feature-group-patterns/08-links-joins.md#as-of-point-in-time-joins).
 
 ---
 

--- a/docs/guides/feature-group-patterns/08-links-joins.md
+++ b/docs/guides/feature-group-patterns/08-links-joins.md
@@ -69,10 +69,10 @@ below for the keyword reference, per-backend support, and a runnable end-to-end 
 ## As-of (point-in-time) joins
 
 A plain `Link.inner()` / `Link.left()` is an equi-join: rows pair up only when their
-join keys are exactly equal. An as-of join adds a per-row time
-match on top of that: for each left row, mloda picks the right row that was valid at
-the left row's timestamp. This is the join that recsys, slowly-changing-dimension
-lookups, and event-vs-state pipelines need, and it cannot be expressed as an equi-join.
+join keys are exactly equal. An as-of join adds a per-row time match on top of that: for
+each left row, mloda picks the right row that was valid at the left row's timestamp.
+This is the join that recsys, slowly-changing-dimension lookups, and event-vs-state
+pipelines need, and it cannot be expressed as an equi-join.
 
 Two matches happen at once:
 
@@ -101,16 +101,16 @@ both factories (`Link.asof(left_spec, right_spec, *, left_time_column=..., ...)`
 |---|---|---|
 | Pandas | yes | Native `pd.merge_asof`. Supports `direction="nearest"` and `timedelta` tolerances. |
 | Polars (lazy) | yes | Native `join_asof`. Supports `direction="nearest"` and `timedelta` tolerances. |
-| PyArrow | yes | Native Acero `Table.join_asof` ([mloda#489](https://github.com/mloda-ai/mloda/pull/489), 0.9.0). Rejects `direction="nearest"`, `allow_exact_matches=False`, and non-integer tolerances (integer only). |
+| PyArrow | yes | Native Acero `Table.join_asof` ([mloda#489](https://github.com/mloda-ai/mloda/pull/489)). Rejects `direction="nearest"`, `allow_exact_matches=False`, and non-integer tolerances (integer only). |
 | DuckDB | yes | SQL `ASOF JOIN`. Rejects `direction="nearest"` and a `timedelta` tolerance with a `ValueError`; pass a numeric tolerance instead. |
 | SQLite | yes | SQL window functions. Same restriction as DuckDB: no `nearest`, numeric tolerance only. |
 
 `direction="nearest"` and `timedelta` tolerances work only on the Pandas and Polars
 backends; PyArrow and the SQL backends reject them (see the table). Two guards apply to
-every backend: as-of time columns must be ordered, so a non-ordered
-(e.g. string) column raises a clear `ValueError` naming it
-([mloda#529](https://github.com/mloda-ai/mloda/pull/529)); and `coerce_time_columns=True`
-opts in to coercing ISO-8601 string columns per backend
+every backend: as-of time columns must be ordered, so a non-ordered (e.g. string) column
+raises a clear `ValueError` naming it
+([mloda#529](https://github.com/mloda-ai/mloda/pull/529)); and
+`coerce_time_columns=True` opts in to coercing ISO-8601 string columns per backend
 ([mloda#548](https://github.com/mloda-ai/mloda/pull/548)).
 
 ### Defining the link

--- a/docs/guides/feature-group-patterns/08-links-joins.md
+++ b/docs/guides/feature-group-patterns/08-links-joins.md
@@ -69,7 +69,7 @@ below for the keyword reference, per-backend support, and a runnable end-to-end 
 ## As-of (point-in-time) joins
 
 A plain `Link.inner()` / `Link.left()` is an equi-join: rows pair up only when their
-join keys are exactly equal. An as-of join (added in mloda 0.8.0) adds a per-row time
+join keys are exactly equal. An as-of join adds a per-row time
 match on top of that: for each left row, mloda picks the right row that was valid at
 the left row's timestamp. This is the join that recsys, slowly-changing-dimension
 lookups, and event-vs-state pipelines need, and it cannot be expressed as an equi-join.
@@ -107,7 +107,7 @@ both factories (`Link.asof(left_spec, right_spec, *, left_time_column=..., ...)`
 
 `direction="nearest"` and `timedelta` tolerances work only on the Pandas and Polars
 backends; PyArrow and the SQL backends reject them (see the table). Two guards apply to
-every backend (mloda 0.9.0): as-of time columns must be ordered, so a non-ordered
+every backend: as-of time columns must be ordered, so a non-ordered
 (e.g. string) column raises a clear `ValueError` naming it
 ([mloda#529](https://github.com/mloda-ai/mloda/pull/529)); and `coerce_time_columns=True`
 opts in to coercing ISO-8601 string columns per backend

--- a/docs/guides/feature-group-patterns/12-calculate-feature.md
+++ b/docs/guides/feature-group-patterns/12-calculate-feature.md
@@ -66,7 +66,7 @@ Every framework above also accepts a columnar `dict[str, list]` as the whole-fra
 
 ### PythonDictFramework Is Columnar
 
-The native structure is columnar `dict[str, list[Any]]`: one key per column, all value-lists the same length.
+PythonDictFramework's native structure is columnar `dict[str, list[Any]]`: one key per column, all value-lists the same length.
 
 ```python
 @classmethod

--- a/docs/guides/feature-group-patterns/12-calculate-feature.md
+++ b/docs/guides/feature-group-patterns/12-calculate-feature.md
@@ -66,7 +66,7 @@ Every framework above also accepts a columnar `dict[str, list]` as the whole-fra
 
 ### PythonDictFramework Is Columnar
 
-Since mloda 0.9.0 the native structure is columnar `dict[str, list[Any]]`: one key per column, all value-lists the same length.
+The native structure is columnar `dict[str, list[Any]]`: one key per column, all value-lists the same length.
 
 ```python
 @classmethod

--- a/docs/guides/feature-group-patterns/17-data-connection-matching.md
+++ b/docs/guides/feature-group-patterns/17-data-connection-matching.md
@@ -57,7 +57,7 @@ class CsvFeature(FeatureGroup):
     ) -> bool:
         if data_access_collection is None or not data_access_collection.folders:
             return False
-        # `folders` is a dict[handle, path] in mloda 0.7.0+; iterate `.values()`
+        # `folders` is a dict[handle, path]; iterate `.values()`
         # for the path (iterating the dict directly yields handle names).
         options.set("_data_folder", next(iter(data_access_collection.folders.values())))
         return True
@@ -77,7 +77,7 @@ The `options` parameter is required. For the full reader-selection contract
 
 ## Named Handles and Multi-Source Disambiguation
 
-Since mloda 0.7.0, `DataAccessCollection` registers each resource under a stable
+`DataAccessCollection` registers each resource under a stable
 **handle**. Pass a `dict[handle, value]` to name resources explicitly; a `set`/`list`
 still works and auto-assigns internal handles.
 
@@ -123,7 +123,7 @@ binding the wrong source.
 
 Credentials are a resource kind alongside connections, files, and folders, but with
 one twist: a credential *is* a dict, so a bare `{connector_id: slot}` dict collides
-with the named `{handle: value}` form. Since mloda 0.9.0, wrap each credential slot
+with the named `{handle: value}` form. Wrap each credential slot
 in the typed `Credential` class so the meaning comes from the type, not the nesting
 depth:
 

--- a/docs/guides/feature-group-patterns/17-data-connection-matching.md
+++ b/docs/guides/feature-group-patterns/17-data-connection-matching.md
@@ -57,8 +57,8 @@ class CsvFeature(FeatureGroup):
     ) -> bool:
         if data_access_collection is None or not data_access_collection.folders:
             return False
-        # `folders` is a dict[handle, path]; iterate `.values()`
-        # for the path (iterating the dict directly yields handle names).
+        # `folders` is a dict[handle, path]; iterate `.values()` for the path (iterating
+        # the dict directly yields handle names).
         options.set("_data_folder", next(iter(data_access_collection.folders.values())))
         return True
 ```
@@ -77,9 +77,9 @@ The `options` parameter is required. For the full reader-selection contract
 
 ## Named Handles and Multi-Source Disambiguation
 
-`DataAccessCollection` registers each resource under a stable
-**handle**. Pass a `dict[handle, value]` to name resources explicitly; a `set`/`list`
-still works and auto-assigns internal handles.
+`DataAccessCollection` registers each resource under a stable **handle**. Pass a
+`dict[handle, value]` to name resources explicitly; a `set`/`list` still works and
+auto-assigns internal handles.
 
 ```python
 from mloda.user import DataAccessCollection
@@ -121,11 +121,10 @@ binding the wrong source.
 
 ## Credentials
 
-Credentials are a resource kind alongside connections, files, and folders, but with
-one twist: a credential *is* a dict, so a bare `{connector_id: slot}` dict collides
-with the named `{handle: value}` form. Wrap each credential slot
-in the typed `Credential` class so the meaning comes from the type, not the nesting
-depth:
+Credentials are a resource kind alongside connections, files, and folders, but with one
+twist: a credential *is* a dict, so a bare `{connector_id: slot}` dict collides with the
+named `{handle: value}` form. Wrap each credential slot in the typed `Credential` class
+so the meaning comes from the type, not the nesting depth:
 
 ```python
 from mloda.user import Credential, DataAccessCollection

--- a/docs/guides/feature-group-patterns/26-input-feature-forwarding.md
+++ b/docs/guides/feature-group-patterns/26-input-feature-forwarding.md
@@ -45,6 +45,8 @@ Set these on the `Feature(...)` you return from `input_features()`:
 
 `forward_group=False` combined with a non-empty `forward_group_exclude` is contradictory and raises `ValueError`.
 
+`feature_chainer_parser_key` carries no special meaning here: a leftover key from an older integration forwards like any other group option and can trigger the "extra group option(s)" rejection above if the upstream does not recognize it.
+
 ## Worked Example: A Connector Consuming a Source Feature
 
 `GraphRagConnector` runs a query against a knowledge graph. It consumes the `knowledge_graph` root feature published by a different group. The connector accepts a `backend` selector (which the upstream also understands, so it *should* forward) and a `top_k` (purely consumer-local, which the upstream rejects, so it must **not** forward).

--- a/docs/guides/feature-group-patterns/26-input-feature-forwarding.md
+++ b/docs/guides/feature-group-patterns/26-input-feature-forwarding.md
@@ -8,8 +8,6 @@ When a feature group declares **another group's** feature in `input_features()`,
 **Where**: `input_features()` return values, on the `Feature(...)` objects you construct there.
 **How**: Leave children at the default to inherit everything, or use the typed opt-outs `forward_group`, `forward_group_exclude`, and the context pull/push pair `inherit_context_keys` / `propagate_context_keys`.
 
-> Requires `mloda>=0.9.0`. Earlier releases used a `feature_chainer_parser_key` denylist shield that is removed in 0.9.0; do not use it. The API below is the replacement.
-
 ## The Default: Group Options Forward
 
 A consumer's **group** options flow onto every input feature by default. **Context** options never flow through this forwarding merge (the one exception is a bare-string child, which shares the consumer's `Options` outright: see the caveat below). `in_features` itself never flows.


### PR DESCRIPTION
## Summary

Collapses the remaining version-gated mentions in the pattern guides naming an mloda release below the current dependency floor (`mloda>=0.11.0,<0.12.0`) to unconditional current-floor wording, the same class of cleanup as the prior 0.10.0 sweep.

## Changes

- `docs/guides/feature-group-patterns/26-input-feature-forwarding.md`: drop the `Requires mloda>=0.9.0` note; the migration guidance it carried no longer applies at the current floor, but a leftover-key caveat is kept since it is still accurate.
- `docs/guides/feature-group-patterns/12-calculate-feature.md`: drop the `Since mloda 0.9.0` prefix from the columnar-structure note.
- `docs/guides/feature-group-patterns/17-data-connection-matching.md`: drop the `mloda 0.7.0+` / `Since mloda 0.7.0` / `Since mloda 0.9.0` qualifiers on the folders, handle, and Credential notes.
- `docs/guides/feature-group-patterns/08-links-joins.md`: drop the `added in mloda 0.8.0` and `(mloda 0.9.0)` notes on the as-of join sections, and the same class `0.9.0` tag on the PyArrow PR link.
- `docs/guides/data-operation-patterns/framework-support-matrix.md`: drop the `added in mloda 0.8.0` note on the as-of join pointer.

Wrapped paragraphs touched by the edits are reflowed to the surrounding line width.

## Test plan

- [x] `tox -e lint-docs` passes