### PR TITLE
fix: reject empty partition_by across window aggregation, offset, rank, and percentile

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -233,6 +233,10 @@ class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
             source_col = source_features[0]
             offset_type = cls._extract_offset_type(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)
+            if not partition_by:
+                raise ValueError(
+                    f"offset requires a non-empty partition_by, got {partition_by!r} for feature {feature_name!r}."
+                )
             # Any: matching requires order_by, but a direct call still passes an absent one through.
             order_by: Any = option_value(feature.options, cls.ORDER_BY, column_ref_value)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -233,10 +233,11 @@ class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
             source_col = source_features[0]
             offset_type = cls._extract_offset_type(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)
-            if not partition_by:
+            if not isinstance(partition_by, (list, tuple)) or not partition_by:
                 raise ValueError(
                     f"offset requires a non-empty partition_by, got {partition_by!r} for feature {feature_name!r}."
                 )
+            partition_by = list(partition_by)
             # Any: matching requires order_by, but a direct call still passes an absent one through.
             order_by: Any = option_value(feature.options, cls.ORDER_BY, column_ref_value)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
@@ -252,6 +252,11 @@ class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
             source_col = source_features[0]
             percentile = cls._extract_percentile(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)
+            if not isinstance(partition_by, (list, tuple)) or not partition_by:
+                raise ValueError(
+                    f"percentile requires a non-empty partition_by, got {partition_by!r} for feature {feature_name!r}."
+                )
+            partition_by = list(partition_by)
             mask_spec = parse_mask_spec(feature.options.get(MASK_KEY))
 
             table = cls._compute_percentile(table, feature_name, source_col, partition_by, percentile, mask_spec)

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -284,6 +284,10 @@ class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup
 
             rank_type = cls._extract_rank_type(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)
+            if not partition_by:
+                raise ValueError(
+                    f"rank requires a non-empty partition_by, got {partition_by!r} for feature {feature_name!r}."
+                )
             # Any: matching requires order_by, but a direct call still passes an absent one through.
             order_by: Any = option_value(feature.options, cls.ORDER_BY, column_ref_value)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -284,10 +284,11 @@ class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup
 
             rank_type = cls._extract_rank_type(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)
-            if not partition_by:
+            if not isinstance(partition_by, (list, tuple)) or not partition_by:
                 raise ValueError(
                     f"rank requires a non-empty partition_by, got {partition_by!r} for feature {feature_name!r}."
                 )
+            partition_by = list(partition_by)
             # Any: matching requires order_by, but a direct call still passes an absent one through.
             order_by: Any = option_value(feature.options, cls.ORDER_BY, column_ref_value)
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -207,6 +207,11 @@ class WindowAggregationFeatureGroup(AggregationFeatureGroupBase):
             source_col = source_features[0]
             agg_type = cls._extract_aggregation_type(feature)
             partition_by = feature.options.get(cls.PARTITION_BY)
+            if not isinstance(partition_by, (list, tuple)) or not partition_by:
+                raise ValueError(
+                    f"window_aggregation requires a non-empty partition_by, got {partition_by!r} for feature {feature_name!r}."
+                )
+            partition_by = list(partition_by)
             order_by = option_value(feature.options, cls.ORDER_BY, column_ref_value)
             mask_spec = parse_mask_spec(feature.options.get(MASK_KEY))
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/base.py
@@ -164,6 +164,8 @@ class WindowAggregationFeatureGroup(AggregationFeatureGroupBase):
         partition_by = options.get(cls.PARTITION_BY)
         if not isinstance(partition_by, (list, tuple)):
             return False
+        if not partition_by:
+            return False
         if not all(isinstance(item, str) for item in partition_by):
             return False
 

--- a/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/window_aggregation/tests/test_base.py
@@ -172,6 +172,14 @@ class TestConfigValidation:
         result = WindowAggregationFeatureGroup.match_feature_group_criteria(feature_name, options, None)
         assert result is expected
 
+    def test_partition_by_rejects_empty_list(self) -> None:
+        options = Options(context={"partition_by": []})
+        assert not WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__sum_window", options, None)
+
+    def test_partition_by_rejects_empty_tuple(self) -> None:
+        options = Options(context={"partition_by": ()})
+        assert not WindowAggregationFeatureGroup.match_feature_group_criteria("value_int__sum_window", options, None)
+
 
 class TestConfigBasedFeatures:
     """Tests for configuration-based feature matching (non-string features)."""

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -315,6 +315,25 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         with pytest.raises((ValueError, KeyError)):
             self.implementation_class().calculate_feature(self.test_data, fs)
 
+    def test_partition_by_empty_raises(self) -> None:
+        """Calling calculate_feature directly with partition_by=[] should raise a clear ValueError."""
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+        from mloda.user import Feature
+
+        feature = Feature(
+            "value_int__lag_1_offset",
+            options=Options(
+                context={
+                    "partition_by": [],
+                    "order_by": "value_int",
+                }
+            ),
+        )
+        fs = FeatureSet()
+        fs.add(feature)
+        with pytest.raises(ValueError):
+            self.implementation_class().calculate_feature(self.test_data, fs)
+
     # -- Matching tests -------------------------------------------------------
 
     def test_match_rejects_empty_partition_by(self) -> None:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/offset/offset.py
@@ -331,7 +331,7 @@ class OffsetTestBase(ReservedColumnsTestMixin, DataOpsTestBase):
         )
         fs = FeatureSet()
         fs.add(feature)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="non-empty partition_by"):
             self.implementation_class().calculate_feature(self.test_data, fs)
 
     # -- Matching tests -------------------------------------------------------

--- a/mloda/testing/feature_groups/data_operations/row_preserving/percentile/percentile.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/percentile/percentile.py
@@ -273,6 +273,23 @@ class PercentileTestBase(MaskTestMixin, DataOpsTestBase):
         with pytest.raises(ValueError, match="at most 1"):
             self.implementation_class().calculate_feature(self.test_data, fs)
 
+    def test_partition_by_empty_raises(self) -> None:
+        """calculate_feature must reject an empty partition_by with a clear ValueError naming it."""
+        feature = Feature(
+            "my_result",
+            options=Options(
+                context={
+                    "percentile": 0.5,
+                    "in_features": "value_int",
+                    "partition_by": [],
+                }
+            ),
+        )
+        fs = FeatureSet()
+        fs.add(feature)
+        with pytest.raises(ValueError, match="non-empty partition_by"):
+            self.implementation_class().calculate_feature(self.test_data, fs)
+
     # -- Null consistency tests (multi-null columns) ---------------------------
 
     def test_multi_null_column_p50(self) -> None:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
@@ -439,7 +439,7 @@ class RankTestBase(DataOpsTestBase):
         )
         fs = FeatureSet()
         fs.add(feature)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="non-empty partition_by"):
             self.implementation_class().calculate_feature(self.test_data, fs)
 
     # -- Tier 3: Partition / order_by null tests ------------------------------

--- a/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/rank/rank.py
@@ -422,6 +422,26 @@ class RankTestBase(DataOpsTestBase):
         with pytest.raises((ValueError, KeyError)):
             self.implementation_class().calculate_feature(self.test_data, fs)
 
+    def test_partition_by_empty_raises(self) -> None:
+        """Calling calculate_feature directly with partition_by=[] should raise a clear ValueError."""
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+        from mloda.core.abstract_plugins.components.options import Options
+        from mloda.user import Feature
+
+        feature = Feature(
+            "value_int__row_number_ranked",
+            options=Options(
+                context={
+                    "partition_by": [],
+                    "order_by": "value_int",
+                }
+            ),
+        )
+        fs = FeatureSet()
+        fs.add(feature)
+        with pytest.raises(ValueError):
+            self.implementation_class().calculate_feature(self.test_data, fs)
+
     # -- Tier 3: Partition / order_by null tests ------------------------------
 
     def test_null_partition_key_rank(self) -> None:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -824,6 +824,20 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
         valid_options = Options(context={"partition_by": ["region"]})
         assert self.implementation_class().match_feature_group_criteria("value_int__sum_window", valid_options, None)
 
+    def test_partition_by_empty_raises(self) -> None:
+        """Calling calculate_feature directly with partition_by=[] should raise a clear ValueError naming it."""
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+        from mloda.user import Feature
+
+        feature = Feature(
+            "value_int__sum_window",
+            options=Options(context={"partition_by": []}),
+        )
+        fs = FeatureSet()
+        fs.add(feature)
+        with pytest.raises(ValueError, match="non-empty partition_by"):
+            self.implementation_class().calculate_feature(self.test_data, fs)
+
     # -- Row-order preservation ------------------------------------------------
 
     def test_row_order_preserved_first(self) -> None:

--- a/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
+++ b/mloda/testing/feature_groups/data_operations/row_preserving/window_aggregation/window_aggregation.py
@@ -17,6 +17,7 @@ from typing import Any
 import pyarrow as pa
 import pytest
 
+from mloda.core.abstract_plugins.components.options import Options
 from mloda.testing.feature_groups.data_operations.base import DataOpsTestBase
 from mloda.testing.feature_groups.data_operations.helpers import make_feature_set
 from mloda.testing.feature_groups.data_operations.mixins.mask import MaskTestMixin
@@ -776,7 +777,6 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
     def test_option_based_sum_window(self) -> None:
         """Option-based configuration (not string pattern) produces the same result."""
         from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-        from mloda.core.abstract_plugins.components.options import Options
         from mloda.user import Feature
 
         feature = Feature(
@@ -799,7 +799,6 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
     def test_unsupported_aggregation_type_raises(self) -> None:
         """Calling calculate_feature with an unknown aggregation type should raise."""
         from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-        from mloda.core.abstract_plugins.components.options import Options
         from mloda.user import Feature
 
         feature = Feature(
@@ -814,6 +813,16 @@ class WindowAggregationTestBase(ReservedColumnsTestMixin, MaskTestMixin, DataOps
         fs.add(feature)
         with pytest.raises((ValueError, KeyError)):
             self.implementation_class().calculate_feature(self.test_data, fs)
+
+    # -- Matching tests -------------------------------------------------------
+
+    def test_match_rejects_empty_partition_by(self) -> None:
+        """Empty partition_by must be rejected at match time, not reach backend-specific compute."""
+        options = Options(context={"partition_by": [], "order_by": "value_int"})
+        assert not self.implementation_class().match_feature_group_criteria("value_int__sum_window", options, None)
+
+        valid_options = Options(context={"partition_by": ["region"]})
+        assert self.implementation_class().match_feature_group_criteria("value_int__sum_window", valid_options, None)
 
     # -- Row-order preservation ------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `WindowAggregationFeatureGroup.match_feature_group_criteria` now rejects an explicitly empty `partition_by`, matching its own docs and the existing rank/offset behavior.
- `OffsetFeatureGroup`, `RankFeatureGroup`, `WindowAggregationFeatureGroup`, and `PercentileFeatureGroup` now all validate `partition_by` inside `calculate_feature` itself (non-list/tuple or empty raises a clear `ValueError`), so a direct call that bypasses match-time resolution no longer reaches backend-specific breakage (silent whole-table windows on DuckDB/SQLite, unrelated internal errors on pandas/polars).

## Test plan

- [x] Full `tox` (pytest, ruff format, ruff check, mypy --strict, bandit) passes clean.
- [x] Per-backend regression tests added for every guard (pandas, polars, duckdb, sqlite, pyarrow as applicable per family).