### PR TITLE
fix(skills): reconcile SKILL.md guide references with docs/guides tree

### DIFF
--- a/.claude/skills/mloda-core/SKILL.md
+++ b/.claude/skills/mloda-core/SKILL.md
@@ -25,7 +25,7 @@ If path is empty, ask user to set `MLODA_PATH` environment variable or clone mlo
 | `mloda_plugins/function_extender/` | Function extender plugins |
 | `docs/docs/` | Documentation source (MkDocs, same as mloda-ai.github.io/mloda/) |
 | `docs/mkdocs.yml` | MkDocs configuration |
-| `tests/` | Test suite (1500+ tests) |
+| `tests/` | Test suite |
 
 **Online fallback:**
 - Docs: https://mloda-ai.github.io/mloda/

--- a/.claude/skills/mloda-core/SKILL.md
+++ b/.claude/skills/mloda-core/SKILL.md
@@ -23,7 +23,6 @@ If path is empty, ask user to set `MLODA_PATH` environment variable or clone mlo
 | `mloda_plugins/compute_framework/` | Compute framework plugins |
 | `mloda_plugins/feature_group/` | Feature group plugins |
 | `mloda_plugins/function_extender/` | Function extender plugins |
-| `mloda_plugins/config/` | Plugin configuration |
 | `docs/docs/` | Documentation source (MkDocs, same as mloda-ai.github.io/mloda/) |
 | `docs/mkdocs.yml` | MkDocs configuration |
 | `tests/` | Test suite (1500+ tests) |

--- a/.claude/skills/mloda-plugins/SKILL.md
+++ b/.claude/skills/mloda-plugins/SKILL.md
@@ -110,6 +110,9 @@ Q25: Several readers under one root group, or a non-file (HTTP/API) source?
 
 Q26: Does it declare another feature group's feature (source, connector) in input_features(), and need to control which of its own options forward to that input?
     YES → See 26-input-feature-forwarding
+
+Q27: Is it a standard column transform (binning, window/scalar/frame aggregate, rank, offset, percentile, string op, time bucketization, ffill, EMA, resample, sessionization)?
+    YES → See Data Operation Patterns below
 ```
 
 ### Feature Group Pattern Guides

--- a/.claude/skills/mloda-plugins/SKILL.md
+++ b/.claude/skills/mloda-plugins/SKILL.md
@@ -107,6 +107,9 @@ Q24: Need conditional aggregation that nulls out non-matching values instead of 
 
 Q25: Several readers under one root group, or a non-file (HTTP/API) source?
     YES → See 27-input-data-readers
+
+Q26: Does it declare another feature group's feature (source, connector) in input_features(), and need to control which of its own options forward to that input?
+    YES → See 26-input-feature-forwarding
 ```
 
 ### Feature Group Pattern Guides
@@ -142,6 +145,35 @@ Location: `docs/guides/feature-group-patterns/`
 | 25 | `25-masking.md` | Conditional aggregation via FilterMask |
 | 26 | `26-input-feature-forwarding.md` | Consume another group's root feature; option forwarding |
 | 27 | `27-input-data-readers.md` | Sibling reader selection; non-file / HTTP readers |
+
+---
+
+## Data Operation Patterns
+
+Location: `docs/guides/data-operation-patterns/`
+
+Built-in feature groups that transform existing columns: row-preserving analytics (binning, ranks, windows, offsets, percentiles), group-reducing aggregations, element-wise string transforms.
+
+| # | Guide | Description |
+|---|-------|-------------|
+| 01 | `01-overview.md` | Categories, naming patterns, code layout |
+| 02 | `02-row-preserving-contract.md` | Output row count/order must match input |
+| 03 | `03-reference-implementation.md` | PyArrow as source of truth |
+| 04 | `04-supported-ops.md` | Ops excluded per framework |
+| 05 | `05-binning.md` | `bin` vs `qbin` |
+| 06 | `06-window-aggregation.md` | Partitioned aggregates broadcast per row |
+| 07 | `07-percentile-rank-offset.md` | Analytic window family |
+| 08 | `08-scalar-and-frame-aggregate.md` | Global/rolling aggregates, arithmetic |
+| 09 | `09-string-operations.md` | Element-wise string transforms |
+| 10 | `10-adding-new-operation.md` | End-to-end recipe for a new operation |
+| 11 | `11-time-bucketization.md` | Floor/ceil/round timestamp to a bucket |
+| 12 | `12-ffill-by-time.md` | Forward fill across time gaps |
+| 13 | `13-ema.md` | Exponential moving average |
+| 14 | `14-resample.md` | Collapse events onto a regular time grid |
+| 15 | `15-sessionization.md` | Gap-threshold session id |
+| 16 | `16-return-data-type-rule.md` | Fail-fast return-type contract |
+
+See also `framework-support-matrix.md` (op x framework support) and `known-divergences.md` (audited framework divergences).
 
 ---
 
@@ -186,6 +218,9 @@ Q10: Should connections be auto-created or user-provided?
 
 Q11: Ready to test your implementation?
     YES → See 09-testing-guide
+
+Q12: Need to map a native column type (e.g. pandas dtype, Arrow type) to mloda's DataType?
+    YES → See 10-data-type-extraction
 ```
 
 ### Compute Framework Pattern Guides
@@ -203,6 +238,7 @@ Location: `docs/guides/compute-framework-patterns/`
 | 07 | `07-filter-engine.md` | Filter operations |
 | 08 | `08-framework-transformer.md` | Cross-framework conversion |
 | 09 | `09-testing-guide.md` | Testing your implementation |
+| 10 | `10-data-type-extraction.md` | Mapping native column types to mloda `DataType` |
 
 ---
 

--- a/docs/guides/09-create-feature-group.md
+++ b/docs/guides/09-create-feature-group.md
@@ -81,6 +81,12 @@ Q23: Need both plan reuse and incremental per-group delivery?
 
 Q24: Need conditional aggregation (include only rows matching a predicate)?
     YES → See 25-masking
+
+Q25: Several readers under one root group, or a non-file (HTTP/API) source?
+    YES → See 27-input-data-readers
+
+Q26: Does it declare another feature group's feature (source, connector) in input_features(), and need to control which of its own options forward to that input?
+    YES → See 26-input-feature-forwarding
 ```
 
 ## Pattern Guides
@@ -117,3 +123,5 @@ Q24: Need conditional aggregation (include only rows matching a predicate)?
 | [23-streaming](feature-group-patterns/23-streaming.md) | Consume results incrementally with `stream_all` |
 | [24-realtime](feature-group-patterns/24-realtime.md) | Reuse execution plans with `prepare` + `run` |
 | [25-masking](feature-group-patterns/25-masking.md) | Conditional aggregation via `mask` context option |
+| [26-input-feature-forwarding](feature-group-patterns/26-input-feature-forwarding.md) | Consuming another group's feature; controlling option forwarding |
+| [27-input-data-readers](feature-group-patterns/27-input-data-readers.md) | Sibling reader selection; non-file / HTTP readers |

--- a/docs/guides/10-create-compute-framework.md
+++ b/docs/guides/10-create-compute-framework.md
@@ -43,6 +43,9 @@ Q10: Should connections be auto-created or user-provided?
 
 Q11: Ready to test your implementation?
     YES → See 09-testing-guide
+
+Q12: Need to map a native column type (e.g. pandas dtype, Arrow type) to mloda's DataType?
+    YES → See 10-data-type-extraction
 ```
 
 ## Category Guides


### PR DESCRIPTION
The shipped Claude Code skill files (`.claude/skills/*/SKILL.md`) had drifted from the actual `docs/guides/` tree:

- `mloda-core/SKILL.md` listed a `mloda_plugins/config/` directory that no longer exists in the `mloda` repo (it only has `compute_framework/`, `feature_group/`, `function_extender/`).
- `mloda-plugins/SKILL.md`'s Feature Group Decision Tree never routed to `26-input-feature-forwarding.md`, even though that guide was already listed in the Feature Group Pattern Guides table.
- `mloda-plugins/SKILL.md`'s Compute Framework Pattern Guides table stopped at guide 09, missing `10-data-type-extraction.md`. The `docs/guides/data-operation-patterns/` tree (18 guides) wasn't referenced anywhere in the skill.

This reconciles both skill files against the current guide tree: removes the stale row, adds the missing decision-tree question and table rows, and adds a Data Operation Patterns section with its own decision-tree entry point.

While verifying the fix, found the same defect class in the canonical guide files themselves (`docs/guides/09-create-feature-group.md` and `docs/guides/10-create-compute-framework.md`): their embedded decision trees didn't route to guides already listed in their own tables. Fixed those too, since they're the source of truth agents are told to read directly.

Also dropped a stale hardcoded test count in `mloda-core/SKILL.md` while touching that table.