### PR TITLE
test(data-operations): cross-validate manifest optional-backends allowlist against packaging config

### DIFF
--- a/tests/test_end2end/test_manifest_resilience.py
+++ b/tests/test_end2end/test_manifest_resilience.py
@@ -22,16 +22,24 @@ silently. The guard only sees direct top-level third-party imports under
 mloda core's own compute-framework shims (e.g. duckdb, which has no direct
 import anywhere under ``data_operations/**`` and is only ever imported inside
 ``mloda_plugins.compute_framework.base_implementations.duckdb.*``) is invisible
-to this guard and relies on core's own try/except shims guarding it.
+to this guard and relies on core's own try/except shims guarding it. A second guard
+cross-validates the allowlist against ``config/packages.toml``'s declared optional
+frameworks, so a required dependency cannot be silently marked optional.
 """
 
 from __future__ import annotations
 
 import ast
+import re
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
 
 import pytest
 
@@ -42,9 +50,13 @@ _IMPORT_MODULE_TARGET = "mloda.community.feature_groups.data_operations.manifest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DATA_OPERATIONS_ROOT = _REPO_ROOT / "mloda" / "community" / "feature_groups" / "data_operations"
+_PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
 
 # mloda and mloda_plugins are required core dependencies, not optional backends.
 _FIRST_PARTY_IMPORT_ROOTS = frozenset({"mloda", "mloda_plugins"})
+
+# numpy is only ever missing because pandas needs it, never its own optional extra.
+_TRANSITIVE_ONLY_OPTIONAL_ROOTS = frozenset({"numpy"})
 
 
 class _KeptClass:
@@ -211,6 +223,30 @@ def test_except_handler_fallback_import_root_is_caught(tmp_path: Path) -> None:
     }
 
 
+def _load_toml(path: Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _dep_name(spec: str) -> str:
+    """Extract the bare package name from a PEP 508 requirement string."""
+    return re.split(r"[<>=!~\s\[]", spec, maxsplit=1)[0].strip()
+
+
+def _declared_optional_framework_roots() -> set[str]:
+    """Third-party import roots the data_operations packages declare as optional extras in packages.toml."""
+    packages: dict[str, dict[str, Any]] = _load_toml(_PACKAGES_CONFIG).get("packages", {})
+    roots: set[str] = set()
+    for pkg_config in packages.values():
+        if not pkg_config.get("path", "").startswith("mloda/community/feature_groups/data_operations"):
+            continue
+        for extra_name, specs in pkg_config.get("optional_dependencies", {}).items():
+            if extra_name == "all":
+                continue
+            roots.update(_dep_name(spec) for spec in specs)
+    return roots
+
+
 def test_data_operations_import_roots_are_covered_by_optional_backends() -> None:
     assert _DATA_OPERATIONS_ROOT.is_dir(), f"data_operations tree not found at {_DATA_OPERATIONS_ROOT}"
 
@@ -223,4 +259,20 @@ def test_data_operations_import_roots_are_covered_by_optional_backends() -> None
         + "; ".join(f"{root} (used by {', '.join(str(p) for p in files_by_root[root])})" for root in missing)
         + "; add it to _OPTIONAL_BACKENDS only if it is an optional framework or a transitive dependency of one, "
         "a required dependency must stay a hard failure."
+    )
+
+
+def test_optional_backends_matches_packages_config_declared_frameworks() -> None:
+    """_OPTIONAL_BACKENDS must equal packages.toml's declared optional frameworks plus documented transitive roots.
+
+    Catches a required dependency being silently added to the allowlist: any root that is neither
+    declared optional in config/packages.toml nor in _TRANSITIVE_ONLY_OPTIONAL_ROOTS fails this test.
+    """
+    expected = _declared_optional_framework_roots() | _TRANSITIVE_ONLY_OPTIONAL_ROOTS
+    assert manifest_utils._OPTIONAL_BACKENDS == expected, (
+        f"manifest_utils._OPTIONAL_BACKENDS {sorted(manifest_utils._OPTIONAL_BACKENDS)} does not match "
+        f"config/packages.toml's declared optional frameworks plus transitive roots {sorted(expected)}; "
+        "add a genuinely optional framework to config/packages.toml's optional_dependencies (not just "
+        "_OPTIONAL_BACKENDS), or if it is purely transitive (like numpy), add it to "
+        "_TRANSITIVE_ONLY_OPTIONAL_ROOTS above."
     )

--- a/tests/test_end2end/test_manifest_resilience.py
+++ b/tests/test_end2end/test_manifest_resilience.py
@@ -47,6 +47,7 @@ _IMPORT_MODULE_TARGET = "mloda.community.feature_groups.data_operations.manifest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DATA_OPERATIONS_ROOT = _REPO_ROOT / "mloda" / "community" / "feature_groups" / "data_operations"
+_DATA_OPERATIONS_REL = _DATA_OPERATIONS_ROOT.relative_to(_REPO_ROOT).as_posix()
 _PACKAGES_CONFIG = _REPO_ROOT / "config" / "packages.toml"
 
 # mloda and mloda_plugins are required core dependencies, not optional backends.
@@ -54,6 +55,11 @@ _FIRST_PARTY_IMPORT_ROOTS = frozenset({"mloda", "mloda_plugins"})
 
 # numpy is only ever missing because pandas needs it, never its own optional extra.
 _TRANSITIVE_ONLY_OPTIONAL_ROOTS = frozenset({"numpy"})
+
+# Extras that never name a compute framework: 'all' just re-aggregates the others; 'dev' is
+# tooling (see config/shared.toml [defaults].optional_dependencies and mloda-testing's own
+# 'dev' extra in this file), never a compute-framework backend.
+_NON_FRAMEWORK_EXTRAS = frozenset({"all", "dev"})
 
 
 class _KeptClass:
@@ -226,20 +232,32 @@ def _load_toml(path: Path) -> dict[str, Any]:
 
 def _dep_name(spec: str) -> str:
     """Extract the bare package name from a PEP 508 requirement string."""
-    return re.split(r"[<>=!~\s\[]", spec, maxsplit=1)[0].strip()
+    return re.split(r"[<>=!~;\s\[(@]", spec.strip(), maxsplit=1)[0]
 
 
 def _declared_optional_framework_roots() -> set[str]:
-    """Third-party import roots the data_operations packages declare as optional extras in packages.toml."""
+    """PyPI distribution names the data_operations packages declare as optional extras in packages.toml.
+
+    Compared directly against manifest_utils._OPTIONAL_BACKENDS' import roots; this only works because
+    today's optional frameworks share their distribution name with their import name. A future optional
+    framework whose distribution name differs from its import root (e.g. scikit-learn -> sklearn) needs
+    its own explicit mapping, not a _TRANSITIVE_ONLY_OPTIONAL_ROOTS entry (reserved for genuinely
+    transitive dependencies, e.g. numpy via pandas).
+    """
+    assert _PACKAGES_CONFIG.is_file(), f"packages config not found at {_PACKAGES_CONFIG}"
     packages: dict[str, dict[str, Any]] = _load_toml(_PACKAGES_CONFIG).get("packages", {})
     roots: set[str] = set()
     for pkg_config in packages.values():
-        if not pkg_config.get("path", "").startswith("mloda/community/feature_groups/data_operations"):
+        path = pkg_config.get("path", "")
+        if path != _DATA_OPERATIONS_REL and not path.startswith(_DATA_OPERATIONS_REL + "/"):
             continue
         for extra_name, specs in pkg_config.get("optional_dependencies", {}).items():
-            if extra_name == "all":
+            if extra_name in _NON_FRAMEWORK_EXTRAS:
                 continue
-            roots.update(_dep_name(spec) for spec in specs)
+            assert isinstance(specs, list), (
+                f"{pkg_config.get('path')}: optional_dependencies.{extra_name} must be a list, got {specs!r}"
+            )
+            roots.update(_dep_name(spec) for spec in specs if "{" not in spec)
     return roots
 
 
@@ -265,10 +283,13 @@ def test_optional_backends_matches_packages_config_declared_frameworks() -> None
     declared optional in config/packages.toml nor in _TRANSITIVE_ONLY_OPTIONAL_ROOTS fails this test.
     """
     expected = _declared_optional_framework_roots() | _TRANSITIVE_ONLY_OPTIONAL_ROOTS
-    assert manifest_utils._OPTIONAL_BACKENDS == expected, (
-        f"manifest_utils._OPTIONAL_BACKENDS {sorted(manifest_utils._OPTIONAL_BACKENDS)} does not match "
-        f"config/packages.toml's declared optional frameworks plus transitive roots {sorted(expected)}; "
-        "add a genuinely optional framework to config/packages.toml's optional_dependencies (not just "
-        "_OPTIONAL_BACKENDS), or if it is purely transitive (like numpy), add it to "
-        "_TRANSITIVE_ONLY_OPTIONAL_ROOTS above."
+    unexpected = manifest_utils._OPTIONAL_BACKENDS - expected
+    missing = expected - manifest_utils._OPTIONAL_BACKENDS
+    assert not unexpected and not missing, (
+        f"manifest_utils._OPTIONAL_BACKENDS diverges from config/packages.toml's declared optional "
+        f"frameworks plus transitive roots. "
+        f"In _OPTIONAL_BACKENDS but not declared optional or transitive (may be a required dependency "
+        f"added to the allowlist by mistake): {sorted(unexpected)}. "
+        f"Declared optional in config/packages.toml but missing from _OPTIONAL_BACKENDS (add it there so "
+        f"its backend is skipped when not installed): {sorted(missing)}."
     )

--- a/tests/test_end2end/test_manifest_resilience.py
+++ b/tests/test_end2end/test_manifest_resilience.py
@@ -14,10 +14,7 @@ module's top-level third-party import root is covered by ``_OPTIONAL_BACKENDS``,
 so a backend module that top-imports an uncovered root fails this test instead
 of silently breaking a bare floor install. ``third_party_import_roots_by_file``
 is the public scanner backing that guard; a ``tmp_path`` battery below pins its
-behaviour directly, including that an import inside a module-level ``except:``
-handler is walked, and the real-tree test also asserts the walk is non-vacuous
-so a moved or emptied ``data_operations`` tree cannot make the guard pass
-silently. The guard only sees direct top-level third-party imports under
+behaviour directly. The guard only sees direct top-level third-party imports under
 ``data_operations/**``; an optional framework reached only indirectly through
 mloda core's own compute-framework shims (e.g. duckdb, which has no direct
 import anywhere under ``data_operations/**`` and is only ever imported inside
@@ -211,8 +208,7 @@ def test_except_handler_fallback_import_root_is_caught(tmp_path: Path) -> None:
     if the except body itself falls back to importing a *different* optional root, that
     fallback import lives only inside the ``ExceptHandler`` node. A naive walk that only
     recurses into ``ast.stmt`` children would miss it, since ``ast.ExceptHandler`` is not
-    an ``ast.stmt``. This pins the fixed walker's behaviour: it descends into the handler
-    body and catches the fallback root.
+    an ``ast.stmt``.
     """
     body = "try:\n    import polars as pl\nexcept ImportError:\n    import pandas as pl\n"
     _write(tmp_path / "m.py", body)

--- a/tests/test_end2end/test_manifest_resilience.py
+++ b/tests/test_end2end/test_manifest_resilience.py
@@ -1,27 +1,6 @@
-"""Unit tests for the resilient manifest loader helper (issue #271).
-
-``load_plugin_classes`` builds an entry-point manifest's class list by importing
-each backend module individually. A backend whose optional compute framework
-(pandas, polars, duckdb, pyarrow, numpy) is not installed must be skipped so the
-rest still register, while any other import error must stay loud. numpy is
-transitive: it is only ever missing because pandas needs it, not because a
-backend module targets a "numpy compute framework" directly. These tests drive
-that behaviour by monkeypatching the helper module's ``importlib.import_module``,
-so they need no optional framework installed and touch no network.
-
-A further test walks the real data_operations tree on disk and asserts every
-module's top-level third-party import root is covered by ``_OPTIONAL_BACKENDS``,
-so a backend module that top-imports an uncovered root fails this test instead
-of silently breaking a bare floor install. ``third_party_import_roots_by_file``
-is the public scanner backing that guard; a ``tmp_path`` battery below pins its
-behaviour directly. The guard only sees direct top-level third-party imports under
-``data_operations/**``; an optional framework reached only indirectly through
-mloda core's own compute-framework shims (e.g. duckdb, which has no direct
-import anywhere under ``data_operations/**`` and is only ever imported inside
-``mloda_plugins.compute_framework.base_implementations.duckdb.*``) is invisible
-to this guard and relies on core's own try/except shims guarding it. A second guard
-cross-validates the allowlist against ``config/packages.toml``'s declared optional
-frameworks, so a required dependency cannot be silently marked optional.
+"""Tests for the resilient manifest loader: a backend missing its optional compute framework is
+skipped, not fatal, while any other import error still raises. Two guards keep _OPTIONAL_BACKENDS
+honest: an on-disk import-root sweep, and a cross-check against config/packages.toml.
 """
 
 from __future__ import annotations
@@ -56,9 +35,7 @@ _FIRST_PARTY_IMPORT_ROOTS = frozenset({"mloda", "mloda_plugins"})
 # numpy is only ever missing because pandas needs it, never its own optional extra.
 _TRANSITIVE_ONLY_OPTIONAL_ROOTS = frozenset({"numpy"})
 
-# Extras that never name a compute framework: 'all' just re-aggregates the others; 'dev' is
-# tooling (see config/shared.toml [defaults].optional_dependencies and mloda-testing's own
-# 'dev' extra in this file), never a compute-framework backend.
+# Extras that never name a compute framework: aggregate ('all') or tooling ('dev').
 _NON_FRAMEWORK_EXTRAS = frozenset({"all", "dev"})
 
 
@@ -208,14 +185,7 @@ def test_third_party_import_roots_by_file_catches_both_roots_like_pandas_binning
 
 
 def test_except_handler_fallback_import_root_is_caught(tmp_path: Path) -> None:
-    """An import inside a module-level ``except ImportError:`` handler must be caught.
-
-    mloda core's framework shims use ``try: import <framework> / except ImportError: ...``;
-    if the except body itself falls back to importing a *different* optional root, that
-    fallback import lives only inside the ``ExceptHandler`` node. A naive walk that only
-    recurses into ``ast.stmt`` children would miss it, since ``ast.ExceptHandler`` is not
-    an ``ast.stmt``.
-    """
+    """An import inside a module-level except handler is caught (ast.ExceptHandler is not an ast.stmt)."""
     body = "try:\n    import polars as pl\nexcept ImportError:\n    import pandas as pl\n"
     _write(tmp_path / "m.py", body)
     files_by_root = third_party_import_roots_by_file(tmp_path)
@@ -236,14 +206,7 @@ def _dep_name(spec: str) -> str:
 
 
 def _declared_optional_framework_roots() -> set[str]:
-    """PyPI distribution names the data_operations packages declare as optional extras in packages.toml.
-
-    Compared directly against manifest_utils._OPTIONAL_BACKENDS' import roots; this only works because
-    today's optional frameworks share their distribution name with their import name. A future optional
-    framework whose distribution name differs from its import root (e.g. scikit-learn -> sklearn) needs
-    its own explicit mapping, not a _TRANSITIVE_ONLY_OPTIONAL_ROOTS entry (reserved for genuinely
-    transitive dependencies, e.g. numpy via pandas).
-    """
+    """PyPI distribution names the data_operations packages declare as optional extras in packages.toml."""
     assert _PACKAGES_CONFIG.is_file(), f"packages config not found at {_PACKAGES_CONFIG}"
     packages: dict[str, dict[str, Any]] = _load_toml(_PACKAGES_CONFIG).get("packages", {})
     roots: set[str] = set()
@@ -277,11 +240,6 @@ def test_data_operations_import_roots_are_covered_by_optional_backends() -> None
 
 
 def test_optional_backends_matches_packages_config_declared_frameworks() -> None:
-    """_OPTIONAL_BACKENDS must equal packages.toml's declared optional frameworks plus documented transitive roots.
-
-    Catches a required dependency being silently added to the allowlist: any root that is neither
-    declared optional in config/packages.toml nor in _TRANSITIVE_ONLY_OPTIONAL_ROOTS fails this test.
-    """
     expected = _declared_optional_framework_roots() | _TRANSITIVE_ONLY_OPTIONAL_ROOTS
     unexpected = manifest_utils._OPTIONAL_BACKENDS - expected
     missing = expected - manifest_utils._OPTIONAL_BACKENDS


### PR DESCRIPTION
## Summary

`manifest_utils._OPTIONAL_BACKENDS` is a hand-maintained allowlist of third-party import roots that `load_plugin_classes` treats as "optional framework not installed, skip this backend" rather than a hard error. It had no link to `config/packages.toml`, which already declares per-package which frameworks are genuinely optional.

The existing AST-based guard in `tests/test_end2end/test_manifest_resilience.py` only checks that the allowlist is a superset of what's actually imported under `data_operations/**`. That direction alone cannot tell a genuinely optional framework apart from a required dependency added to the set by mistake.

## Changes

- Add a second guard test that cross-validates `_OPTIONAL_BACKENDS` against `config/packages.toml`'s declared `optional_dependencies` for the data_operations package family, plus an explicit, documented transitive-only root (`numpy`, which is only ever missing because pandas needs it). A required dependency added to the allowlist now fails this test instead of silently passing.
- Harden the guard against plausible future drift: skip the `dev` extra (tooling, never a compute-framework backend) and unexpanded `{...}` placeholder specs, fix the PEP 508 name-extraction regex for marker/paren/leading-space forms, guard against a non-list extras value, derive the data_operations path prefix instead of duplicating it as a literal, and report failures as a symmetric set difference.
- No production code changes: `config/packages.toml` is not shipped inside any published package's wheel, so deriving the allowlist from it at runtime isn't viable; the cross-validation lives in the test suite instead.

## Test plan

- [x] `tox` (full gate: pytest, ruff format/check, mypy --strict, bandit) passes.