### PR TITLE
docs(guides): document ClassVar annotation for PROPERTY_MAPPING and mutable class defaults

### DIFF
--- a/docs/guides/feature-group-patterns/03-chained-features.md
+++ b/docs/guides/feature-group-patterns/03-chained-features.md
@@ -69,6 +69,8 @@ class MeanImputedFeature(FeatureChainParserMixin, FeatureGroup):
 
 > **Manual alternative**: Before `_resolve_operation()`, plugins called `FeatureChainParser.parse_feature_name()` directly and handled the options fallback themselves. The helper handles this dual-path lookup automatically, so prefer `_resolve_operation()` in new code.
 
+> **Linting**: `PROPERTY_MAPPING` and other mutable class-level defaults trip ruff `RUF012` unless annotated `ClassVar`. See [Options: Annotate with ClassVar](11-options.md#annotate-with-classvar).
+
 ## Usage
 
 ```python

--- a/docs/guides/feature-group-patterns/11-options.md
+++ b/docs/guides/feature-group-patterns/11-options.md
@@ -108,6 +108,24 @@ Omitting `default` declares no default, so the key is required; `default=None` d
 
 A spec validates itself when it is built, so a `strict=True` `default` outside the accepted set (or one the key's `element_validator` rejects) raises `ValueError` from the `property_spec(...)` call, not from the `FeatureGroup` class definition that reads the mapping. The message names the spec's explanation and the rejected default. A `default` of `None` is exempt (the conventional "unset" sentinel), and the check is a no-op under `strict=False`.
 
+### Annotate with ClassVar
+
+`FeatureGroup` declares `PROPERTY_MAPPING: ClassVar[...]`, but ruff's `RUF012` (mutable class defaults) does not follow inheritance across files, so a plain `PROPERTY_MAPPING = {...}` in a subclass still trips it once that rule is enabled. Annotate the assignment:
+
+```python
+from typing import ClassVar
+
+from mloda.provider import FeatureGroup, property_spec
+
+
+class ArithmeticFeature(FeatureGroup):
+    PROPERTY_MAPPING: ClassVar = {
+        "operation_type": property_spec("Arithmetic operation", context=False),
+    }
+```
+
+A bare `ClassVar` is enough: `mypy --strict` infers `dict[str, PropertySpec]` from the initializer, so no `PropertySpec` import is needed just for the annotation. Apply the same to any other mutable class-level default on a plugin class, such as a backend registry dict or a set of supported methods.
+
 ## Validation and Conditional Requirements
 
 When using `PROPERTY_MAPPING` with `FeatureChainParserMixin`, you can declare validation rules and conditional requirements directly on option entries:


### PR DESCRIPTION
## Summary

Ruff's `RUF012` (mutable class defaults) does not follow inheritance across files, so a plugin subclass that writes `PROPERTY_MAPPING = {...}` trips the rule as soon as it is enabled, even though `FeatureGroup` already declares the attribute as `ClassVar`. The guides did not cover this, so plugin authors had to work the pattern out from core source.

## Changes

- `docs/guides/feature-group-patterns/11-options.md`: new subsection "Annotate with ClassVar" showing `PROPERTY_MAPPING: ClassVar = {...}` on a `FeatureGroup` subclass. A bare `ClassVar` suffices; `mypy --strict` infers `dict[str, PropertySpec]` from the initializer, so no extra `PropertySpec` import is needed. The same applies to backend registry dicts and method sets.
- `docs/guides/feature-group-patterns/03-chained-features.md`: one-line linting note after the first `PROPERTY_MAPPING` example, linking to the new subsection.

The snippet was checked verbatim: `ruff check --select RUF012` is clean, `mypy --strict` passes, and the class definition executes. `scripts/lint_docs.py` passes.

Closes #435
