### PR TITLE
docs: fix plugin discovery, add README plugin-table lint, document entry-point workaround

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,12 @@ uv sync --all-extras
 uv run tox
 ```
 
-`uv sync --all-extras` alone does not register any plugin's entry points, so
-`PluginLoader.all()` finds no feature groups in this venv (tests use
-`PluginCollector.enabled_feature_groups(...)` instead, which does not need entry
-points). To exercise `PluginLoader.all()` locally, editable-install the plugin
-package you need, e.g. `uv pip install -e mloda/community`.
+`uv sync --all-extras` does not register plugin entry points, so
+`PluginLoader.all()` discovers none of this repository's plugins in this venv
+(tests use `PluginCollector.enabled_feature_groups(...)` instead, which needs
+none). To exercise `PluginLoader.all()` locally, editable-install the plugin
+package needed, e.g. `uv pip install -e mloda/community`. A later `uv sync` or
+`uv run` removes that install again, so repeat it whenever you need it.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,12 @@ uv sync --all-extras
 uv run tox
 ```
 
+`uv sync --all-extras` alone does not register any plugin's entry points, so
+`PluginLoader.all()` finds no feature groups in this venv (tests use
+`PluginCollector.enabled_feature_groups(...)` instead, which does not need entry
+points). To exercise `PluginLoader.all()` locally, editable-install the plugin
+package you need, e.g. `uv pip install -e mloda/community`.
+
 ## Code Style
 
 All code must pass the automated checks enforced by tox. The toolchain includes:

--- a/docs/guides/02-discover-plugins.md
+++ b/docs/guides/02-discover-plugins.md
@@ -8,7 +8,7 @@ How to find what plugins are available and what's installed in your environment.
 
 The simplest way to discover available plugins:
 
-1. **This repository**: Browse the `plugins/` directory for community and official plugins
+1. **This repository**: Browse [`mloda/community/`](../../mloda/community/) and [`mloda/enterprise/`](../../mloda/enterprise/), or see the [Plugins table](../../README.md#plugins) in the README
 2. **Plugin READMEs**: Each plugin package has a README describing its feature groups
 
 ## Discovering Installed Plugins

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -10,6 +10,12 @@ import re
 import sys
 from collections import deque
 from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCS_DIR = REPO_ROOT / "docs"
@@ -18,6 +24,15 @@ DOCS_DIR = REPO_ROOT / "docs"
 GUIDES_DIR = DOCS_DIR / "guides"
 
 PLUGIN_SOURCE_DIR = REPO_ROOT / "mloda"
+
+README_PATH = REPO_ROOT / "README.md"
+
+PACKAGES_CONFIG = REPO_ROOT / "config" / "packages.toml"
+
+# Nested under this prefix, excluding the shared base package itself at the prefix path.
+DATA_OPERATIONS_PATH_PREFIX = "mloda/community/feature_groups/data_operations/"
+
+PLUGINS_SECTION_RE = re.compile(r"^## Plugins\n(.*?)(?=^## )", re.MULTILINE | re.DOTALL)
 
 INTERNAL_IMPORT_RE = re.compile(r"from mloda\.core\.")
 
@@ -137,6 +152,37 @@ def check_internal_imports(md_file: Path, content: str) -> list[str]:
             if INTERNAL_IMPORT_RE.search(stripped):
                 errors.append(f"{md_file}:{opener_lineno + lineno}: internal import in code snippet -> {stripped}")
     return errors
+
+
+def _load_packages_config(packages_config: Path) -> dict[str, dict[str, Any]]:
+    with open(packages_config, "rb") as f:
+        data = tomllib.load(f)
+    packages: dict[str, dict[str, Any]] = data.get("packages", {})
+    return packages
+
+
+def _published_data_operation_packages(packages: dict[str, dict[str, Any]]) -> list[str]:
+    """Published data-operation plugin packages, excluding the shared base package itself."""
+    names = [
+        name
+        for name, cfg in packages.items()
+        if cfg.get("published") and cfg.get("path", "").startswith(DATA_OPERATIONS_PATH_PREFIX)
+    ]
+    return sorted(names)
+
+
+def check_readme_plugin_table(readme_path: Path, packages_config: Path) -> list[str]:
+    """Flag published data-operation packages missing from the README Plugins table."""
+    if not readme_path.is_file() or not packages_config.is_file():
+        return []
+    names = _published_data_operation_packages(_load_packages_config(packages_config))
+    match = PLUGINS_SECTION_RE.search(readme_path.read_text(encoding="utf-8"))
+    section = match.group(1) if match else ""
+    return [
+        f"{readme_path}: Plugins table missing published package `{name}`"
+        for name in names
+        if f"`{name}`" not in section
+    ]
 
 
 def _collect_linked_md(md_file: Path, content: str) -> set[Path]:
@@ -392,6 +438,7 @@ def main() -> int:
         content = py_file.read_text(encoding="utf-8")
         all_errors.extend(check_source_property_mapping(py_file, content))
 
+    all_errors.extend(check_readme_plugin_table(README_PATH, PACKAGES_CONFIG))
     all_errors.extend(link_errors)
 
     # Only link errors inside guides can corrupt the reachability BFS.

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -29,10 +29,10 @@ README_PATH = REPO_ROOT / "README.md"
 
 PACKAGES_CONFIG = REPO_ROOT / "config" / "packages.toml"
 
-# Nested under this prefix, excluding the shared base package itself at the prefix path.
+# Trailing slash excludes the shared base package itself, whose path has no nested segment.
 DATA_OPERATIONS_PATH_PREFIX = "mloda/community/feature_groups/data_operations/"
 
-PLUGINS_SECTION_RE = re.compile(r"^## Plugins\n(.*?)(?=^## )", re.MULTILINE | re.DOTALL)
+PLUGINS_SECTION_RE = re.compile(r"^## Plugins\n(.*?)(?=^## |\Z)", re.MULTILINE | re.DOTALL)
 
 INTERNAL_IMPORT_RE = re.compile(r"from mloda\.core\.")
 
@@ -171,17 +171,22 @@ def _published_data_operation_packages(packages: dict[str, dict[str, Any]]) -> l
     return sorted(names)
 
 
+def _table_rows(section: str) -> str:
+    """Join the section's table-row lines (those starting with ``|``), so prose mentions don't count."""
+    return "\n".join(line for line in section.splitlines() if line.lstrip().startswith("|"))
+
+
 def check_readme_plugin_table(readme_path: Path, packages_config: Path) -> list[str]:
     """Flag published data-operation packages missing from the README Plugins table."""
-    if not readme_path.is_file() or not packages_config.is_file():
-        return []
+    if not readme_path.is_file():
+        return [f"{readme_path}: README not found for Plugins table check"]
+    if not packages_config.is_file():
+        return [f"{packages_config}: packages config not found for Plugins table check"]
     names = _published_data_operation_packages(_load_packages_config(packages_config))
     match = PLUGINS_SECTION_RE.search(readme_path.read_text(encoding="utf-8"))
-    section = match.group(1) if match else ""
+    rows = _table_rows(match.group(1)) if match else ""
     return [
-        f"{readme_path}: Plugins table missing published package `{name}`"
-        for name in names
-        if f"`{name}`" not in section
+        f"{readme_path}: Plugins table missing published package `{name}`" for name in names if f"`{name}`" not in rows
     ]
 
 

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -831,10 +831,19 @@ published = true
 path = "mloda/community/feature_groups/data_operations/row_preserving/unreleased"
 """
 
+_COMPLETE_TABLE = (
+    "## Plugins\n\n"
+    "| Plugin | Feature name |\n"
+    "|--------|--------------|\n"
+    "| `mloda-community-aggregation` | ... |\n"
+    "| `mloda-community-rank` | ... |\n"
+    "\n## PyPI packages\n"
+)
+
 
 def test_check_readme_plugin_table_accepts_complete_table(tmp_path: Path) -> None:
     readme = tmp_path / "README.md"
-    _write(readme, "## Plugins\n\n`mloda-community-aggregation`\n`mloda-community-rank`\n\n## PyPI packages\n")
+    _write(readme, _COMPLETE_TABLE)
     packages_config = tmp_path / "packages.toml"
     _write(packages_config, _DATA_OP_PACKAGES_TOML)
     assert lint_docs.check_readme_plugin_table(readme, packages_config) == []
@@ -842,7 +851,7 @@ def test_check_readme_plugin_table_accepts_complete_table(tmp_path: Path) -> Non
 
 def test_check_readme_plugin_table_flags_missing_package(tmp_path: Path) -> None:
     readme = tmp_path / "README.md"
-    _write(readme, "## Plugins\n\n`mloda-community-aggregation`\n\n## PyPI packages\n")
+    _write(readme, "## Plugins\n\n| `mloda-community-aggregation` | ... |\n\n## PyPI packages\n")
     packages_config = tmp_path / "packages.toml"
     _write(packages_config, _DATA_OP_PACKAGES_TOML)
     errors = lint_docs.check_readme_plugin_table(readme, packages_config)
@@ -850,13 +859,15 @@ def test_check_readme_plugin_table_flags_missing_package(tmp_path: Path) -> None
     assert "mloda-community-rank" in errors[0]
 
 
-def test_check_readme_plugin_table_excludes_base_and_unpublished_packages(tmp_path: Path) -> None:
+def test_published_data_operation_packages_excludes_base_and_unpublished(tmp_path: Path) -> None:
     """The shared data-operations base and an unpublished package must never be required in the table."""
-    readme = tmp_path / "README.md"
-    _write(readme, "## Plugins\n\n`mloda-community-aggregation`\n`mloda-community-rank`\n\n## PyPI packages\n")
     packages_config = tmp_path / "packages.toml"
     _write(packages_config, _DATA_OP_PACKAGES_TOML)
-    assert lint_docs.check_readme_plugin_table(readme, packages_config) == []
+    packages = lint_docs._load_packages_config(packages_config)
+    assert lint_docs._published_data_operation_packages(packages) == [
+        "mloda-community-aggregation",
+        "mloda-community-rank",
+    ]
 
 
 def test_check_readme_plugin_table_ignores_matches_outside_plugins_section(tmp_path: Path) -> None:
@@ -864,13 +875,63 @@ def test_check_readme_plugin_table_ignores_matches_outside_plugins_section(tmp_p
     readme = tmp_path / "README.md"
     _write(
         readme,
-        "## Plugins\n\n`mloda-community-aggregation`\n\n## PyPI packages\n\n`mloda-community-rank`\n",
+        "## Plugins\n\n| `mloda-community-aggregation` | ... |\n\n## PyPI packages\n\n`mloda-community-rank`\n",
     )
     packages_config = tmp_path / "packages.toml"
     _write(packages_config, _DATA_OP_PACKAGES_TOML)
     errors = lint_docs.check_readme_plugin_table(readme, packages_config)
     assert len(errors) == 1
     assert "mloda-community-rank" in errors[0]
+
+
+def test_check_readme_plugin_table_ignores_prose_mention_inside_plugins_section(tmp_path: Path) -> None:
+    """A package name mentioned in prose inside the Plugins section, but not in a table row, still counts missing."""
+    readme = tmp_path / "README.md"
+    _write(
+        readme,
+        "## Plugins\n\n"
+        "| `mloda-community-aggregation` | ... |\n\n"
+        "Also published: `mloda-community-rank` (not yet in the table above).\n\n"
+        "## PyPI packages\n",
+    )
+    packages_config = tmp_path / "packages.toml"
+    _write(packages_config, _DATA_OP_PACKAGES_TOML)
+    errors = lint_docs.check_readme_plugin_table(readme, packages_config)
+    assert len(errors) == 1
+    assert "mloda-community-rank" in errors[0]
+
+
+def test_check_readme_plugin_table_handles_plugins_as_last_section(tmp_path: Path) -> None:
+    """The Plugins section must be read to end-of-file when no further ``## `` heading follows."""
+    readme = tmp_path / "README.md"
+    _write(readme, "# Root\n\n" + _COMPLETE_TABLE.rsplit("\n## PyPI packages\n", 1)[0] + "\n")
+    packages_config = tmp_path / "packages.toml"
+    _write(packages_config, _DATA_OP_PACKAGES_TOML)
+    assert lint_docs.check_readme_plugin_table(readme, packages_config) == []
+
+
+def test_check_readme_plugin_table_missing_readme_is_flagged(tmp_path: Path) -> None:
+    packages_config = tmp_path / "packages.toml"
+    _write(packages_config, _DATA_OP_PACKAGES_TOML)
+    errors = lint_docs.check_readme_plugin_table(tmp_path / "missing.md", packages_config)
+    assert len(errors) == 1
+    assert "not found" in errors[0]
+
+
+def test_check_readme_plugin_table_missing_packages_config_is_flagged(tmp_path: Path) -> None:
+    readme = tmp_path / "README.md"
+    _write(readme, _COMPLETE_TABLE)
+    errors = lint_docs.check_readme_plugin_table(readme, tmp_path / "missing.toml")
+    assert len(errors) == 1
+    assert "not found" in errors[0]
+
+
+def test_published_data_operation_packages_real_config_excludes_base() -> None:
+    """Regression guard: the real config/packages.toml base package stays excluded from the required set."""
+    packages = lint_docs._load_packages_config(lint_docs.PACKAGES_CONFIG)
+    names = lint_docs._published_data_operation_packages(packages)
+    assert "mloda-community-data-operations" not in names
+    assert "mloda-community-aggregation" in names
 
 
 def test_check_readme_plugin_table_real_repo_readme_is_complete() -> None:

--- a/tests/test_end2end/test_lint_docs.py
+++ b/tests/test_end2end/test_lint_docs.py
@@ -812,6 +812,94 @@ def test_check_source_property_mapping_has_no_findings_in_real_plugin_source() -
     assert findings == []
 
 
+# check_readme_plugin_table: published data-operation packages must appear in the README Plugins table.
+
+_DATA_OP_PACKAGES_TOML = """
+[packages.mloda-community-data-operations]
+path = "mloda/community/feature_groups/data_operations"
+published = true
+
+[packages.mloda-community-aggregation]
+path = "mloda/community/feature_groups/data_operations/aggregation"
+published = true
+
+[packages.mloda-community-rank]
+path = "mloda/community/feature_groups/data_operations/row_preserving/rank"
+published = true
+
+[packages.mloda-community-unreleased]
+path = "mloda/community/feature_groups/data_operations/row_preserving/unreleased"
+"""
+
+
+def test_check_readme_plugin_table_accepts_complete_table(tmp_path: Path) -> None:
+    readme = tmp_path / "README.md"
+    _write(readme, "## Plugins\n\n`mloda-community-aggregation`\n`mloda-community-rank`\n\n## PyPI packages\n")
+    packages_config = tmp_path / "packages.toml"
+    _write(packages_config, _DATA_OP_PACKAGES_TOML)
+    assert lint_docs.check_readme_plugin_table(readme, packages_config) == []
+
+
+def test_check_readme_plugin_table_flags_missing_package(tmp_path: Path) -> None:
+    readme = tmp_path / "README.md"
+    _write(readme, "## Plugins\n\n`mloda-community-aggregation`\n\n## PyPI packages\n")
+    packages_config = tmp_path / "packages.toml"
+    _write(packages_config, _DATA_OP_PACKAGES_TOML)
+    errors = lint_docs.check_readme_plugin_table(readme, packages_config)
+    assert len(errors) == 1
+    assert "mloda-community-rank" in errors[0]
+
+
+def test_check_readme_plugin_table_excludes_base_and_unpublished_packages(tmp_path: Path) -> None:
+    """The shared data-operations base and an unpublished package must never be required in the table."""
+    readme = tmp_path / "README.md"
+    _write(readme, "## Plugins\n\n`mloda-community-aggregation`\n`mloda-community-rank`\n\n## PyPI packages\n")
+    packages_config = tmp_path / "packages.toml"
+    _write(packages_config, _DATA_OP_PACKAGES_TOML)
+    assert lint_docs.check_readme_plugin_table(readme, packages_config) == []
+
+
+def test_check_readme_plugin_table_ignores_matches_outside_plugins_section(tmp_path: Path) -> None:
+    """A package name mentioned elsewhere in the README does not satisfy the Plugins table requirement."""
+    readme = tmp_path / "README.md"
+    _write(
+        readme,
+        "## Plugins\n\n`mloda-community-aggregation`\n\n## PyPI packages\n\n`mloda-community-rank`\n",
+    )
+    packages_config = tmp_path / "packages.toml"
+    _write(packages_config, _DATA_OP_PACKAGES_TOML)
+    errors = lint_docs.check_readme_plugin_table(readme, packages_config)
+    assert len(errors) == 1
+    assert "mloda-community-rank" in errors[0]
+
+
+def test_check_readme_plugin_table_real_repo_readme_is_complete() -> None:
+    """Regression guard: the real README Plugins table stays in sync with published data-operation packages."""
+    assert lint_docs.check_readme_plugin_table(lint_docs.README_PATH, lint_docs.PACKAGES_CONFIG) == []
+
+
+def test_main_flags_readme_missing_published_package(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write(tmp_path / "guides" / "index.md", "# Guides\n")
+    _write(tmp_path / "README.md", "## Plugins\n\n`mloda-community-aggregation`\n\n## PyPI packages\n")
+    _write(tmp_path / "packages.toml", _DATA_OP_PACKAGES_TOML)
+    monkeypatch.setattr(lint_docs, "DOCS_DIR", tmp_path / "guides")
+    monkeypatch.setattr(lint_docs, "GUIDES_DIR", tmp_path / "guides")
+    monkeypatch.setattr(lint_docs, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(lint_docs, "README_PATH", tmp_path / "README.md")
+    monkeypatch.setattr(lint_docs, "PACKAGES_CONFIG", tmp_path / "packages.toml")
+    empty_plugin_source = tmp_path / "empty_plugin_source"
+    empty_plugin_source.mkdir()
+    monkeypatch.setattr(lint_docs, "PLUGIN_SOURCE_DIR", empty_plugin_source)
+    rc = lint_docs.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "mloda-community-rank" in out
+
+
 def test_main_reports_missing_plugin_source_dir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,9 @@ description = Check docs for broken links/imports and plugin source for raw-dict
 # Needs skip_install, which the lock runner ignores.
 runner = uv-venv-runner
 skip_install = true
+# tomli: nothing else here provides it, and Python 3.10 has no tomllib.
+deps =
+    tomli
 commands =
     python scripts/lint_docs.py
 


### PR DESCRIPTION
## Summary

- The discover-plugins guide told readers to browse a `plugins/` directory that does not exist; it now links `mloda/community/`, `mloda/enterprise/`, and the README's Plugins table.
- `scripts/lint_docs.py` now fails when a published data-operation package in `config/packages.toml` is missing from the README's Plugins table, so the two can no longer drift apart silently.
- `CONTRIBUTING.md` documents that `uv sync --all-extras` alone does not register plugin entry points, so `PluginLoader.all()` won't discover this repo's plugins in a fresh dev checkout, and gives the one-liner workaround (`uv pip install -e mloda/community`).

## Test plan

- [x] `uv run tox` (full gate: pytest, ruff format, ruff check, mypy --strict, bandit) passes
- [x] `tox -e lint-docs` passes, including on a freshly rebuilt env (verifies the added `tomli` dep)
- [x] New unit tests for the README plugin-table check, including edge cases (Plugins as the last section, a name mentioned in prose but not a table row, missing README/config files)
- [x] Manually reproduced the `PluginLoader.all()` discovery gap in a dev checkout and confirmed the documented workaround fixes it