### PR TITLE
fix(resample): validate options in_feature count and forwarded resample_op mismatch

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -128,8 +128,10 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
     # unit/agg. [a-z]+ (not \w+) keeps unit and agg disjoint from the "_" separator, so there is exactly
     # one way to split the token and no catastrophic backtracking. n=0 and an unknown unit/agg (e.g.
     # "century", "median") still match the pattern; _validate_string_match narrows via _parse_resample_op,
-    # which already enumerates the valid units/aggs and rejects n<=0 (mirrors time_bucketization).
-    PREFIX_PATTERN = r".*__resample_((?:[1-9]\d*|0)_[a-z]+_[a-z]+)$"
+    # which already enumerates the valid units/aggs and rejects n<=0 (mirrors time_bucketization). Named
+    # so FeatureChainParser.bind_name_captures binds it to resample_op, enabling the forwarded-value vs.
+    # name-parsed-value mismatch check in _validate_forwarded_name_mismatch.
+    PREFIX_PATTERN = r".*__resample_(?P<resample_op>(?:[1-9]\d*|0)_[a-z]+_[a-z]+)$"
 
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
@@ -168,12 +170,14 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return True
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        _feature_name = str(feature_name)
         prefix_patterns = self._get_prefix_patterns()
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(str(feature_name), prefix_patterns)
+        operation_config, source_feature = FeatureChainParser.parse_feature_name(_feature_name, prefix_patterns)
         if operation_config and source_feature:
             return {Feature(source_feature)}
 
         in_features_set = options.get_in_features()
+        self._validate_in_feature_count(list(in_features_set), _feature_name)
         return set(in_features_set)
 
     # -- Name / token parsing ----------------------------------------------

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -124,20 +124,20 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
     floor + group-by + aggregate) and the two presence guards.
     """
 
-    # Broad capture: 0 or a positive integer with no leading zero, then two lowercase-letter runs for
-    # unit/agg. [a-z]+ (not \w+) keeps unit and agg disjoint from the "_" separator, so there is exactly
-    # one way to split the token and no catastrophic backtracking. n=0 and an unknown unit/agg (e.g.
-    # "century", "median") still match the pattern; _validate_string_match narrows via _parse_resample_op,
-    # which already enumerates the valid units/aggs and rejects n<=0 (mirrors time_bucketization).
-    # Named "resample_op" so bind_name_captures can feed it into the forwarded-value mismatch check.
-    PREFIX_PATTERN = r".*__resample_(?P<resample_op>(?:[1-9]\d*|0)_[a-z]+_[a-z]+)$"
-
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
     PARTITION_BY = "partition_by"
     TIME_COLUMN = "time_column"
     RESAMPLE_OP = "resample_op"
+
+    # Broad capture: 0 or a positive integer with no leading zero, then two lowercase-letter runs for
+    # unit/agg. [a-z]+ (not \w+) keeps unit and agg disjoint from the "_" separator, so there is exactly
+    # one way to split the token and no catastrophic backtracking. n=0 and an unknown unit/agg (e.g.
+    # "century", "median") still match the pattern; _validate_string_match narrows via _parse_resample_op,
+    # which already enumerates the valid units/aggs and rejects n<=0 (mirrors time_bucketization). Named
+    # after RESAMPLE_OP so bind_name_captures can feed it into the forwarded-value mismatch check.
+    PREFIX_PATTERN = rf".*__resample_(?P<{RESAMPLE_OP}>(?:[1-9]\d*|0)_[a-z]+_[a-z]+)$"
 
     PROPERTY_MAPPING = {
         DefaultOptionKeys.in_features: property_spec(
@@ -155,7 +155,6 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
         RESAMPLE_OP: property_spec(
             "Resample token '{n}_{unit}_{agg}' (e.g. '1_hour_mean') when the op is not encoded in the feature name.",
             match_guard=_is_valid_resample_op,
-            deferred_binding=True,
         ),
     }
 

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/base.py
@@ -128,9 +128,8 @@ class ResampleFeatureGroup(RejectionReasonMixin, FeatureGroup):
     # unit/agg. [a-z]+ (not \w+) keeps unit and agg disjoint from the "_" separator, so there is exactly
     # one way to split the token and no catastrophic backtracking. n=0 and an unknown unit/agg (e.g.
     # "century", "median") still match the pattern; _validate_string_match narrows via _parse_resample_op,
-    # which already enumerates the valid units/aggs and rejects n<=0 (mirrors time_bucketization). Named
-    # so FeatureChainParser.bind_name_captures binds it to resample_op, enabling the forwarded-value vs.
-    # name-parsed-value mismatch check in _validate_forwarded_name_mismatch.
+    # which already enumerates the valid units/aggs and rejects n<=0 (mirrors time_bucketization).
+    # Named "resample_op" so bind_name_captures can feed it into the forwarded-value mismatch check.
     PREFIX_PATTERN = r".*__resample_(?P<resample_op>(?:[1-9]\d*|0)_[a-z]+_[a-z]+)$"
 
     MIN_IN_FEATURES = 1

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.match_validation import MatchValidationTestBase, TokenCase
 from mloda.user import DataType, Feature
@@ -86,6 +87,42 @@ class TestResampleOpConfig:
 
     def test_resample_op_in_property_mapping(self) -> None:
         assert ResampleFeatureGroup.RESAMPLE_OP in ResampleFeatureGroup.PROPERTY_MAPPING
+
+
+class TestOptionsPathInFeatureCount:
+    """The options-based fallback in ``input_features`` must validate in_feature count like the name path."""
+
+    def test_input_features_rejects_multiple_option_in_features(self) -> None:
+        options = Options(
+            context={
+                "resample_op": "1_hour_mean",
+                "time_column": "timestamp",
+                "in_features": ["value_a", "value_b"],
+            }
+        )
+        instance = ResampleFeatureGroup()
+        with pytest.raises(ValueError, match="at most 1"):
+            instance.input_features(options, FeatureName("my_result"))
+
+
+class TestForwardedResampleOpMismatch:
+    """A forwarded ``resample_op`` that contradicts the name-parsed op must be rejected, not silently ignored."""
+
+    def test_mismatched_forwarded_resample_op_raises(self) -> None:
+        consumer_options = Options(group={"resample_op": "2_hour_sum"})
+        child_options = Options(context={"time_column": "timestamp"})
+        child_options.inherit_from(consumer_options)
+
+        with pytest.raises(ValueError, match="resample_op"):
+            ResampleFeatureGroup.match_feature_group_criteria("value__resample_1_hour_mean", child_options, None)
+
+    def test_matching_forwarded_resample_op_is_accepted(self) -> None:
+        consumer_options = Options(group={"resample_op": "1_hour_mean"})
+        child_options = Options(context={"time_column": "timestamp"})
+        child_options.inherit_from(consumer_options)
+
+        result = ResampleFeatureGroup.match_feature_group_criteria("value__resample_1_hour_mean", child_options, None)
+        assert result is True
 
 
 class TestResampleMatchValidation(MatchValidationTestBase):

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_base.py
@@ -106,7 +106,7 @@ class TestOptionsPathInFeatureCount:
 
 
 class TestForwardedResampleOpMismatch:
-    """A forwarded ``resample_op`` that contradicts the name-parsed op must be rejected, not silently ignored."""
+    """A group-forwarded ``resample_op`` that contradicts the name-parsed op must be rejected, not silently ignored."""
 
     def test_mismatched_forwarded_resample_op_raises(self) -> None:
         consumer_options = Options(group={"resample_op": "2_hour_sum"})


### PR DESCRIPTION
## Summary

ResampleFeatureGroup had two related gaps in how it handled input options:

- `input_features`'s config-based fallback (used when the feature name does not resolve a source column) skipped `_validate_in_feature_count`, unlike the sibling `TimeBucketizationFeatureGroup`. Supplying more than the single allowed source column via `in_features` options was silently accepted.
- `PREFIX_PATTERN`'s `resample_op` capture was positional (unnamed), so core's `bind_name_captures` never bound it to the `resample_op` PROPERTY_MAPPING key. That meant core's forwarded-value-vs-name-mismatch protection never fired for `resample_op`: a consumer-forwarded value that disagreed with what the feature name parsed to was silently ignored, with the name always winning.

## Changes

- `input_features` now calls `self._validate_in_feature_count(...)` on the options-based fallback path, matching the name-based path and `time_bucketization`.
- `PREFIX_PATTERN`'s capture group is now named `(?P<resample_op>...)`, interpolated from the `RESAMPLE_OP` constant so the two cannot drift apart. This lets `bind_name_captures` bind the name-parsed op, enabling the mismatch check. The now-redundant `deferred_binding=True` on the `resample_op` PROPERTY_MAPPING entry is removed, since the key is now bound via the name capture (keeping it would have silently masked a future regression if the capture group were ever renamed).
- Two new tests cover both gaps directly.

## Test plan

- [x] `pytest mloda/community/feature_groups/data_operations/` (4526 passed)
- [x] `tox` (full gate: pytest, ruff format, ruff check, mypy --strict, bandit)