### PR TITLE
fix: close forwarded-op mismatch gap in binning and frame_aggregate

### DIFF
--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/base.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import Any
 
 from mloda.core.abstract_plugins.components.data_types import DataType
@@ -10,6 +12,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import escalate_match_abort
 from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 from mloda.community.feature_groups.data_operations.base import (
     RejectionReasonMixin,
@@ -18,6 +21,8 @@ from mloda.community.feature_groups.data_operations.base import (
     op_token_value,
     positive_int_value,
 )
+
+logger = logging.getLogger(__name__)
 
 BINNING_OPS = {
     "bin": "Equal-width binning (value range divided into n equal intervals)",
@@ -41,6 +46,7 @@ class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup):
             allowed_values=BINNING_OPS,
             match_guard=is_op_token,
         ),
+        # deferred_binding stays True: see _validate_forwarded_n_bins_mismatch for why.
         N_BINS: property_spec(
             "Number of bins (positive integer)",
             match_guard=is_positive_int,
@@ -56,6 +62,58 @@ class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup):
         return operation_config in BINNING_OPS
 
     @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: Any,
+        options: Any,
+        _data_access_collection: Any = None,
+    ) -> bool:
+        if not super().match_feature_group_criteria(feature_name, options, _data_access_collection):
+            return False
+        cls._validate_forwarded_n_bins_mismatch(feature_name, options)
+        return True
+
+    @classmethod
+    def _validate_forwarded_n_bins_mismatch(cls, feature_name: Any, options: Any) -> None:
+        """Reject a forwarded ``n_bins`` that contradicts the name-parsed value.
+
+        The name's digit suffix is never captured by PREFIX_PATTERN (it is parsed by hand in
+        get_binning_params), and its match_guard (is_positive_int) rejects raw capture text anyway,
+        so n_bins can't bind by name like binning_op does; this compares the parsed int directly.
+        """
+        if cls.N_BINS not in (options.inherited_group_keys or ()):
+            return
+        prefix_patterns = cls._get_prefix_patterns()
+        operation_config, source_feature = FeatureChainParser.parse_feature_name(str(feature_name), prefix_patterns)
+        if operation_config is None or source_feature is None:
+            return
+        name_n_bins = cls._name_n_bins(str(feature_name))
+        forwarded = options.get(cls.N_BINS)
+        if forwarded is None:
+            return
+        forwarded_n_bins = positive_int_value(forwarded)
+        if forwarded_n_bins == name_n_bins:
+            return
+        message = (
+            f"Feature '{feature_name}': option '{cls.N_BINS}' was forwarded from a consumer with value "
+            f"'{forwarded}', but the feature name parses to {name_n_bins}. The name-parsed value takes "
+            f"precedence, so the forwarded value would be silently ignored. Carve the key out with "
+            f"forward_group_exclude={{'{cls.N_BINS}'}} on the child in the consumer's input_features, or use "
+            f"an allowlist / forward_group=False. Set MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1 to downgrade this "
+            f"error to a warning."
+        )
+        if os.environ.get("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "").lower() in ("1", "true"):
+            logger.warning(message)
+            return
+        # Marked: user misconfiguration; containing it would let a rival group win with the value ignored.
+        raise escalate_match_abort(ValueError(message))
+
+    @staticmethod
+    def _name_n_bins(feature_name: str) -> int:
+        """The digit suffix PREFIX_PATTERN anchors on, e.g. 5 in ``value__bin_5``."""
+        return int(feature_name.rsplit("_", 1)[-1])
+
+    @classmethod
     def _validate_n_bins(cls, n_bins: int, feature_name: str) -> None:
         if n_bins < 1:
             raise ValueError(f"n_bins must be >= 1, got {n_bins} (feature: {feature_name})")
@@ -65,7 +123,7 @@ class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup):
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None and source_feature is not None:
-            n_bins = int(feature_name.rsplit("_", 1)[-1])
+            n_bins = cls._name_n_bins(feature_name)
             cls._validate_n_bins(n_bins, feature_name)
             return operation_config, n_bins
         raise ValueError(f"Could not extract binning parameters from feature name: {feature_name}")
@@ -76,7 +134,7 @@ class BinningFeatureGroup(RejectionReasonMixin, FeatureGroup):
         prefix_patterns = cls._get_prefix_patterns()
         operation_config, source_feature = FeatureChainParser.parse_feature_name(feature_name, prefix_patterns)
         if operation_config is not None:
-            n_bins = int(feature_name.rsplit("_", 1)[-1])
+            n_bins = cls._name_n_bins(feature_name)
             cls._validate_n_bins(n_bins, feature_name)
             return operation_config, n_bins
         op = feature.options.get(cls.BINNING_OP)

--- a/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/binning/tests/test_base.py
@@ -187,6 +187,41 @@ class TestReturnDataTypeRule:
         assert BinningFeatureGroup.return_data_type_rule(feature) == DataType.INT64
 
 
+class TestForwardedNBinsMismatch:
+    """A group-forwarded ``n_bins`` that contradicts the name-parsed value is rejected, not silently ignored."""
+
+    def test_mismatched_forwarded_n_bins_raises(self) -> None:
+        consumer_options = Options(group={"n_bins": 10})
+        child_options = Options()
+        child_options.inherit_from(consumer_options)
+
+        with pytest.raises(ValueError, match="n_bins"):
+            BinningFeatureGroup.match_feature_group_criteria("value_int__bin_5", child_options, None)
+
+    def test_matching_forwarded_n_bins_is_accepted(self) -> None:
+        consumer_options = Options(group={"n_bins": 5})
+        child_options = Options()
+        child_options.inherit_from(consumer_options)
+
+        result = BinningFeatureGroup.match_feature_group_criteria("value_int__bin_5", child_options, None)
+        assert result is True
+
+    def test_locally_set_contradictory_n_bins_is_not_flagged(self) -> None:
+        options = Options(context={"n_bins": 10})
+
+        result = BinningFeatureGroup.match_feature_group_criteria("value_int__bin_5", options, None)
+        assert result is True
+
+    def test_mismatched_n_bins_env_downgrade_is_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "1")
+        consumer_options = Options(group={"n_bins": 10})
+        child_options = Options()
+        child_options.inherit_from(consumer_options)
+
+        result = BinningFeatureGroup.match_feature_group_criteria("value_int__bin_5", child_options, None)
+        assert result is True
+
+
 class TestBinningMatchValidation(MatchValidationTestBase):
     @classmethod
     def feature_group_class(cls) -> Any:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/base.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import functools
+import logging
+import os
 import re
 from typing import Any
 
@@ -11,6 +13,7 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import escalate_match_abort
 from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec, record_match_rejection
 
 from mloda.community.feature_groups.data_operations.base import (
@@ -52,6 +55,8 @@ _EXPANDING_PATTERN = re.compile(r"^.+__expanding_(\w+)$")
 # full set, so they need no narrower table of their own.
 _AGGREGATION_TYPES = frozenset({"sum", "avg", "count", "min", "max", "std", "var", "median"})
 _TIME_UNITS = {"second", "minute", "hour", "day", "week", "month", "year"}
+
+logger = logging.getLogger(__name__)
 
 
 def _option_token(options: Options, key: str) -> str | None:
@@ -229,7 +234,8 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
                 "expanding": "Same as cumulative",
             },
             match_guard=is_op_token,
-            # A frame name carries its own type via _parse_frame_feature, not a named capture.
+            # A frame name carries its own type via _parse_frame_feature, not a named capture; see
+            # _validate_forwarded_frame_mismatch for the forwarded-value protection this loses.
             deferred_binding=True,
         ),
         FRAME_SIZE: property_spec(
@@ -334,10 +340,14 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
         if not super().match_feature_group_criteria(feature_name, options, _data_access_collection):
             return False
 
+        parsed = cls._parse_frame_feature(str(feature_name))
+        if parsed is not None:
+            cls._validate_forwarded_frame_mismatch(feature_name, options, parsed)
+
         # Config path only: SUPPORTED_* narrows per subclass, so it cannot be declared once on the base.
         # frame_size/frame_unit requiredness is hand-enforced here (not via PROPERTY_MAPPING
         # required_when) so it can never mis-fire on the name path; see the PROPERTY_MAPPING comment.
-        if cls._parse_frame_feature(str(feature_name)) is None:
+        if parsed is None:
             frame_type = _option_token(options, cls.FRAME_TYPE)
             if frame_type not in cls.SUPPORTED_FRAME_TYPES:
                 return False
@@ -363,6 +373,44 @@ class FrameAggregateFeatureGroup(SubtypeCapabilityHook, RejectionReasonMixin, Fe
             return False
 
         return True
+
+    @classmethod
+    def _validate_forwarded_frame_mismatch(cls, feature_name: Any, options: Any, parsed: dict[str, Any]) -> None:
+        """Reject a forwarded frame_type/frame_size/frame_unit that contradicts the name-parsed value.
+
+        None of the three bind by name the way aggregation_type does: frame_type is inferred from
+        which PREFIX_PATTERN shape matched rather than captured text (not all of its values are
+        literal substrings of the name); frame_size's captured digits are a str while its match_guard
+        only accepts a real int; and frame_unit, though captured and a member of its own
+        allowed_values, is the pattern's third capture, which the legacy first-capture-only fallback
+        never reaches. Compares the already-typed parsed values directly.
+        """
+        inherited = options.inherited_group_keys or ()
+        for key, name_value, unwrap in (
+            (cls.FRAME_TYPE, parsed["frame_type"], op_token_value),
+            (cls.FRAME_SIZE, parsed["frame_size"], positive_int_value),
+            (cls.FRAME_UNIT, parsed["frame_unit"], op_token_value),
+        ):
+            if key not in inherited or name_value is None:
+                continue
+            forwarded = options.get(key)
+            if forwarded is None:
+                continue
+            if unwrap(forwarded) == name_value:
+                continue
+            message = (
+                f"Feature '{feature_name}': option '{key}' was forwarded from a consumer with value "
+                f"'{forwarded}', but the feature name parses to '{name_value}'. The name-parsed value "
+                f"takes precedence, so the forwarded value would be silently ignored. Carve the key out "
+                f"with forward_group_exclude={{'{key}'}} on the child in the consumer's input_features, "
+                f"or use an allowlist / forward_group=False. Set MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1 to "
+                f"downgrade this error to a warning."
+            )
+            if os.environ.get("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "").lower() in ("1", "true"):
+                logger.warning(message)
+                continue
+            # Marked: user misconfiguration; containing it would let a rival group win with the value ignored.
+            raise escalate_match_abort(ValueError(message))
 
     @classmethod
     def _capability_subtype(cls, feature_name: str, options: Options) -> str | None:

--- a/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
+++ b/mloda/community/feature_groups/data_operations/row_preserving/frame_aggregate/tests/test_base.py
@@ -517,6 +517,50 @@ class TestForwardedNameMismatch:
         with pytest.raises(ValueError):
             FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
 
+    def test_forwarded_frame_type_mismatch_raises(self) -> None:
+        consumer = Options(group={"frame_type": "time"})
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        options.inherit_from(consumer)
+        with pytest.raises(ValueError, match="frame_type"):
+            FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
+
+    def test_forwarded_frame_size_mismatch_raises(self) -> None:
+        consumer = Options(group={"frame_size": 99})
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        options.inherit_from(consumer)
+        with pytest.raises(ValueError, match="frame_size"):
+            FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
+
+    def test_forwarded_frame_unit_mismatch_raises(self) -> None:
+        consumer = Options(group={"frame_unit": "hour"})
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        options.inherit_from(consumer)
+        with pytest.raises(ValueError, match="frame_unit"):
+            FrameAggregateFeatureGroup.match_feature_group_criteria("sales__avg_7_day_window", options, None)
+
+    def test_matching_forwarded_frame_params_is_accepted(self) -> None:
+        consumer = Options(group={"frame_type": "time", "frame_size": 7, "frame_unit": "day"})
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        options.inherit_from(consumer)
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__avg_7_day_window", options, None)
+        assert result is True
+
+    def test_forwarded_frame_type_mismatch_env_downgrade_is_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "1")
+        consumer = Options(group={"frame_type": "time"})
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        options.inherit_from(consumer)
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria("sales__sum_rolling_3", options, None)
+        assert result is True
+
+    @pytest.mark.parametrize("feature_name", ["sales__cumsum", "sales__expanding_avg"])
+    def test_sizeless_shapes_ignore_forwarded_frame_size_and_unit(self, feature_name: str) -> None:
+        consumer = Options(group={"frame_size": 99, "frame_unit": "hour"})
+        options = Options(context={"partition_by": ["region"], "order_by": "timestamp"})
+        options.inherit_from(consumer)
+        result = FrameAggregateFeatureGroup.match_feature_group_criteria(feature_name, options, None)
+        assert result is True
+
 
 #: Each frame name shape, its configuration equivalent, and the same shape with a malformed agg token.
 _FRAME_SHAPE_PAIRS: list[tuple[str, dict[str, Any], str]] = [


### PR DESCRIPTION
## Summary

- `binning_op` and `aggregation_type` were already protected against a forwarded value that contradicts a feature's name-parsed value (verified): both are always the first capture of their pattern, and their value is a member of their own `allowed_values`, so the legacy positional binding fallback already caught a mismatch there.
- `n_bins` (binning) and `frame_type` / `frame_size` / `frame_unit` (frame_aggregate) were not protected. `n_bins` and `frame_size` are digit suffixes the option's own `match_guard` requires as a real int, not the string a regex capture would produce. `frame_type` is inferred from which of frame_aggregate's four name shapes matched rather than from any captured text at all (for two of its four values, the value itself is never a literal substring of the name). `frame_unit` is captured and a member of its own `allowed_values`, but the legacy fallback only ever looks at a pattern's first capture group, so it was never reached.
- Both feature groups now enforce this protection directly in `match_feature_group_criteria`, reusing each group's own existing name-parsing (binning's digit-suffix extraction, frame_aggregate's already-typed frame-shape parser) to compare the name-derived value against a forwarded one, instead of relying on a name capture that can't represent these values.

## Test plan

- [x] Added tests per feature group: a forwarded mismatch is rejected, a matching forward is accepted, a locally-set (non-forwarded) value is not flagged, and the `MLODA_ALLOW_FORWARDED_NAME_MISMATCH` downgrade-to-warning path is honored.
- [x] Added coverage for frame_aggregate's sizeless name shapes (cumulative, expanding), confirming a forwarded `frame_size`/`frame_unit` is correctly ignored there rather than misfiring.
- [x] Full `tox` (pytest, ruff format, ruff check, mypy --strict, bandit) passes clean on all touched files.