### PR TITLE
fix: close resample's undeclared dependency on time_bucketization

### DIFF
--- a/mloda/community/feature_groups/data_operations/duckdb_helpers.py
+++ b/mloda/community/feature_groups/data_operations/duckdb_helpers.py
@@ -1,0 +1,54 @@
+"""Shared DuckDB helper utilities for time bucketization and resample.
+
+Centralizes the epoch-anchored floor expression (and the interval-literal
+building block it depends on) so every DuckDB-based bucket/resample feature
+group floors timestamps identically.
+"""
+
+from __future__ import annotations
+
+# DuckDB ``DATE_TRUNC`` unit names per logical unit.
+DUCKDB_TRUNC_UNIT: dict[str, str] = {
+    "minute": "minute",
+    "hour": "hour",
+    "day": "day",
+    "week": "week",
+    "month": "month",
+    "year": "year",
+}
+
+
+def interval_literal(n: int, unit: str) -> str:
+    """DuckDB interval literal for ``n`` units of ``unit``."""
+    if unit == "minute":
+        return f"INTERVAL {n} MINUTE"
+    if unit == "hour":
+        return f"INTERVAL {n} HOUR"
+    if unit == "day":
+        return f"INTERVAL {n} DAY"
+    if unit == "week":
+        return "INTERVAL 1 WEEK"
+    if unit == "month":
+        return "INTERVAL 1 MONTH"
+    if unit == "year":
+        return "INTERVAL 1 YEAR"
+    raise ValueError(f"Unsupported time bucketization unit for DuckDB: {unit!r}")
+
+
+def floor_expr(quoted_source: str, n: int, unit: str) -> str:
+    """SQL flooring a DuckDB timestamp to the ``(n, unit)`` bucket.
+
+    Shared entry point for both DuckDB backends. Requires a UTC session tz,
+    guaranteed by ``DuckDBFramework`` (mloda >= 0.9.0); do not add a local pin.
+    """
+    if n == 1:
+        return f"DATE_TRUNC('{DUCKDB_TRUNC_UNIT[unit]}', {quoted_source})"
+    # ``n > 1`` is only valid for fixed-freq units (minute/hour/day).
+    interval = interval_literal(n, unit)
+    # Pin the origin to 1970-01-01 to match PyArrow's bucket alignment
+    # (multiples since the epoch). Without an explicit origin, DuckDB's
+    # ``time_bucket`` anchors sub-month widths at 2000-01-03, which
+    # diverges from PyArrow on multi-day buckets. DATE auto-casts to both
+    # TIMESTAMP and TIMESTAMPTZ so the same literal works for either
+    # source column type.
+    return f"time_bucket({interval}, {quoted_source}, DATE '1970-01-01')"

--- a/mloda/community/feature_groups/data_operations/pandas_helpers.py
+++ b/mloda/community/feature_groups/data_operations/pandas_helpers.py
@@ -13,6 +13,13 @@ import pandas as pd
 
 from mloda.community.feature_groups.data_operations.helper_columns import unique_helper_name
 
+# Pandas frequency aliases for fixed-freq dt floor/ceil/round.
+FIXED_FREQ_ALIASES: dict[str, str] = {
+    "minute": "min",
+    "hour": "h",
+    "day": "D",
+}
+
 PANDAS_AGG_FUNCS: dict[str, str] = {
     "sum": "sum",
     "avg": "mean",

--- a/mloda/community/feature_groups/data_operations/polars_helpers.py
+++ b/mloda/community/feature_groups/data_operations/polars_helpers.py
@@ -1,0 +1,24 @@
+"""Shared Polars duration-token helper for time bucketization and resample.
+
+Centralizes the unit-alias table and the ``(n, unit)`` -> duration string
+formatting so every Polars-based bucket/resample feature group builds the
+same ``dt.truncate`` / ``dt.round`` tokens.
+"""
+
+from __future__ import annotations
+
+# Polars duration aliases for each unit. Polars' ``dt.truncate('1w')`` is
+# Monday-anchored, which matches the ISO week convention pinned by the FG.
+POLARS_UNIT_ALIASES: dict[str, str] = {
+    "minute": "m",
+    "hour": "h",
+    "day": "d",
+    "week": "w",
+    "month": "mo",
+    "year": "y",
+}
+
+
+def duration_token(n: int, unit: str) -> str:
+    """Format the Polars duration token for ``(n, unit)`` (e.g. ``5m``, ``1d``)."""
+    return f"{n}{POLARS_UNIT_ALIASES[unit]}"

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/duckdb_resample.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/duckdb_resample.py
@@ -1,7 +1,7 @@
 """DuckDB implementation of resample.
 
-Floors the time column with the SAME epoch-anchored expression as
-``duckdb_time_bucketization`` (``DATE_TRUNC`` for n=1, ``time_bucket`` with a
+Floors the time column with the shared ``floor_expr`` epoch-anchored
+expression (``DATE_TRUNC`` for n=1, ``time_bucket`` with a
 ``DATE '1970-01-01'`` origin for n>1 -- NOT the native 2000-01-03 anchor) so
 buckets align with the PyArrow oracle. SQL ``SUM`` / ``AVG`` ignore nulls and
 return NULL for all-null groups, and ``COUNT(col)`` counts non-null values, so
@@ -15,12 +15,10 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framewor
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import floor_expr
 from mloda.community.feature_groups.data_operations.row_changing.resample.base import (
     RESAMPLE_AGGS,
     ResampleFeatureGroup,
-)
-from mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.duckdb_time_bucketization import (
-    floor_expr,
 )
 
 # Resample agg -> DuckDB aggregate function. SUM/AVG/MIN/MAX ignore nulls and

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/pandas_resample.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/pandas_resample.py
@@ -1,7 +1,7 @@
 """Pandas implementation of resample.
 
-Floors the time column with ``Series.dt.floor`` (same fixed-freq aliases as
-``pandas_time_bucketization``), groups by ``(*partition_by, bucket)`` with
+Floors the time column with ``Series.dt.floor`` (the same shared fixed-freq
+aliases used for bucketization), groups by ``(*partition_by, bucket)`` with
 ``dropna=False`` and aggregates via the shared pandas helpers. ``sum`` uses
 ``min_count=1`` so an all-null bucket yields NaN (then coerced to ``None``),
 matching the PyArrow oracle rather than pandas' default ``0.0``.
@@ -15,6 +15,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 from mloda.community.feature_groups.data_operations.pandas_helpers import (
+    FIXED_FREQ_ALIASES,
     PANDAS_AGG_FUNCS,
     apply_null_safe_agg,
     coerce_count_dtype,
@@ -23,9 +24,6 @@ from mloda.community.feature_groups.data_operations.pandas_helpers import (
 from mloda.community.feature_groups.data_operations.row_changing.resample.base import (
     RESAMPLE_AGGS,
     ResampleFeatureGroup,
-)
-from mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.pandas_time_bucketization import (
-    _FIXED_FREQ_ALIASES,
 )
 
 
@@ -68,7 +66,7 @@ class PandasResample(ResampleFeatureGroup):
 
         data = data.copy()
         # Floor the time column in place (bucket start keeps the original name).
-        data[time_column] = data[time_column].dt.floor(f"{n}{_FIXED_FREQ_ALIASES[unit]}")
+        data[time_column] = data[time_column].dt.floor(f"{n}{FIXED_FREQ_ALIASES[unit]}")
 
         keys = [*partition_by, time_column]
         grouped = null_safe_groupby(data, keys, source_col)

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/polars_lazy_resample.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/polars_lazy_resample.py
@@ -1,7 +1,7 @@
 """Polars Lazy implementation of resample.
 
-Floors the time column with ``dt.truncate`` (same duration tokens as
-``polars_lazy_time_bucketization``), groups by ``(*partition_by, bucket)`` and
+Floors the time column with ``dt.truncate`` (the same shared duration-token
+helper used for bucketization), groups by ``(*partition_by, bucket)`` and
 aggregates. Polars ``sum()`` returns ``0`` for an all-null group, so the sum
 path coerces all-null buckets to ``None`` to match the PyArrow oracle.
 """
@@ -15,12 +15,10 @@ import polars as pl
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
+from mloda.community.feature_groups.data_operations.polars_helpers import duration_token
 from mloda.community.feature_groups.data_operations.row_changing.resample.base import (
     RESAMPLE_AGGS,
     ResampleFeatureGroup,
-)
-from mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.polars_lazy_time_bucketization import (
-    _duration_token,
 )
 
 # Resample agg -> Polars expression builder over the source column.
@@ -71,7 +69,7 @@ class PolarsLazyResample(ResampleFeatureGroup):
         if agg not in _POLARS_AGG_EXPRS:
             raise ValueError(f"Unsupported resample agg {agg!r} for Polars; supported: {sorted(RESAMPLE_AGGS)}.")
 
-        duration = _duration_token(n, unit)
+        duration = duration_token(n, unit)
         # Floor the time column in place (bucket start keeps the original name).
         data = data.with_columns(pl.col(time_column).dt.truncate(duration).alias(time_column))
 

--- a/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_packaging.py
+++ b/mloda/community/feature_groups/data_operations/row_changing/resample/tests/test_packaging.py
@@ -1,0 +1,37 @@
+"""Packaging lint: resample's backend modules must not import from time_bucketization.
+
+config/packages.toml declares only mloda-community-data-operations as resample's
+dependency, never mloda-community-time-bucketization. A pip install of
+mloda-community-resample on its own never pulls in time_bucketization, so any
+cross-package import from it in a resample backend module breaks at plugin-discovery
+time in a real install, invisible to the checkout-local test suite (which always has
+the whole monorepo on sys.path). ``time_bucketization`` never appears in these files
+for any other reason, so a bare substring search is both necessary and sufficient.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_RESAMPLE_DIR = Path(__file__).resolve().parent.parent
+
+_FORBIDDEN_SUBSTRING = "time_bucketization"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        pytest.param("duckdb_resample.py", id="duckdb"),
+        pytest.param("pandas_resample.py", id="pandas"),
+        pytest.param("polars_lazy_resample.py", id="polars_lazy"),
+    ],
+)
+def test_backend_does_not_import_time_bucketization(filename: str) -> None:
+    source = (_RESAMPLE_DIR / filename).read_text()
+    assert _FORBIDDEN_SUBSTRING not in source, (
+        f"{filename} contains {_FORBIDDEN_SUBSTRING!r}; resample's own config/packages.toml entry "
+        "declares no dependency on mloda-community-time-bucketization, so a resample backend module "
+        "must not import from it (the shared helpers belong in the data_operations base package)."
+    )

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/duckdb_time_bucketization.py
@@ -16,6 +16,10 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framewor
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 
+from mloda.community.feature_groups.data_operations.duckdb_helpers import (
+    floor_expr,
+    interval_literal,
+)
 from mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.base import (
     TIME_BUCKETIZATION_OPS,
     TimeBucketizationFeatureGroup,
@@ -26,16 +30,6 @@ from mloda.community.feature_groups.data_operations.row_preserving.time_bucketiz
 # ``week`` / ``month`` / ``year``).
 _CALENDAR_CEIL_ALWAYS_ADVANCES: frozenset[str] = frozenset({"week", "month", "year"})
 
-# DuckDB ``DATE_TRUNC`` unit names per logical unit.
-_DUCKDB_TRUNC_UNIT: dict[str, str] = {
-    "minute": "minute",
-    "hour": "hour",
-    "day": "day",
-    "week": "week",
-    "month": "month",
-    "year": "year",
-}
-
 # DuckDB type names that imply a timestamp source. Parameterized variants
 # (``TIMESTAMP_NS``, ``TIMESTAMP WITH TIME ZONE``) are matched as prefixes.
 # Bare DATE is intentionally NOT accepted: round at sub-day units fails
@@ -45,42 +39,6 @@ _DUCKDB_TIMESTAMP_PREFIXES: tuple[str, ...] = (
     "TIMESTAMP",
     "DATETIME",
 )
-
-
-def _interval_literal(n: int, unit: str) -> str:
-    """DuckDB interval literal for ``n`` units of ``unit``."""
-    if unit == "minute":
-        return f"INTERVAL {n} MINUTE"
-    if unit == "hour":
-        return f"INTERVAL {n} HOUR"
-    if unit == "day":
-        return f"INTERVAL {n} DAY"
-    if unit == "week":
-        return "INTERVAL 1 WEEK"
-    if unit == "month":
-        return "INTERVAL 1 MONTH"
-    if unit == "year":
-        return "INTERVAL 1 YEAR"
-    raise ValueError(f"Unsupported time bucketization unit for DuckDB: {unit!r}")
-
-
-def floor_expr(quoted_source: str, n: int, unit: str) -> str:
-    """SQL flooring a DuckDB timestamp to the ``(n, unit)`` bucket.
-
-    Shared entry point for both DuckDB backends. Requires a UTC session tz,
-    guaranteed by ``DuckDBFramework`` (mloda >= 0.9.0); do not add a local pin.
-    """
-    if n == 1:
-        return f"DATE_TRUNC('{_DUCKDB_TRUNC_UNIT[unit]}', {quoted_source})"
-    # ``n > 1`` is only valid for fixed-freq units (minute/hour/day).
-    interval = _interval_literal(n, unit)
-    # Pin the origin to 1970-01-01 to match PyArrow's bucket alignment
-    # (multiples since the epoch). Without an explicit origin, DuckDB's
-    # ``time_bucket`` anchors sub-month widths at 2000-01-03, which
-    # diverges from PyArrow on multi-day buckets. DATE auto-casts to both
-    # TIMESTAMP and TIMESTAMPTZ so the same literal works for either
-    # source column type.
-    return f"time_bucket({interval}, {quoted_source}, DATE '1970-01-01')"
 
 
 def _bucket_seconds_for_fixed_freq(n: int, unit: str) -> int:
@@ -131,7 +89,7 @@ class DuckdbTimeBucketization(TimeBucketizationFeatureGroup):
         quoted_source = quote_ident(source_col)
         quoted_feature = quote_ident(feature_name)
         floor_sql = floor_expr(quoted_source, n, unit)
-        interval = _interval_literal(n, unit)
+        interval = interval_literal(n, unit)
         ceil_next = f"({floor_sql} + {interval})"
 
         if op == "floor":

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pandas_time_bucketization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/pandas_time_bucketization.py
@@ -17,17 +17,11 @@ import pandas as pd
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
+from mloda.community.feature_groups.data_operations.pandas_helpers import FIXED_FREQ_ALIASES
 from mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.base import (
     TIME_BUCKETIZATION_OPS,
     TimeBucketizationFeatureGroup,
 )
-
-# Pandas frequency aliases for fixed-freq dt floor/ceil/round.
-_FIXED_FREQ_ALIASES: dict[str, str] = {
-    "minute": "min",
-    "hour": "h",
-    "day": "D",
-}
 
 # Pandas period-based floor for calendar units (n=1 only). For ISO weeks
 # (Monday start) we use ``W-SUN`` (week ending Sunday), so a Sunday rolls
@@ -117,14 +111,14 @@ class PandasTimeBucketization(TimeBucketizationFeatureGroup):
 
     @classmethod
     def _floor_series(cls, col: pd.Series, n: int, unit: str) -> pd.Series:
-        if unit in _FIXED_FREQ_ALIASES:
-            return col.dt.floor(f"{n}{_FIXED_FREQ_ALIASES[unit]}")
+        if unit in FIXED_FREQ_ALIASES:
+            return col.dt.floor(f"{n}{FIXED_FREQ_ALIASES[unit]}")
         return _calendar_floor(col, unit)
 
     @classmethod
     def _ceil_series(cls, col: pd.Series, n: int, unit: str) -> pd.Series:
-        if unit in _FIXED_FREQ_ALIASES:
-            return col.dt.ceil(f"{n}{_FIXED_FREQ_ALIASES[unit]}")
+        if unit in FIXED_FREQ_ALIASES:
+            return col.dt.ceil(f"{n}{FIXED_FREQ_ALIASES[unit]}")
         # Calendar units: always advance one bucket (matches PyArrow).
         floored = _calendar_floor(col, unit)
         offset = _calendar_offset(unit)
@@ -140,9 +134,9 @@ class PandasTimeBucketization(TimeBucketizationFeatureGroup):
         we still rely on ``dt.floor`` / ``dt.ceil`` to get the bracket
         bucket and then pick via midpoint comparison.
         """
-        if unit in _FIXED_FREQ_ALIASES:
-            floored = col.dt.floor(f"{n}{_FIXED_FREQ_ALIASES[unit]}")
-            ceiled = col.dt.ceil(f"{n}{_FIXED_FREQ_ALIASES[unit]}")
+        if unit in FIXED_FREQ_ALIASES:
+            floored = col.dt.floor(f"{n}{FIXED_FREQ_ALIASES[unit]}")
+            ceiled = col.dt.ceil(f"{n}{FIXED_FREQ_ALIASES[unit]}")
         else:
             floored = _calendar_floor(col, unit)
             ceiled = floored + _calendar_offset(unit)

--- a/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/polars_lazy_time_bucketization.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/time_bucketization/polars_lazy_time_bucketization.py
@@ -15,32 +15,17 @@ import polars as pl
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
 
+from mloda.community.feature_groups.data_operations.polars_helpers import duration_token
 from mloda.community.feature_groups.data_operations.row_preserving.time_bucketization.base import (
     TIME_BUCKETIZATION_OPS,
     TimeBucketizationFeatureGroup,
 )
-
-# Polars duration aliases for each unit. Polars' ``dt.truncate('1w')`` is
-# Monday-anchored, which matches the ISO week convention pinned by the FG.
-_POLARS_UNIT_ALIASES: dict[str, str] = {
-    "minute": "m",
-    "hour": "h",
-    "day": "d",
-    "week": "w",
-    "month": "mo",
-    "year": "y",
-}
 
 # Calendar units whose ``ceil`` always advances by one bucket even on
 # aligned input (matches PyArrow's ``ceil_temporal`` behaviour for
 # ``week`` / ``month`` / ``year``). Fixed-freq units are idempotent on
 # aligned input.
 _CALENDAR_CEIL_ALWAYS_ADVANCES: frozenset[str] = frozenset({"week", "month", "year"})
-
-
-def _duration_token(n: int, unit: str) -> str:
-    """Format the Polars duration token for ``(n, unit)`` (e.g. ``5m``, ``1d``)."""
-    return f"{n}{_POLARS_UNIT_ALIASES[unit]}"
 
 
 class PolarsLazyTimeBucketization(TimeBucketizationFeatureGroup):
@@ -72,7 +57,7 @@ class PolarsLazyTimeBucketization(TimeBucketizationFeatureGroup):
         unit: str,
     ) -> pl.LazyFrame:
         col = pl.col(source_col)
-        duration = _duration_token(n, unit)
+        duration = duration_token(n, unit)
 
         if op == "floor":
             expr = col.dt.truncate(duration)

--- a/scripts/verify_floor_installs.py
+++ b/scripts/verify_floor_installs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Install each published package with its in-repo dependency pinned to the declared floor, probing its import surface.
 
-The import surface is the dotted package root plus its base module when the checkout ships a base.py.
+The import surface is the dotted package root plus its base module when the checkout ships a
+base.py, and its manifest module when the checkout ships a manifest.py.
 
 Run: python scripts/verify_floor_installs.py <version>
 Exit code: 1 if any floored pair fails to install or its import surface fails to load, 0 otherwise.

--- a/scripts/verify_independent_installs.py
+++ b/scripts/verify_independent_installs.py
@@ -52,7 +52,8 @@ def top_level_distributions(packages: dict[str, dict[str, Any]]) -> list[str]:
 
 
 def probe_modules(name: str, packages: dict[str, dict[str, Any]]) -> list[str]:
-    """The distribution's own import surface plus every nested configured package's, in config order."""
+    """The distribution's own import surface (root plus base/manifest modules) plus every nested
+    configured package's, in config order."""
     # The single derivation point for import surfaces lives in verify_published_imports.
     surface: Callable[[str], tuple[str, ...]] = _load_sibling("verify_published_imports").import_surface
     path = str(packages[name]["path"]).rstrip("/")

--- a/scripts/verify_published_imports.py
+++ b/scripts/verify_published_imports.py
@@ -2,7 +2,8 @@
 """Smoke-import every configured package inside the venv holding the released set.
 
 Every configured package ships in some wheel, so every import surface (the dotted root plus its
-base module when the checkout ships a base.py) gets probed.
+base module when the checkout ships a base.py, and its manifest module when the checkout ships a
+manifest.py) gets probed.
 
 Run: python scripts/verify_published_imports.py <venv-python>
 Exit code: 1 if any module fails to import, 0 otherwise.
@@ -22,17 +23,23 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def import_surface(path: str) -> tuple[str, ...]:
-    """The dotted package root, plus its base module when <path>/base.py exists in the checkout."""
+    """The dotted package root, plus its base module when <path>/base.py exists in the checkout, and its
+    manifest module when <path>/manifest.py exists in the checkout."""
     root = path.replace("/", ".")
     # Most leaf __init__.py files are empty and the cross-package imports live in the leaf's base
     # module, so importing only the root is vacuous. Resolve against the checkout, never the cwd.
+    modules = [root]
     if (REPO_ROOT / path / "base.py").exists():
-        return (root, f"{root}.base")
-    return (root,)
+        modules.append(f"{root}.base")
+    # manifest.py is mloda's real plugin entry-point discovery module; a package can ship one without
+    # a base.py, so this check is independent of the one above.
+    if (REPO_ROOT / path / "manifest.py").exists():
+        modules.append(f"{root}.manifest")
+    return tuple(modules)
 
 
 def import_modules(packages: dict[str, dict[str, Any]]) -> list[str]:
-    """The import surface of every configured package, in config order (roots plus base modules)."""
+    """The import surface of every configured package, in config order (roots plus base/manifest modules)."""
     modules: list[str] = []
     for pkg_config in packages.values():
         modules.extend(import_surface(str(pkg_config["path"])))

--- a/tests/test_end2end/test_published_set_single_source.py
+++ b/tests/test_end2end/test_published_set_single_source.py
@@ -157,9 +157,13 @@ def _dotted_path(pkg_name: str) -> str:
 
 
 def _expected_surface(path: str) -> list[str]:
-    """The import surface of a package path: the dotted root plus base when the checkout ships base.py."""
+    """The import surface of a package path: the dotted root, base when the checkout ships base.py, and
+    manifest when the checkout ships manifest.py."""
     dotted = path.replace("/", ".")
-    return [dotted, f"{dotted}.base"] if (_REPO_ROOT / path / "base.py").exists() else [dotted]
+    surface = [dotted, f"{dotted}.base"] if (_REPO_ROOT / path / "base.py").exists() else [dotted]
+    if (_REPO_ROOT / path / "manifest.py").exists():
+        surface.append(f"{dotted}.manifest")
+    return surface
 
 
 def _published_children() -> list[str]:

--- a/tests/test_end2end/test_verify_floor_installs.py
+++ b/tests/test_end2end/test_verify_floor_installs.py
@@ -35,12 +35,14 @@ _DEP = "mloda-community-data-operations"
 _LEAF = "mloda-community-aggregation"
 _LEAF_PATH = "mloda/community/feature_groups/data_operations/aggregation"
 _LEAF_MODULE = "mloda.community.feature_groups.data_operations.aggregation"
-# The dotted path is always the first probe; aggregation ships base.py, so its base module probes too.
-_LEAF_MODULES = (_LEAF_MODULE, f"{_LEAF_MODULE}.base")
+# The dotted path is always the first probe; aggregation ships base.py and manifest.py, so both probe too.
+_LEAF_MODULES = (_LEAF_MODULE, f"{_LEAF_MODULE}.base", f"{_LEAF_MODULE}.manifest")
 
-# A leaf whose checkout directory has no base.py, so the dotted path is its only probe.
+# A leaf whose checkout directory has no base.py (but does ship manifest.py), so the dotted path plus
+# the manifest module are its only probes.
 _NO_BASE_PATH = "mloda/community/feature_groups/example/example_a"
 _NO_BASE_MODULE = "mloda.community.feature_groups.example.example_a"
+_NO_BASE_MODULES = (_NO_BASE_MODULE, f"{_NO_BASE_MODULE}.manifest")
 
 
 def _internal_floor_pairs() -> Callable[[dict[str, dict[str, Any]]], list[Any]]:
@@ -86,7 +88,8 @@ def _real_pairs() -> list[Any]:
 
 def test_a_published_leaf_yields_its_internal_floor_pair() -> None:
     """The pair carries the leaf, the floored distribution, the floor, and the import probes: the dotted
-    path first, then its '.base' module because <path>/base.py exists in the checkout."""
+    path first, then its '.base' and '.manifest' modules because <path>/base.py and <path>/manifest.py
+    exist in the checkout."""
     pairs = _internal_floor_pairs()(_synthetic_packages())
 
     assert len(pairs) == 1, f"expected exactly one pair, got {pairs!r}"
@@ -95,20 +98,21 @@ def test_a_published_leaf_yields_its_internal_floor_pair() -> None:
     assert pair.dependency == _DEP, f"pair.dependency must be the floored distribution, got {pair.dependency!r}"
     assert pair.floor == "0.4.0", f"pair.floor must be the '>=' bound, got {pair.floor!r}"
     assert pair.modules == _LEAF_MODULES, (
-        f"pair.modules must be the dotted path plus its base module, got {pair.modules!r}"
+        f"pair.modules must be the dotted path plus its base and manifest modules, got {pair.modules!r}"
     )
     assert tuple(pair) == (_LEAF, _DEP, "0.4.0", _LEAF_MODULES), (
         "FloorPair must be a NamedTuple ordered (package, dependency, floor, modules)"
     )
 
 
-def test_a_leaf_without_a_base_module_probes_only_its_package_root() -> None:
-    """example_a ships no base.py, so the dotted package root is its only import probe."""
+def test_a_leaf_without_a_base_module_probes_only_its_package_root_and_manifest() -> None:
+    """example_a ships no base.py but does ship manifest.py, so the dotted package root plus the
+    manifest module are its only import probes."""
     pairs = _internal_floor_pairs()(_synthetic_packages(path=_NO_BASE_PATH))
 
     assert len(pairs) == 1, f"expected exactly one pair, got {pairs!r}"
-    assert pairs[0].modules == (_NO_BASE_MODULE,), (
-        f"a leaf without base.py must probe only its package root, got {pairs[0].modules!r}"
+    assert pairs[0].modules == _NO_BASE_MODULES, (
+        f"a leaf without base.py must probe only its package root and manifest module, got {pairs[0].modules!r}"
     )
 
 


### PR DESCRIPTION
Closes #434

## Summary

`mloda-community-resample`'s duckdb, pandas, and polars backends imported private helpers (`floor_expr`, `_FIXED_FREQ_ALIASES`, `_duration_token`) from the sibling `mloda-community-time-bucketization` leaf package, but `config/packages.toml` never declares that dependency for resample: it only declares the shared `mloda-community-data-operations` base. Installing `mloda-community-resample` on its own and importing it raises `ModuleNotFoundError`, since time_bucketization is a separate wheel never pulled in.

## Changes

- Move the three shared helpers into the `data_operations` base package resample already depends on: new `duckdb_helpers.py`, new `polars_helpers.py`, and an addition to the existing `pandas_helpers.py`. The `time_bucketization` backends now import these from the base too, so both families share one definition instead of resample reaching into a sibling leaf's private names.
- Fix the verification gap that let this ship unnoticed: `import_surface()` in `scripts/verify_published_imports.py` (shared by `verify_floor_installs.py` and `verify_independent_installs.py`) only ever probed a package's root and its `.base` module, never its `.manifest` module, which is what mloda's real plugin entry-point discovery loads. It now probes `.manifest` too when the package ships one.
- Add a packaging test asserting none of resample's backend modules import from `time_bucketization`.

No new dependency is declared in `config/packages.toml`; resample's existing `mloda-community-data-operations` dependency is now sufficient. The dependency floor for the new base symbols is left unchanged in this change (a floor can never exceed the currently released workspace version, per `docs/packaging.md`); it will be raised in a follow-up once this releases.
