### PR TITLE
docs(feature-group-patterns): add named-capture PREFIX_PATTERN example

### DIFF
--- a/docs/guides/feature-group-patterns/14-feature-matching.md
+++ b/docs/guides/feature-group-patterns/14-feature-matching.md
@@ -59,6 +59,7 @@ When multiple method variants exist for a feature group type (e.g., different sc
 | `AggregatedFeatureGroup` | `aggregation_type` | `r".*__([\w]+)_aggr$"` |
 | `ScalingFeatureGroup` | `scaler_type` | `r".*__(standard|minmax|robust|normalizer)_scaled$"` |
 | `EncodingFeatureGroup` | `encoder_type` | `r".*__(onehot|label|ordinal)_encoded(~\d+)?$"` |
+| `RankFeatureGroup` (named capture) | `rank_type` | `r".*__(?P<rank_type>[\w]+)_ranked$"` |
 
 ### Pattern
 
@@ -104,6 +105,35 @@ Feature("my_output", Options(context={"my_method": "algo_b", "in_features": "inp
 ```
 
 **Note:** Subclasses typically only override `compute_framework_rule()` to specify which framework they support (Pandas, Polars, etc.), not matching logic.
+
+### Named-Capture Form
+
+The example above uses a legacy positional capture group: `bind_name_captures` only binds `MY_METHOD`'s value when it is already a member of `MY_METHODS` (`allowed_values`), so an unsupported token in the feature name just fails to bind rather than reaching `element_validator`. Name the capture group after the `PROPERTY_MAPPING` key instead, and the mixin binds it unconditionally, so `element_validator` and `match_guard` run against it like any explicit option and can reject it (see [What a Validator Receives](#what-a-validator-receives)):
+
+```python
+class BaseMyTransform(FeatureChainParserMixin, FeatureGroup):
+    # Named capture: the group name ("my_method") is itself the PROPERTY_MAPPING key, so a
+    # permissive regex still only matches supported values, via allowed_values / element_validator
+    # rather than the regex alternation.
+    PREFIX_PATTERN = r".*__(?P<my_method>[\w]+)_transformed$"
+
+    MY_METHOD = "my_method"
+    MY_METHODS = {
+        "algo_a": "Algorithm A description",
+        "algo_b": "Algorithm B description",
+    }
+
+    PROPERTY_MAPPING = {
+        MY_METHOD: property_spec(
+            "Transform algorithm",
+            strict=True,
+            allowed_values=MY_METHODS,
+        ),
+        DefaultOptionKeys.in_features: property_spec("Source feature"),
+    }
+```
+
+`Feature("input__algo_b_transformed")` matches and binds `my_method="algo_b"` under both forms. They diverge on an unsupported token like `input__algo_c_transformed`: against the positional pattern (loosened to `[\w]+` so the regex itself would accept it), `"algo_c"` never binds to `my_method` at all, since `bind_name_captures` only binds values already in `allowed_values`; against the named-capture pattern, `"algo_c"` binds and is then rejected by `allowed_values`/`element_validator` with a recorded reason. See `RankFeatureGroup.PREFIX_PATTERN` (`mloda/community/feature_groups/data_operations/row_preserving/rank/base.py`) for a production named-capture example with an `element_validator`.
 
 ### Extracting the Discriminator at Compute Time
 


### PR DESCRIPTION
## Summary

- `docs/guides/feature-group-patterns/14-feature-matching.md` explains that a named-capture `PREFIX_PATTERN` group (whose capture name matches a `PROPERTY_MAPPING` key) binds unconditionally and is validated via `element_validator`/`match_guard`, unlike a legacy positional capture, which only binds an already-`allowed_values` value.
- Every `PREFIX_PATTERN` example in the guide used the positional form, so there was no concrete model for the named-capture case the guide describes.
- Adds a "Named-Capture Form" subsection with a named-capture variant of the existing `BaseMyTransform` example, contrasts it against the positional form on an unsupported token (`algo_c`), and adds a `RankFeatureGroup` row to the existing-examples table as a production reference.

## Verification

Confirmed the binding/validation contrast described in the new prose against real core code (not just by reading), using `mloda`'s `FeatureChainParser.bind_name_captures` and `match_feature_group_criteria` directly:

- Named-capture pattern: an unsupported token (`algo_c`) binds to the option and is then rejected by `allowed_values`.
- Positional pattern: the same token never binds at all (`bind_name_captures` returns `{}`), so matching fails on "required option absent" instead of a value rejection.

```
named bindings for algo_c: {'my_method': 'algo_c'}
positional bindings for algo_c: {}
positional bindings for algo_b: {'my_method': 'algo_b'}
```

## Test plan

- [x] `.venv/bin/python scripts/lint_docs.py` → `All docs OK.`
- [x] `.venv/bin/python -m pytest tests/test_end2end/test_lint_docs.py -q` → 80 passed
- [x] `.venv/bin/ruff check .` → All checks passed
- [x] Manually verified the doc's binding/validation claims against `mloda.core...feature_chain_parser` (see above)

Fixes #459