### PR TITLE
fix: close forwarded-op mismatch gap in time_bucketization, rank, offset, percentile

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/base.py
@@ -110,14 +110,16 @@ class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
     - ``order_by``: Column to order by within each partition
     """
 
-    PREFIX_PATTERN = r".*__([\w]+)_offset$"
-
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
     OFFSET_TYPE = "offset_type"
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
+
+    # Named after OFFSET_TYPE so bind_name_captures binds it, including the parametric families
+    # (lag_N / lead_N / diff_N / pct_change_N) the old allowed_values-based fallback missed.
+    PREFIX_PATTERN = rf".*__(?P<{OFFSET_TYPE}>[\w]+)_offset$"
 
     # Aliases of the module tables the validator reads: overriding them in a subclass has no
     # effect, per-backend narrowing belongs in SubtypeCapabilityHook.
@@ -132,7 +134,6 @@ class OffsetFeatureGroup(RejectionReasonMixin, FeatureGroup):
             allowed_values=OFFSET_TYPES,
             element_validator=_is_supported_offset_type,
             match_guard=is_op_token,
-            deferred_binding=True,
         ),
         DefaultOptionKeys.in_features: property_spec(
             "Source feature for offset operation",

--- a/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/offset/tests/test_base.py
@@ -303,6 +303,34 @@ class TestReturnDataTypeRule:
         assert OffsetFeatureGroup.return_data_type_rule(feature) is None
 
 
+class TestForwardedOffsetTypeMismatch:
+    """A group-forwarded ``offset_type`` that contradicts the name-parsed type is rejected, not silently ignored."""
+
+    def test_mismatched_forwarded_offset_type_raises(self) -> None:
+        consumer_options = Options(group={"offset_type": "lag_5"})
+        child_options = Options(context={"partition_by": ["region"], "order_by": "ts"})
+        child_options.inherit_from(consumer_options)
+
+        with pytest.raises(ValueError, match="offset_type"):
+            OffsetFeatureGroup.match_feature_group_criteria("value_int__lag_1_offset", child_options, None)
+
+    def test_matching_forwarded_offset_type_is_accepted(self) -> None:
+        consumer_options = Options(group={"offset_type": "lag_1"})
+        child_options = Options(context={"partition_by": ["region"], "order_by": "ts"})
+        child_options.inherit_from(consumer_options)
+
+        result = OffsetFeatureGroup.match_feature_group_criteria("value_int__lag_1_offset", child_options, None)
+        assert result is True
+
+    def test_mismatched_forwarded_fixed_offset_type_raises(self) -> None:
+        consumer_options = Options(group={"offset_type": "first_value"})
+        child_options = Options(context={"partition_by": ["region"], "order_by": "ts"})
+        child_options.inherit_from(consumer_options)
+
+        with pytest.raises(ValueError, match="offset_type"):
+            OffsetFeatureGroup.match_feature_group_criteria("value_int__last_value_offset", child_options, None)
+
+
 class TestOffsetMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/base.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -9,6 +11,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import escalate_match_abort
 from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
 from mloda.community.feature_groups.data_operations.base import (
@@ -17,6 +20,8 @@ from mloda.community.feature_groups.data_operations.base import (
     scalar_number_value,
 )
 from mloda.community.feature_groups.data_operations.mask_utils import MASK_KEY, parse_mask_spec
+
+logger = logging.getLogger(__name__)
 
 
 def _unit_percentile(value: object) -> float | None:
@@ -83,6 +88,7 @@ class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
     PARTITION_BY = "partition_by"
 
     PROPERTY_MAPPING = {
+        # deferred_binding stays True: see _validate_forwarded_percentile_mismatch for why.
         PERCENTILE: property_spec(
             "Percentile value (float between 0.0 and 1.0)",
             strict=True,
@@ -125,7 +131,7 @@ class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
         options: Any,
         _data_access_collection: Any = None,
     ) -> bool:
-        """Extend mixin matching with partition_by and percentile validation.
+        """Extend mixin matching with forwarded-percentile protection and partition_by validation.
 
         The mixin handles:
         - Pattern and config matching via PROPERTY_MAPPING
@@ -133,11 +139,20 @@ class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
         - MIN/MAX_IN_FEATURES enforcement
 
         We add:
-        - partition_by type validation (must be a list of strings)
+        - forwarded-value vs. name-parsed-value protection for ``percentile``
         - percentile range validation for config-based features (0.0-1.0)
+        - partition_by type validation (must be a list of strings)
         """
         if not super().match_feature_group_criteria(feature_name, options, _data_access_collection):
             return False
+
+        # None covers both halves: unresolvable, and resolved but outside 0.0-1.0.
+        resolved_percentile, name_matched = cls._resolve_percentile(feature_name, options)
+        if resolved_percentile is None:
+            return False
+
+        if name_matched:
+            cls._validate_forwarded_percentile_mismatch(feature_name, options, resolved_percentile)
 
         partition_by = options.get(cls.PARTITION_BY)
         if not isinstance(partition_by, (list, tuple)):
@@ -147,21 +162,49 @@ class PercentileFeatureGroup(RejectionReasonMixin, FeatureGroup):
         if not all(isinstance(item, str) for item in partition_by):
             return False
 
-        # None covers both halves: unresolvable, and resolved but outside 0.0-1.0.
-        if cls._resolve_percentile(feature_name, options) is None:
-            return False
-
         return True
 
     @classmethod
-    def _resolve_percentile(cls, feature_name: Any, options: Any) -> float | None:
-        """Extract percentile as a float in 0.0-1.0 from feature name or options; None if there is none."""
+    def _validate_forwarded_percentile_mismatch(
+        cls, feature_name: Any, options: Any, resolved_percentile: float
+    ) -> None:
+        """Reject a forwarded ``percentile`` that contradicts the name-parsed value.
+
+        PREFIX_PATTERN captures a "pN" percent token, while ``percentile`` is a 0.0-1.0 fraction, so
+        the two can't share a name binding the way bucket_op / rank_type / offset_type do; this
+        compares the shared float value directly instead.
+        """
+        if cls.PERCENTILE not in (options.inherited_group_keys or ()):
+            return
+        forwarded = options.get(cls.PERCENTILE)
+        forwarded_value = _unit_percentile(forwarded)
+        if forwarded_value is None or forwarded_value == resolved_percentile:
+            return
+        message = (
+            f"Feature '{feature_name}': option '{cls.PERCENTILE}' was forwarded from a consumer with value "
+            f"'{forwarded}', but the feature name parses to percentile {resolved_percentile}. The name-parsed "
+            f"value takes precedence, so the forwarded value would be silently ignored. Carve the key out with "
+            f"forward_group_exclude={{'{cls.PERCENTILE}'}} on the child in the consumer's input_features, or use "
+            f"an allowlist / forward_group=False. Set MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1 to downgrade this "
+            f"error to a warning."
+        )
+        if os.environ.get("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "").lower() in ("1", "true"):
+            logger.warning(message)
+            return
+        raise escalate_match_abort(ValueError(message))
+
+    @classmethod
+    def _resolve_percentile(cls, feature_name: Any, options: Any) -> tuple[float | None, bool]:
+        """Extract percentile as a float in 0.0-1.0 from feature name or options; None if there is none.
+
+        Second element is True when the name identified the group.
+        """
         name = str(feature_name)
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, _ = FeatureChainParser.parse_feature_name(name, prefix_patterns)
         if operation_config is not None:
-            return cls._parse_percentile_from_config(operation_config)
-        return _unit_percentile(options.get(cls.PERCENTILE))
+            return cls._parse_percentile_from_config(operation_config), True
+        return _unit_percentile(options.get(cls.PERCENTILE)), False
 
     @classmethod
     def get_percentile_value(cls, feature_name: str) -> float:

--- a/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/percentile/tests/test_base.py
@@ -214,6 +214,57 @@ class TestRejectionReporting:
         assert reason is None
 
 
+class TestForwardedPercentileMismatch:
+    """A group-forwarded ``percentile`` that contradicts the name-parsed value is rejected, not silently ignored."""
+
+    def test_mismatched_forwarded_percentile_raises(self) -> None:
+        consumer_options = Options(group={"percentile": 0.75})
+        child_options = Options(context={"partition_by": ["region"]})
+        child_options.inherit_from(consumer_options)
+
+        with pytest.raises(ValueError, match="percentile"):
+            PercentileFeatureGroup.match_feature_group_criteria("value_int__p50_percentile", child_options, None)
+
+    def test_matching_forwarded_percentile_is_accepted(self) -> None:
+        consumer_options = Options(group={"percentile": 0.5})
+        child_options = Options(context={"partition_by": ["region"]})
+        child_options.inherit_from(consumer_options)
+
+        result = PercentileFeatureGroup.match_feature_group_criteria("value_int__p50_percentile", child_options, None)
+        assert result is True
+
+    def test_matching_forwarded_integer_percentile_is_accepted(self) -> None:
+        consumer_options = Options(group={"percentile": 1})
+        child_options = Options(context={"partition_by": ["region"]})
+        child_options.inherit_from(consumer_options)
+
+        result = PercentileFeatureGroup.match_feature_group_criteria("value_int__p100_percentile", child_options, None)
+        assert result is True
+
+    def test_mismatched_percentile_env_downgrade_is_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "1")
+        consumer_options = Options(group={"percentile": 0.75})
+        child_options = Options(context={"partition_by": ["region"]})
+        child_options.inherit_from(consumer_options)
+
+        result = PercentileFeatureGroup.match_feature_group_criteria("value_int__p50_percentile", child_options, None)
+        assert result is True
+
+    def test_locally_set_contradictory_percentile_is_not_flagged(self) -> None:
+        options = Options(context={"percentile": 0.75, "partition_by": ["region"]})
+
+        result = PercentileFeatureGroup.match_feature_group_criteria("value_int__p50_percentile", options, None)
+        assert result is True
+
+    def test_config_based_feature_ignores_unrelated_forwarded_percentile(self) -> None:
+        consumer_options = Options(group={"percentile": 0.75})
+        child_options = Options(context={"in_features": "value_int", "partition_by": ["region"]})
+        child_options.inherit_from(consumer_options)
+
+        result = PercentileFeatureGroup.match_feature_group_criteria("my_result", child_options, None)
+        assert result is True
+
+
 class TestPercentileMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/base.py
@@ -126,14 +126,16 @@ class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup
     - ``order_by``: Column to order by within each partition
     """
 
-    PREFIX_PATTERN = r".*__([\w]+)_ranked$"
-
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
     RANK_TYPE = "rank_type"
     PARTITION_BY = "partition_by"
     ORDER_BY = "order_by"
+
+    # Named after RANK_TYPE so bind_name_captures binds it, including the parametric families
+    # (ntile_N / top_N / bottom_N) the old allowed_values-based fallback missed.
+    PREFIX_PATTERN = rf".*__(?P<{RANK_TYPE}>[\w]+)_ranked$"
 
     # Aliases of the module tables the validator reads: overriding them in a subclass has no
     # effect, per-backend narrowing belongs in SubtypeCapabilityHook.
@@ -148,7 +150,6 @@ class RankFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, FeatureGroup
             allowed_values=RANK_TYPES,
             element_validator=_is_supported_rank_type,
             match_guard=is_op_token,
-            deferred_binding=True,
         ),
         DefaultOptionKeys.in_features: property_spec(
             "Source feature for rank ordering",

--- a/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/rank/tests/test_base.py
@@ -397,6 +397,34 @@ class TestReturnDataTypeRule:
         assert RankFeatureGroup.return_data_type_rule(feature) is None
 
 
+class TestForwardedRankTypeMismatch:
+    """A group-forwarded ``rank_type`` that contradicts the name-parsed type must be rejected, not silently ignored."""
+
+    def test_mismatched_forwarded_rank_type_raises(self) -> None:
+        consumer_options = Options(group={"rank_type": "ntile_8"})
+        child_options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
+        child_options.inherit_from(consumer_options)
+
+        with pytest.raises(ValueError, match="rank_type"):
+            RankFeatureGroup.match_feature_group_criteria("value_int__ntile_4_ranked", child_options, None)
+
+    def test_matching_forwarded_rank_type_is_accepted(self) -> None:
+        consumer_options = Options(group={"rank_type": "ntile_4"})
+        child_options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
+        child_options.inherit_from(consumer_options)
+
+        result = RankFeatureGroup.match_feature_group_criteria("value_int__ntile_4_ranked", child_options, None)
+        assert result is True
+
+    def test_mismatched_forwarded_fixed_rank_type_raises(self) -> None:
+        consumer_options = Options(group={"rank_type": "rank"})
+        child_options = Options(context={"partition_by": ["region"], "order_by": "value_int"})
+        child_options.inherit_from(consumer_options)
+
+        with pytest.raises(ValueError, match="rank_type"):
+            RankFeatureGroup.match_feature_group_criteria("value_int__dense_rank_ranked", child_options, None)
+
+
 class TestRankMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/base.py
@@ -114,15 +114,14 @@ class TimeBucketizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
     arithmetic) and ``_assert_source_column_is_timestamp`` (the dtype guard).
     """
 
-    # Regex captures the FULL op token (e.g. ``floor_1_day``) in a single
-    # group. The validation in ``_validate_string_match`` calls
-    # ``_parse_bucket_op`` to reject ``n=0`` and ``n>1`` calendar-unit tokens.
-    PREFIX_PATTERN = r".*__((?:floor|ceil|round)_\d+_(?:minute|hour|day|week|month|year))$"
-
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
 
     BUCKET_OP = "bucket_op"
+
+    # Named after BUCKET_OP so bind_name_captures binds it, enabling the forwarded-value vs.
+    # name-parsed-value mismatch check.
+    PREFIX_PATTERN = rf".*__(?P<{BUCKET_OP}>(?:floor|ceil|round)_\d+_(?:minute|hour|day|week|month|year))$"
 
     @staticmethod
     def _is_valid_bucket_op_value(value: Any) -> bool:
@@ -148,7 +147,6 @@ class TimeBucketizationFeatureGroup(RejectionReasonMixin, FeatureGroup):
             strict=True,
             element_validator=_is_valid_bucket_op_value,
             match_guard=is_op_token,
-            deferred_binding=True,
         ),
         DefaultOptionKeys.in_features: property_spec(
             "Single source timestamp column to bucketize",

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/tests/test_base.py
@@ -294,6 +294,26 @@ class TestBucketOpExtraction:
         assert result == op_token
 
 
+class TestForwardedBucketOpMismatch:
+    """A group-forwarded ``bucket_op`` that contradicts the name-parsed op must be rejected, not silently ignored."""
+
+    def test_mismatched_forwarded_bucket_op_raises(self) -> None:
+        consumer_options = Options(group={"bucket_op": "ceil_1_day"})
+        child_options = Options()
+        child_options.inherit_from(consumer_options)
+
+        with pytest.raises(ValueError, match="bucket_op"):
+            TimeBucketizationFeatureGroup.match_feature_group_criteria("ts__floor_1_day", child_options, None)
+
+    def test_matching_forwarded_bucket_op_is_accepted(self) -> None:
+        consumer_options = Options(group={"bucket_op": "floor_1_day"})
+        child_options = Options()
+        child_options.inherit_from(consumer_options)
+
+        result = TimeBucketizationFeatureGroup.match_feature_group_criteria("ts__floor_1_day", child_options, None)
+        assert result is True
+
+
 class TestTimeBucketizationMatchValidation(MatchValidationTestBase):
     """Shared match-validation tests adapted for time bucketization.
 


### PR DESCRIPTION
## Summary

- `TimeBucketizationFeatureGroup`, `RankFeatureGroup`, and `OffsetFeatureGroup` switch their `PREFIX_PATTERN` operation capture (`bucket_op`, `rank_type`, `offset_type`) to a named group tied to the `PROPERTY_MAPPING` key, mirroring the earlier `resample_op` fix. This lets core's `bind_name_captures` bind the token by name, which enables the forwarded-value vs. name-parsed-value mismatch check for every operation token, including the parametric families (`ntile_N`, `top_N`, `bottom_N`, `lag_N`, `lead_N`, `diff_N`, `pct_change_N`) that the previous `allowed_values`-based fallback silently missed. The now-redundant `deferred_binding=True` is dropped on each.
- `PercentileFeatureGroup`'s name pattern captures a `pN` percent token while its own `percentile` option is a 0.0-1.0 fraction, so the two representations can never share one string form and the token can't bind by name the way the other three do. `match_feature_group_criteria` now enforces the same protection directly, comparing on the shared float value instead, in the same order core runs its own name-matched checks (immediately after the base match, before the group's own extra validation).
- A consumer that forwards one of these options with a value contradicting the feature name is now rejected with a clear error (downgradable to a warning via `MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1`) instead of having the forwarded value silently ignored.

## Known limitation

This closes the gap for group-forwarded values (`forward_group` / `Options(group=...)`). Values forwarded via context propagation (`propagate_context_keys` / `inherit_context_keys`) are not covered, since core's own underlying mismatch check has the same limitation; the four groups here all document context-based configuration as their primary usage pattern, so this is a real gap worth a follow-up.

## Test plan

- [x] Added forwarded-mismatch tests (raises on contradiction, accepted on match) for all four feature groups, covering both fixed and parametric operation families.
- [x] Added percentile-specific edge case coverage: int-vs-float comparison, env-var downgrade, a locally-set (non-forwarded) value is not flagged, and a config-based feature ignores an unrelated forwarded percentile.
- [x] Full `tox` (pytest, ruff format, ruff check, mypy --strict, bandit) passes clean on all touched files.