### PR TITLE
fix(packaging): add backend extras to datetime and string

### DIFF
--- a/config/packages.toml
+++ b/config/packages.toml
@@ -171,6 +171,7 @@ description = "Datetime extraction feature group (element-wise, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.4.4"]
 path = "mloda/community/feature_groups/data_operations/row_preserving/datetime"
 published = true
+optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], python_dict = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-string]
@@ -178,6 +179,7 @@ description = "String operation feature group (element-wise, row-preserving)"
 dependencies = ["mloda-community-data-operations>=0.4.4"]
 path = "mloda/community/feature_groups/data_operations/string"
 published = true
+optional_dependencies = { pyarrow = ["pyarrow"], sqlite = [], python_dict = [], duckdb = ["duckdb"], polars = ["polars"], pandas = ["pandas"], all = ["pyarrow", "polars", "pandas", "duckdb"] }
 entry_point_groups = ["mloda.feature_groups"]
 
 [packages.mloda-community-binning]

--- a/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/row_preserving/datetime/pyproject.toml
@@ -16,6 +16,13 @@ requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]
+pyarrow = ["pyarrow"]
+sqlite = []
+python_dict = []
+duckdb = ["duckdb"]
+polars = ["polars"]
+pandas = ["pandas"]
+all = ["pyarrow", "polars", "pandas", "duckdb"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/mloda/community/feature_groups/data_operations/string/pyproject.toml
+++ b/mloda/community/feature_groups/data_operations/string/pyproject.toml
@@ -16,6 +16,13 @@ requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
 dev = ["mloda-testing", "pytest>=9.0.3"]
+pyarrow = ["pyarrow"]
+sqlite = []
+python_dict = []
+duckdb = ["duckdb"]
+polars = ["polars"]
+pandas = ["pandas"]
+all = ["pyarrow", "polars", "pandas", "duckdb"]
 
 [project.urls]
 Homepage = "https://mloda.ai"

--- a/tests/test_end2end/test_backend_optional_dependencies.py
+++ b/tests/test_end2end/test_backend_optional_dependencies.py
@@ -1,0 +1,45 @@
+"""Backend extras declared by data-operation leaf distributions."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+import pytest
+
+_PACKAGES_CONFIG = Path(__file__).resolve().parents[2] / "config" / "packages.toml"
+
+_FULL_BACKEND_EXTRAS = {
+    "pyarrow": ["pyarrow"],
+    "sqlite": [],
+    "python_dict": [],
+    "duckdb": ["duckdb"],
+    "polars": ["polars"],
+    "pandas": ["pandas"],
+    "all": ["pyarrow", "polars", "pandas", "duckdb"],
+}
+
+_FULL_BACKEND_PACKAGES = ["mloda-community-datetime", "mloda-community-string"]
+
+
+def _packages() -> dict[str, dict[str, Any]]:
+    with open(_PACKAGES_CONFIG, "rb") as f:
+        data = tomllib.load(f)
+    packages: dict[str, dict[str, Any]] = data["packages"]
+    return packages
+
+
+@pytest.mark.parametrize("package_name", _FULL_BACKEND_PACKAGES)
+def test_leaf_package_declares_all_backend_extras(package_name: str) -> None:
+    """Each shipped backend is independently installable through its distribution extra."""
+    actual = _packages()[package_name].get("optional_dependencies", {})
+    assert actual == _FULL_BACKEND_EXTRAS, (
+        f"{package_name}: config/packages.toml must declare the full backend extras "
+        f"{_FULL_BACKEND_EXTRAS!r}, got {actual!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -531,18 +531,46 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "duckdb" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "polars" },
+    { name = "pyarrow" },
+]
 dev = [
     { name = "mloda-testing" },
     { name = "pytest" },
 ]
+duckdb = [
+    { name = "duckdb" },
+]
+pandas = [
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+polars = [
+    { name = "polars" },
+]
+pyarrow = [
+    { name = "pyarrow" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "duckdb", marker = "extra == 'all'" },
+    { name = "duckdb", marker = "extra == 'duckdb'" },
     { name = "mloda-community-data-operations", specifier = ">=0.4.4" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
+    { name = "pandas", marker = "extra == 'all'" },
+    { name = "pandas", marker = "extra == 'pandas'" },
+    { name = "polars", marker = "extra == 'all'" },
+    { name = "polars", marker = "extra == 'polars'" },
+    { name = "pyarrow", marker = "extra == 'all'" },
+    { name = "pyarrow", marker = "extra == 'pyarrow'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "pyarrow", "sqlite", "python-dict", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-ema"
@@ -1173,18 +1201,46 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "duckdb" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "polars" },
+    { name = "pyarrow" },
+]
 dev = [
     { name = "mloda-testing" },
     { name = "pytest" },
 ]
+duckdb = [
+    { name = "duckdb" },
+]
+pandas = [
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+polars = [
+    { name = "polars" },
+]
+pyarrow = [
+    { name = "pyarrow" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "duckdb", marker = "extra == 'all'" },
+    { name = "duckdb", marker = "extra == 'duckdb'" },
     { name = "mloda-community-data-operations", specifier = ">=0.4.4" },
     { name = "mloda-testing", marker = "extra == 'dev'" },
+    { name = "pandas", marker = "extra == 'all'" },
+    { name = "pandas", marker = "extra == 'pandas'" },
+    { name = "polars", marker = "extra == 'all'" },
+    { name = "polars", marker = "extra == 'polars'" },
+    { name = "pyarrow", marker = "extra == 'all'" },
+    { name = "pyarrow", marker = "extra == 'pyarrow'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "pyarrow", "sqlite", "python-dict", "duckdb", "polars", "pandas", "all"]
 
 [[package]]
 name = "mloda-community-time-bucketization"


### PR DESCRIPTION
## Summary

- declare the full backend extras set for `mloda-community-datetime` and `mloda-community-string`
- regenerate both package manifests and lock metadata from `config/packages.toml`
- add a regression test that keeps the two distributions aligned with their shipped backends

## Why

Both leaf packages ship pyarrow, pandas, polars, duckdb, sqlite, and python-dict implementations, but exposed no corresponding installation extras.

## Validation

- focused regression test: 2 passed
- full suite: 5,013 passed, 205 skipped, 1 xfailed
- all 30 generated manifests current
- `uv lock --check`
- Ruff format and lint
- strict mypy: 461 files passed
- Bandit passed

The tox wrapper could not provision a fresh environment because the package index was unavailable and `colorama==0.4.6` was not cached; every primary gate was run individually and passed.

Fixes #477